### PR TITLE
Release paper-docx 0.1.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,38 +3,85 @@ name: Release
 on:
   push:
     tags:
-      # Publish on any tag starting with a `v`, e.g., v1.2.3
       - v*
 
+permissions:
+  contents: read
+
 jobs:
+  quality:
+    uses: ./.github/workflows/test.yml
+
+  build:
+    name: Build release artifacts
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout complete history
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.11.28"
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Verify release source
+        shell: bash
+        run: |
+          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]
+          git fetch origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
+      - name: Build
+        run: uv build
+      - name: Check distribution metadata
+        run: uvx --from twine==6.1.0 twine check --strict dist/*
+      - name: Verify wheel identity
+        shell: bash
+        run: |
+          package_version="$(uv run --isolated --no-project --with dist/*.whl python - <<'PY'
+          import importlib.metadata
+          import docx
+
+          distribution_version = importlib.metadata.version("paper-docx")
+          assert docx.__paper_version__ == distribution_version
+          print(distribution_version)
+          PY
+          )"
+          test "${GITHUB_REF_NAME}" = "v${package_version}"
+      - name: Smoke test source distribution
+        run: |
+          uv run --isolated --no-project --with dist/*.tar.gz python - <<'PY'
+          import importlib.metadata
+          import docx
+
+          assert docx.__paper_version__ == importlib.metadata.version("paper-docx")
+          PY
+      - name: Upload verified artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-distributions
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 1
+
   pypi:
     name: Publish to PyPI
+    needs: build
     runs-on: ubuntu-latest
-    # Environment and permissions trusted publishing.
     environment:
-      # Create this environment in the GitHub repository under Settings -> Environments
       name: pypi
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-      - name: Install Python 3.13
-        run: uv python install 3.13
-      - name: Build
-        run: uv build
-      - name: Verify tag matches package version
-        shell: bash
-        run: |
-          package_version="$(uv run --isolated --no-project python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          test "${GITHUB_REF_NAME}" = "v${package_version}"
-      # Check that basic features work and we didn't miss to include crucial files
-      - name: Smoke test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl python -c "import docx; print(docx.__paper_version__)"
-      - name: Smoke test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz python -c "import docx; print(docx.__paper_version__)"
-      - name: Publish
-        run: uv publish
+      - name: Download verified artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-distributions
+          path: dist
+      - name: Publish exact verified artifacts
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_call:
   pull_request:
   push:
     branches:
@@ -9,8 +10,13 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_INPUT: "1"
+
 jobs:
   test:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -18,16 +24,13 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package and test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install -r requirements-test.txt
+        run: python -m pip install -e . -r requirements-test.txt
       - name: Run pytest
         run: |
           python - <<'PY'
@@ -53,3 +56,117 @@ jobs:
           PY
       - name: Run behave
         run: behave -q
+
+  libreoffice:
+    name: LibreOffice contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - name: Install LibreOffice Writer
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libreoffice-writer
+          command -v soffice
+          soffice --version
+      - name: Install package and test dependencies
+        run: python -m pip install -e . -r requirements-test.txt
+      - name: Run independent-loader contract
+        run: python -m pytest -q -m lo_smoke tests/paper/test_lo_smoke.py
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.9"
+      - name: Install documentation dependencies
+        run: python -m pip install -r requirements-docs.txt
+      - name: Build documentation without warnings
+        run: sphinx-build -W -b html docs docs/.build/html
+
+  build:
+    name: Distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - name: Build and inspect artifacts
+        run: |
+          python -m pip install build==1.2.2.post1 twine==6.1.0
+          python -m build
+          python -m twine check --strict dist/*
+      - name: Verify distribution ownership in real environments
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/paper_docx-*.whl)
+          test "${#wheels[@]}" -eq 1
+          wheel="$(pwd)/${wheels[0]}"
+          matrix_root="$RUNNER_TEMP/paper-docx-install-matrix"
+          rm -rf "$matrix_root"
+
+          expect_failure() {
+            if "$@"; then
+              echo "expected command to refuse: $*" >&2
+              exit 1
+            fi
+          }
+
+          python -m venv "$matrix_root/paper-only"
+          "$matrix_root/paper-only/bin/python" -m pip install "$wheel"
+          "$matrix_root/paper-only/bin/paper-docx-doctor"
+
+          python -m venv "$matrix_root/paper-then-upstream"
+          "$matrix_root/paper-then-upstream/bin/python" -m pip install "$wheel"
+          "$matrix_root/paper-then-upstream/bin/python" -m pip install \
+            --no-deps python-docx==1.2.0
+          expect_failure "$matrix_root/paper-then-upstream/bin/paper-docx-doctor"
+
+          python -m venv "$matrix_root/upstream-then-paper"
+          "$matrix_root/upstream-then-paper/bin/python" -m pip install \
+            python-docx==1.2.0
+          "$matrix_root/upstream-then-paper/bin/python" -m pip install \
+            --no-deps "$wheel"
+          expect_failure "$matrix_root/upstream-then-paper/bin/paper-docx-doctor"
+          expect_failure "$matrix_root/upstream-then-paper/bin/python" \
+            -c "import docx"
+
+          python -m venv "$matrix_root/unsafe-uninstall"
+          "$matrix_root/unsafe-uninstall/bin/python" -m pip install "$wheel"
+          "$matrix_root/unsafe-uninstall/bin/python" -m pip install \
+            --no-deps python-docx==1.2.0
+          "$matrix_root/unsafe-uninstall/bin/python" -m pip uninstall \
+            --yes python-docx
+          expect_failure "$matrix_root/unsafe-uninstall/bin/paper-docx-doctor"
+
+  required:
+    name: Required
+    if: always()
+    needs: [test, libreoffice, docs, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every quality job
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          LIBREOFFICE_RESULT: ${{ needs.libreoffice.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          test "$TEST_RESULT" = success
+          test "$LIBREOFFICE_RESULT" = success
+          test "$DOCS_RESULT" = success
+          test "$BUILD_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
       - name: Install documentation dependencies
         run: python -m pip install -r requirements-docs.txt
       - name: Build documentation without warnings

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
 sphinx:
   configuration: docs/conf.py
   # -- fail on all warnings to avoid broken references --
-  # fail_on_warning: true
+  fail_on_warning: true
 
 # -- package versions required to build your documentation --
 # -- see https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html --

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.13"
 
 # -- build documentation in the "docs/" directory with Sphinx --
 sphinx:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,8 @@ Release History
 - Preserve bookmark, style, numbering, relationship, and field dependencies during composition.
 - Address merged and offset table cells by their visible Word layout grid.
 - Stage and validate complete OPC packages before replacing files or writing output streams.
+- Keep inherited comment authoring, protected compare, and Windows saves within the safety contract.
+- Normalize producer variants in protection, numbering, comment threading, and scrub operations.
 
 
 1.2.0 (2025-06-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 
 - Refuse unsupported comparisons instead of producing lossy redlines.
 - Validate revision, editing, composition, and package operations before mutation.
+- Roll back compound composition, review, scrub, and comment operations after late failures.
 - Reject ambiguous or unsafe ZIP packages with bounded reads.
 - Write deterministic ZIP metadata so identical saves are byte-identical.
 - Verify distribution identity and strengthen test and release gates.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 Release History
 ---------------
 
+0.1.1 (unreleased)
+++++++++++++++++++
+
+- Refuse unsupported comparisons instead of producing lossy redlines.
+- Validate revision, editing, composition, and package operations before mutation.
+- Reject ambiguous or unsafe ZIP packages with bounded reads.
+- Write deterministic ZIP metadata so identical saves are byte-identical.
+- Verify distribution identity and strengthen test and release gates.
+
+
 1.2.0 (2025-06-16)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ---------------
 
-0.1.1 (unreleased)
+0.1.2 (unreleased)
 ++++++++++++++++++
 
 - Refuse unsupported comparisons instead of producing lossy redlines.
@@ -12,6 +12,10 @@ Release History
 - Reject ambiguous or unsafe ZIP packages with bounded reads.
 - Write deterministic ZIP metadata so identical saves are byte-identical.
 - Verify distribution identity and strengthen test and release gates.
+- Reject stale or structurally ambiguous text, comment, bookmark, field, and content-control edits.
+- Preserve bookmark, style, numbering, relationship, and field dependencies during composition.
+- Address merged and offset table cells by their visible Word layout grid.
+- Stage and validate complete OPC packages before replacing files or writing output streams.
 
 
 1.2.0 (2025-06-16)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include HISTORY.rst LICENSE README.rst tox.ini
+include HISTORY.rst LICENSE README.md tox.ini
 include requirements*.txt
 graft src/docx/templates
 graft features

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ and model priors.
 
 - GitHub repository / PyPI distribution: **`paper-docx`**
 - Python import: **`docx`**
-- Fork sentinel: `docx.__paper_version__ = "0.1.1"`
+- Fork sentinel: `docx.__paper_version__ = "0.1.2"`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ result.document.paragraphs[0].text
 # 'Payment is due within thirty business days of the invoice date.'
 ```
 
-`compare` emits markup Word renders as tracked changes. Accepting the redline
-reproduces the revised document; rejecting it reproduces the original. That
-round-trip guarantee holds across every part of the file.
+`compare` emits markup Word renders as tracked changes. Before returning, it
+accepts and rejects private copies and verifies both outcomes. If a difference
+cannot be represented safely as a redline, such as a style or package-part
+change, it raises a typed refusal instead of returning an incomplete result.
 
 ## What it adds
 
@@ -119,21 +120,35 @@ and model priors.
 
 - GitHub repository / PyPI distribution: **`paper-docx`**
 - Python import: **`docx`**
-- Fork sentinel: `docx.__paper_version__ = "0.1.0"`
+- Fork sentinel: `docx.__paper_version__ = "0.1.1"`
 
 ## Installation
 
 Install from PyPI:
 
 ```bash
-pip install paper-docx
+python -m pip uninstall -y python-docx paper-docx
+python -m pip install paper-docx
 ```
+
+The clean uninstall is required when migrating from `python-docx`. Both
+distributions use the frozen `docx` import package, and pip cannot safely
+overlay or uninstall two distributions that own the same files.
 
 Confirm the install:
 
 ```bash
-python -c "import docx; print(docx.__paper_version__)"
+paper-docx-doctor
 ```
+
+Pip does not treat `paper-docx` as satisfying another package's declared
+dependency on `python-docx`. That dependency will reinstall upstream and
+overwrite shared `docx` files. Replace or remove the dependency, or run that
+package in a separate environment.
+
+In a controlled deployment, a constraint containing `python-docx<0` makes pip
+reject direct or transitive attempts to install upstream. The constraint must
+be applied to every install in that environment.
 
 ## Documentation
 

--- a/docs/api/paper-errors.rst
+++ b/docs/api/paper-errors.rst
@@ -21,6 +21,13 @@ disk byte-for-byte unchanged. Programmer mistakes remain ordinary
    :show-inheritance:
 
 
+|PackageLimitError|
+-------------------
+
+.. autoexception:: PackageLimitError
+   :show-inheritance:
+
+
 |AmbiguousTargetError|
 ----------------------
 

--- a/docs/api/paper-package.rst
+++ b/docs/api/paper-package.rst
@@ -9,8 +9,10 @@ Package kernel
 change, so a file-level diff shows your edit and nothing else. ``diff_package``
 and ``text_diff`` report what changed. ``diagnose`` triages an unopenable file
 into a typed verdict. ``compare`` generates a native tracked-change redline
-that transforms one document into another. These names are the pinned public
-path (``docx.package.*``); the implementation lives in private modules.
+that transforms one document into another. It verifies acceptance and
+rejection on private copies before returning and refuses differences it cannot
+encode without loss. These names are the pinned public path
+(``docx.package.*``); the implementation lives in private modules.
 
 .. currentmodule:: docx.package
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -499,4 +499,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/3/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import sys
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-from docx import __version__  # noqa
+from docx import __paper_version__  # noqa
 
 
 # -- General configuration ---------------------------------------------------
@@ -61,9 +61,9 @@ copyright = "2013, Steve Canny (python-docx); 2026, Paper Instruments, Inc. (pap
 # built documents.
 #
 # The short X.Y version.
-version = __version__
+version = __paper_version__
 # The full version, including alpha/beta/rc tags.
-release = __version__
+release = __paper_version__
 
 # A string of reStructuredText that will be included at the end of every source
 # file that is read. This is the right place to add substitutions that should
@@ -211,6 +211,8 @@ rst_epilog = """
 .. ---------------------------------------------------------------------------
 
 .. |PaperRefusal| replace:: :exc:`.PaperRefusal`
+
+.. |PackageLimitError| replace:: :exc:`.PackageLimitError`
 
 .. |AmbiguousTargetError| replace:: :exc:`.AmbiguousTargetError`
 
@@ -400,7 +402,7 @@ html_sidebars = {"**": ["localtoc.html", "relations.html", "sidebarlinks.html", 
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "python-docxdoc"
+htmlhelp_basename = "paper-docxdoc"
 
 
 # -- Options for LaTeX output -----------------------------------------------
@@ -421,7 +423,13 @@ latex_elements = {
 #  author,
 #  documentclass [howto/manual]).
 latex_documents = [
-    ("index", "python-docx.tex", "python-docx Documentation", "Steve Canny", "manual"),
+    (
+        "index",
+        "paper-docx.tex",
+        "paper-docx Documentation",
+        "Steve Canny; Paper Instruments, Inc.",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -449,7 +457,15 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "python-docx", "python-docx Documentation", ["Steve Canny"], 1)]
+man_pages = [
+    (
+        "index",
+        "paper-docx",
+        "paper-docx Documentation",
+        ["Steve Canny", "Paper Instruments, Inc."],
+        1,
+    )
+]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -463,11 +479,11 @@ man_pages = [("index", "python-docx", "python-docx Documentation", ["Steve Canny
 texinfo_documents = [
     (
         "index",
-        "python-docx",
-        "python-docx Documentation",
-        "Steve Canny",
-        "python-docx",
-        "One line description of project.",
+        "paper-docx",
+        "paper-docx Documentation",
+        "Steve Canny; Paper Instruments, Inc.",
+        "paper-docx",
+        "Create, inspect, edit, review, and compose Microsoft Word documents.",
         "Miscellaneous",
     ),
 ]

--- a/docs/user/comments.rst
+++ b/docs/user/comments.rst
@@ -131,7 +131,7 @@ The comments collection supports random access to a comment by its id::
 Adding rich content to a comment
 --------------------------------
 
-A comment is a _block-item container_, just like the document body or a table cell, so
+A comment is a *block-item container*, just like the document body or a table cell, so
 it can contain any content that can appear in those places. It does not contain
 page-layout sections and cannot contain a comment reference, but it can contain multiple
 paragraphs and/or tables, and runs within paragraphs can have emphasis such as bold or

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -3,36 +3,44 @@
 Installing
 ==========
 
-.. note:: python-docx versions 0.3.0 and later are not API-compatible with
-   prior versions.
+Install ``paper-docx`` from PyPI and continue importing ``docx``. The
+distribution name changed; the Python import name did not.
 
-|docx| is hosted on PyPI, so installation is relatively simple, and just
-depends on what installation utilities you have installed.
+Migrating from python-docx
+--------------------------
 
-|docx| may be installed with ``pip`` if you have it available::
+``paper-docx`` and ``python-docx`` cannot coexist in one environment because
+both distributions own the same ``docx`` package files. Pip does not model
+that conflict. Remove both distributions before installing the fork::
 
-    pip install python-docx
+    python -m pip uninstall -y python-docx paper-docx
+    python -m pip install paper-docx
 
-|docx| can also be installed using ``easy_install``, although this is
-discouraged::
+Confirm that the fork, rather than the upstream distribution, owns the import::
 
-    easy_install python-docx
+    paper-docx-doctor
 
-If neither ``pip`` nor ``easy_install`` is available, it can be installed
-manually by downloading the distribution from PyPI, unpacking the tarball,
-and running ``setup.py``::
+The doctor verifies the installed ``docx`` files against ``paper-docx``'s wheel
+record and checks ``docx.__paper_version__``. Existing imports remain unchanged::
 
-    tar xvzf python-docx-{version}.tar.gz
-    cd python-docx-{version}
-    python setup.py install
+    import docx
+    document = docx.Document("contract.docx")
 
-|docx| depends on the ``lxml`` package. Both ``pip`` and ``easy_install``
-will take care of satisfying those dependencies for you, but if you use this
-last method you will need to install those yourself.
+Pip does not treat the fork as satisfying a dependency declared on
+``python-docx``. A package with ``Requires-Dist: python-docx`` will reinstall
+upstream and overwrite shared files. Replace or remove that dependency, or run
+the package in a separate environment.
 
+Controlled deployments can place this line in a constraints file::
+
+    python-docx<0
+
+Apply that constraint to every pip install in the environment. Pip will then
+reject direct and transitive attempts to install upstream.
 
 Dependencies
 ------------
 
-* Python 2.6, 2.7, 3.3, or 3.4
-* lxml >= 2.3.2
+* Python 3.9 or later
+* lxml 3.1.0 or later
+* typing-extensions 4.9.0 or later

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -110,7 +110,9 @@ Compose across documents
 semantically change keep their original bytes, so a file-level diff shows your
 edit and nothing else. ``compare`` generates a native tracked-change redline
 transforming one document into another. Accepting it yields the revised
-document; rejecting it yields the original.
+document; rejecting it yields the original. Before returning, ``compare``
+proves both outcomes on private copies. Style, relationship, or package-part
+changes it cannot express as tracked revisions produce a typed refusal.
 
 ::
 

--- a/hardening_proposal.md
+++ b/hardening_proposal.md
@@ -1,0 +1,172 @@
+# Practical hardening proposal for paper-docx
+
+## Purpose
+
+This proposal captures the hardening work that would materially improve
+`paper-docx` for professional document workflows. It is intentionally narrower
+than the full research audit. The priority is preventing lost work, silent
+document damage, incorrect edits, and unreliable review artifacts in contracts,
+transaction documents, reports, and other long-lived Word files.
+
+The `0.1.1` candidate remains the baseline. The work below should be delivered
+as small, independently reviewed changes after that release rather than as one
+large hardening patch.
+
+## Priority findings
+
+### 1. Guarantee atomic saves and compound edits
+
+Some operations update multiple XML parts, relationships, or package-level
+records. A late refusal or serialization failure must not leave the in-memory
+document partly changed or overwrite a destination with an incomplete package.
+
+This matters in practice because composition, review finalization, scrubbing,
+and comment operations can touch several related parts. A lawyer or banker must
+be able to retry or abandon a failed operation without reopening the original
+file and without wondering which changes were applied.
+
+Recommended contract:
+
+- Fully validate an operation before its first mutation.
+- Roll back every affected in-memory part when a typed refusal or unexpected
+  error occurs after mutation begins.
+- Stage and validate the complete OPC package before replacing a file or
+  writing to a non-restorable output stream.
+- Add forced-late-failure tests for each compound public operation.
+
+### 2. Prevent stale or ambiguous edits from targeting the wrong text
+
+Search results, blocks, spans, comments, and other editing handles can become
+stale after an earlier mutation. Reusing an old handle must refuse rather than
+apply an edit to content that happens to occupy the same approximate location.
+
+This is a high-impact risk in automated contract and presentation-book editing:
+an apparently successful replacement on the wrong clause, footnote, or table
+cell is worse than an error.
+
+Recommended contract:
+
+- Validate content anchors against the current story and block before editing.
+- Treat source location and normalized text identity as part of freshness, not
+  just the visible matched string.
+- Reject reversed, detached, cross-story, or otherwise ambiguous ranges.
+- Keep replacement batches atomic when one result becomes stale during the
+  operation.
+
+### 3. Preserve fields, revisions, comments, bookmarks, and content controls
+
+Visible text in a real Word document is often surrounded by structural markup.
+A text edit that ignores those boundaries can orphan a field instruction,
+invalidate a tracked-change range, detach a comment, hollow out a bookmark, or
+desynchronize a content control from its stored value.
+
+These structures are common in professional templates and negotiated documents.
+They must be treated as document data, not incidental XML.
+
+Recommended contract:
+
+- Refuse edits that partially consume a complex field or cross incompatible
+  revision scopes.
+- Validate the complete selected range, including intervening runs, before
+  adding or changing a comment.
+- Reject stale comment proxies after comments are removed or rebuilt.
+- Preserve bookmark pairing and revision scope, and refuse changes that leave a
+  referenced bookmark empty.
+- Permit generic text mutation only in content controls whose surface is
+  actually text-editable; route typed controls through their dedicated APIs.
+- Apply Restrict Editing checks consistently to inherited and fork-added
+  mutators.
+
+### 4. Make scrub and review finalization complete and trustworthy
+
+`scrub`, accept/reject, and finalization APIs are used immediately before a
+document is sent outside the organization. Their result must not retain hidden
+review data or remove visible/structural content accidentally.
+
+Recommended contract:
+
+- Traverse every reachable story and review-related part, not only the main
+  document body.
+- Remove comment records, anchors, extended-comment data, and relationships as
+  one atomic operation.
+- Refuse hidden-text deletion when it would invalidate a bookmark, field,
+  content control, or consumer-dependent compatibility branch.
+- After finalization, verify that no targeted revision or review residue remains
+  anywhere in the live package graph.
+- Test the saved artifact with reopen checks and LibreOffice load smoke, not
+  only the in-memory XML tree.
+
+### 5. Preserve package relationships during composition
+
+Cross-document composition must copy a complete, internally consistent graph of
+styles, numbering definitions, media, hyperlinks, notes, and other referenced
+parts. A composed document that opens but silently uses the wrong numbering,
+style, image, or link is not a successful result.
+
+Recommended contract:
+
+- Validate source ownership and every transitive internal relationship before
+  mutation.
+- Reconcile style and numbering identifiers deterministically and return the
+  resulting mapping to the caller.
+- Refuse unsupported or ambiguous relationship graphs rather than dropping or
+  sharing targets accidentally.
+- Verify that source and destination remain independently editable after the
+  import.
+
+### 6. Address tables and lists by Word's structural model
+
+Professional documents rely heavily on merged table cells, repeated headers,
+numbered clauses, and nested lists. Physical XML position is not always the
+visible grid column or list identity. Editing by the wrong coordinate can
+change the wrong cell or reconnect a paragraph to the wrong numbering stream.
+
+Recommended contract:
+
+- Resolve table locations through `gridBefore`, `gridSpan`, vertical merges,
+  and the visible layout grid.
+- Guard the whole target cell for fields and pending revisions before replacing
+  its contents.
+- Validate numbering references and abstract-number definitions before list
+  edits or composition.
+- Return explicit remapping information whenever identifiers change.
+
+### 7. Reject ambiguous package graphs before editing
+
+Word files from document-management systems, conversion tools, and long editing
+histories frequently contain optional parts and producer-specific package
+layouts. The library should accept valid variation, but it must not guess when
+duplicate names, conflicting content types, or ambiguous relationships make the
+meaning of a part uncertain.
+
+Recommended contract:
+
+- Resolve internal part names case-insensitively, as OPC requires, while
+  detecting case-colliding members.
+- Validate relationship cardinality, role, target mode, target existence, and
+  content type before exposing a part to a mutator.
+- Preserve unknown but reachable parts byte-for-byte when they are outside the
+  requested edit.
+- Refuse ambiguous graphs before mutation and leave the source and destination
+  unchanged.
+
+## Delivery approach
+
+Each priority should be implemented as a separate PR with a narrow public
+contract and regression fixtures that demonstrate the user-visible failure.
+Tests should include successful round trips, typed refusals, forced late
+failures, package reopen checks, and LibreOffice load smoke where the saved file
+is affected.
+
+The work should not expand the public API unless a new return value is necessary
+to report provenance, remapping, or refusal details. Existing import names,
+signatures, exception messages, and drop-in behavior remain fixed unless a
+separate compatibility decision explicitly changes them.
+
+## Deliberately excluded
+
+This proposal excludes hardening that only concerns contrived XML shapes,
+resource limits with no plausible Office producer, cosmetic API consistency,
+internal refactoring, speculative schema coverage, and checks that duplicate an
+existing guarantee without preventing a practical failure. Those findings can
+remain in the research branch and should not block `0.1.1`.

--- a/hardening_proposal.md
+++ b/hardening_proposal.md
@@ -8,9 +8,9 @@ than the full research audit. The priority is preventing lost work, silent
 document damage, incorrect edits, and unreliable review artifacts in contracts,
 transaction documents, reports, and other long-lived Word files.
 
-The `0.1.1` candidate remains the baseline. The work below should be delivered
-as small, independently reviewed changes after that release rather than as one
-large hardening patch.
+The unmerged `0.1.1` candidate is the baseline. The `0.1.2` candidate combines
+that work with the priorities below so the safety contract can be reviewed and
+released as one coherent change.
 
 ## Priority findings
 
@@ -152,11 +152,10 @@ Recommended contract:
 
 ## Delivery approach
 
-Each priority should be implemented as a separate PR with a narrow public
-contract and regression fixtures that demonstrate the user-visible failure.
-Tests should include successful round trips, typed refusals, forced late
-failures, package reopen checks, and LibreOffice load smoke where the saved file
-is affected.
+Each priority has a narrow public contract and regression fixtures that
+demonstrate the user-visible failure. Tests include successful round trips,
+typed refusals, forced late failures, package reopen checks, and LibreOffice
+load smoke where the saved file is affected.
 
 The work should not expand the public API unless a new return value is necessary
 to report provenance, remapping, or refusal details. Existing import names,
@@ -169,4 +168,4 @@ This proposal excludes hardening that only concerns contrived XML shapes,
 resource limits with no plausible Office producer, cosmetic API consistency,
 internal refactoring, speculative schema coverage, and checks that duplicate an
 existing guarantee without preventing a practical failure. Those findings can
-remain in the research branch and should not block `0.1.1`.
+remain in the research branch and do not block `0.1.2`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools==80.9.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "paper-docx"
-version = "0.1.0"
+dynamic = ["version"]
 authors = [
     {name = "Steve Canny", email = "stcanny@gmail.com"},
     {name = "Paper Instruments, Inc."},
@@ -14,15 +14,14 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Office/Business :: Office Suites",
     "Topic :: Software Development :: Libraries",
 ]
@@ -32,7 +31,7 @@ dependencies = [
 ]
 description = "Create, read, and update Microsoft Word .docx files."
 keywords = ["docx", "office", "openxml", "word"]
-license = { text = "MIT" }
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.9"
 
@@ -58,6 +57,12 @@ Documentation = "https://github.com/The-LLM-Data-Company/paper-docx"
 Homepage = "https://github.com/The-LLM-Data-Company/paper-docx"
 Issues = "https://github.com/The-LLM-Data-Company/paper-docx/issues"
 Repository = "https://github.com/The-LLM-Data-Company/paper-docx"
+
+[project.scripts]
+paper-docx-doctor = "paper_docx_doctor:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "docx._version.__paper_version__"}
 
 [tool.pyright]
 include = ["src/docx", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,17 +37,17 @@ requires-python = ">=3.9"
 
 [dependency-groups]
 dev = [
-    "Jinja2==2.11.3",
-    "MarkupSafe==0.23",
-    "Sphinx==1.8.6",
-    "alabaster<0.7.14",
+    "Jinja2>=3.1.6,<4; python_version >= '3.10'",
+    "MarkupSafe>=2.1.3,<4; python_version >= '3.10'",
+    "Sphinx>=7.4.7,<8; python_version >= '3.10'",
+    "alabaster>=0.7.14,<0.8; python_version >= '3.10'",
     "behave>=1.2.6",
     "pyparsing>=3.2.3",
     "pyright>=1.1.401",
     "pytest>=8.4.0",
     "ruff>=0.11.13",
-    "tox>=4.26.0",
-    "twine>=6.1.0",
+    "tox>=4.26.0; python_version >= '3.10'",
+    "twine>=6.1.0; python_version >= '3.10'",
     "types-lxml-multi-subclass>=2025.3.30",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 build
 ruff
 setuptools>=61.0.0
-tox
-twine
+tox; python_version >= "3.10"
+twine; python_version >= "3.10"
 types-lxml

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,7 @@
-Sphinx==1.8.6
-Jinja2==2.11.3
-MarkupSafe==0.23
-alabaster<0.7.14
-setuptools<81
+# Documentation tooling runs on Python 3.10+; package runtime support remains 3.9+.
+Sphinx>=7.4.7,<8; python_version >= "3.10"
+Jinja2>=3.1.6,<4; python_version >= "3.10"
+MarkupSafe>=2.1.3,<4; python_version >= "3.10"
+alabaster>=0.7.14,<0.8; python_version >= "3.10"
+setuptools<81; python_version >= "3.10"
 -e .

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,5 @@ Sphinx==1.8.6
 Jinja2==2.11.3
 MarkupSafe==0.23
 alabaster<0.7.14
+setuptools<81
 -e .

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -4,9 +4,15 @@ Export the `Document` constructor function and establish the mapping of part-typ
 the part-classe that implements that type.
 """
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type
+
+from docx._version import __paper_version__, assert_distribution_identity
+
+assert_distribution_identity()
 
 from docx.api import Document
 
@@ -14,10 +20,9 @@ if TYPE_CHECKING:
     from docx.opc.part import Part
 
 __version__ = "1.2.0"
-__paper_version__ = "0.1.0"
 
 
-__all__ = ["Document"]
+__all__ = ["Document", "__paper_version__"]
 
 
 # -- register custom Part classes with opc package reader --

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -2,19 +2,20 @@
 
 `compare(original, revised, *, author, ...)` returns a new document — the
 original with `w:ins`/`w:del` markup that transforms it into the revised
-text. The algebra is the contract:
+document. The algebra is the contract:
 
-* `accept_all(compare(A, B))` == B in visible text, across every story;
+* `accept_all(compare(A, B))` == B, across every supported story;
 * `reject_all(compare(A, B))` == A;
 * `compare(A, A)` emits zero revisions;
 * identical inputs produce byte-identical output (with a fixed `date`).
 
-Declared limits (typed refusals or report-only findings, never silence):
+Declared limits (typed refusals, never lossy output):
 insertions/deletions only — no move or rPrChange synthesis; no cross-story
 detection; paragraph add/remove outside the main body refuses; changed
-merged-cell tables refuse; images/objects and formatting-only differences
-are REPORTED in `CompareResult.findings`, not redlined; a block budget of
-`_MAX_BLOCKS` per story refuses above it.
+merged-cell tables refuse; images/objects, fields, content controls, package
+part changes, and formatting differences refuse; a block budget of
+`_MAX_BLOCKS` per story plus sequence-matching and changed-region pairing
+budgets refuse before quadratic work.
 
 Public path: `docx.package.compare` (kernel re-export).
 """
@@ -22,8 +23,9 @@ Public path: `docx.package.compare` (kernel re-export).
 from __future__ import annotations
 
 import copy
+import io
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -77,6 +79,18 @@ _PROOF_ERR = qn("w:proofErr")
 #: perf budget — documented typed refusal above this many blocks per story
 _MAX_BLOCKS = 10_000
 
+#: Pairing is quadratic in both memory and expensive SequenceMatcher calls.
+#: Refuse before allocating the matrix; block granularity never uses it.
+_MAX_PAIR_CELLS = 10_000
+
+#: SequenceMatcher has quadratic worst-case behavior on repeated sequences.
+#: Apply this budget before both story-block and table-row matching.
+_MAX_SEQUENCE_CELLS = 1_000_000
+
+#: Bound character-similarity and token diff matchers independently from
+#: block/row sequence matching so each expensive layer has its own envelope.
+_MAX_TEXT_SEQUENCE_CELLS = 1_000_000
+
 #: similarity threshold below which paired blocks redline as del+ins rather
 #: than a word-level edit
 _PAIR_RATIO = 0.5
@@ -111,6 +125,16 @@ class CompareResult:
             "stories": list(self.stories),
             "findings": [finding.to_dict() for finding in self.findings],
         }
+
+
+@dataclass(frozen=True)
+class _RawPackage:
+    """Guarded package bytes and the raw parts compare can model as stories."""
+
+    parts: dict[str, bytes]
+    order: Tuple[str, ...]
+    story_parts: frozenset[str]
+    has_revisions: bool
 
 
 @dataclass
@@ -157,8 +181,23 @@ def compare(
             f"materialize must be None, 'accept' or 'reject', got {materialize!r}"
         )
     stamp = date if date is not None else _clock.now()
-    document = _docx.Document(str(original))
-    revised_doc = _docx.Document(str(revised))
+    raw_original = _read_raw_package(original, label="original")
+    raw_revised = _read_raw_package(revised, label="revised")
+    if materialize is None:
+        for which, raw_package in (
+            ("original", raw_original),
+            ("revised", raw_revised),
+        ):
+            if raw_package.has_revisions:
+                raise UnsupportedStructureError(
+                    f"the {which} document carries pending tracked revisions;"
+                    " compare would conflate them with its own redline. Pass"
+                    " materialize='accept' or 'reject' to resolve working"
+                    " copies first (the input files are not modified)"
+                )
+    _refuse_unsupported_package_differences(raw_original, raw_revised)
+    document = _docx.Document(_document_source(original))
+    revised_doc = _docx.Document(_document_source(revised))
     findings: List[CompareFinding] = []
     for which, doc in (("original", document), ("revised", revised_doc)):
         if len(doc.revisions):
@@ -172,6 +211,8 @@ def compare(
             from docx.scrubbing import finalize
 
             finalize(doc, revisions=materialize)
+    original_reference = _serialize_document(document)
+    revised_reference = _serialize_document(revised_doc)
     from docx.protection import acknowledge_protection, protection_status
 
     status = protection_status(document)
@@ -189,22 +230,9 @@ def compare(
             )
         )
 
-    stories_o = {s: root for s, root in _story_elements(document)}
-    stories_r = {s: root for s, root in _story_elements(revised_doc)}
+    stories_o = dict(_story_elements(document))
+    stories_r = dict(_story_elements(revised_doc))
     comments = "word/comments.xml"
-    if _story_text_of(comments, stories_o.get(comments)) != _story_text_of(
-        comments, stories_r.get(comments)
-    ):
-        findings.append(
-            CompareFinding(
-                kind="comments_differ",
-                story=comments,
-                detail=(
-                    "comment content differs between the documents; compare"
-                    " never redlines the comments story (report-only)"
-                ),
-            )
-        )
     names_o = set(stories_o) - {comments}
     names_r = set(stories_r) - {comments}
     if names_o != names_r:
@@ -213,6 +241,18 @@ def compare(
             f" (only-original: {sorted(names_o - names_r)},"
             f" only-revised: {sorted(names_r - names_o)}); compare cannot"
             " redline story-part addition or removal"
+        )
+    if names_o != set(raw_original.story_parts):
+        raise UnsupportedStructureError(
+            "the original package contains a story part compare could not load"
+            f" safely (raw: {sorted(raw_original.story_parts)},"
+            f" loaded: {sorted(names_o)})"
+        )
+    if names_r != set(raw_revised.story_parts):
+        raise UnsupportedStructureError(
+            "the revised package contains a story part compare could not load"
+            f" safely (raw: {sorted(raw_revised.story_parts)},"
+            f" loaded: {sorted(names_r)})"
         )
     numbering_ids = _numbering_ids(document)
     compared: List[str] = []
@@ -230,12 +270,343 @@ def compare(
         )
         _compare_story(ctx, stories_o[story], stories_r[story])
         compared.append(story)
+    _verify_compare_algebra(
+        document,
+        original_reference=original_reference,
+        revised_reference=revised_reference,
+    )
     return CompareResult(
         document=document,
         findings=findings,
         revision_count=len(document.revisions),
         stories=tuple(compared),
     )
+
+
+def _serialize_document(document: "Document") -> bytes:
+    stream = io.BytesIO()
+    document.save(stream)
+    return stream.getvalue()
+
+
+def _document_source(source):
+    """Return a fresh source suitable for ``Document()`` after raw inspection."""
+    return io.BytesIO(source) if isinstance(source, bytes) else str(source)
+
+
+def _read_raw_package(source, *, label: str) -> _RawPackage:
+    """Guard-read and validate one package graph before document loading."""
+    from lxml import etree
+
+    from docx._paperpkg import _effective_content_types, _read_zip
+    from docx.opc.constants import CONTENT_TYPE as CT
+
+    parts, order = _read_zip(source)
+    try:
+        reachable = _reachable_raw_parts(parts)
+        unreachable = sorted(set(parts) - reachable)
+        if unreachable:
+            raise UnsupportedStructureError(
+                f"the {label} contains unreachable package part(s) {unreachable};"
+                " compare cannot preserve parts omitted by the OPC relationship graph"
+            )
+
+        content_types = parts.get("[Content_Types].xml")
+        if content_types is None:
+            raise UnsupportedStructureError(
+                f"the {label} package has no [Content_Types].xml part"
+            )
+        defaults, overrides = _effective_content_types(content_types, order)
+        supported_types = frozenset(
+            (
+                CT.WML_DOCUMENT_MAIN,
+                CT.WML_ENDNOTES,
+                CT.WML_FOOTER,
+                CT.WML_FOOTNOTES,
+                CT.WML_HEADER,
+            )
+        )
+        revision_story_types = supported_types | {CT.WML_COMMENTS}
+        revision_parts = frozenset(
+            name
+            for name in reachable
+            if _raw_content_type(name, defaults, overrides) in revision_story_types
+        )
+        story_parts = frozenset(
+            name
+            for name in reachable
+            if _raw_content_type(name, defaults, overrides) in supported_types
+        )
+        has_revisions = _raw_parts_have_revisions(parts, revision_parts)
+    except UnsupportedStructureError:
+        raise
+    except (KeyError, TypeError, ValueError, etree.XMLSyntaxError) as exc:
+        raise UnsupportedStructureError(
+            f"the {label} package graph cannot be validated safely: {exc}"
+        ) from exc
+    return _RawPackage(parts, tuple(order), story_parts, has_revisions)
+
+
+def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
+    """Return members reachable from package relationships, plus OPC metadata."""
+    from docx._paperpkg import _parse
+    from docx.opc.packuri import PACKAGE_URI, PackURI
+
+    rel_ns = "http://schemas.openxmlformats.org/package/2006/relationships"
+    relationships_tag = f"{{{rel_ns}}}Relationships"
+    relationship_tag = f"{{{rel_ns}}}Relationship"
+    reachable = {"[Content_Types].xml"}
+    pending = [PACKAGE_URI]
+    visited = set()
+    while pending:
+        source_uri = pending.pop()
+        if source_uri in visited:
+            continue
+        visited.add(source_uri)
+        rels_name = source_uri.rels_uri.membername
+        rels_bytes = parts.get(rels_name)
+        if rels_bytes is None:
+            continue
+        reachable.add(rels_name)
+        root = _parse(rels_bytes)
+        if root.tag != relationships_tag:
+            raise UnsupportedStructureError(
+                f"relationship part {rels_name!r} has unexpected root {root.tag!r}"
+            )
+        for relationship in root:
+            if relationship.tag != relationship_tag:
+                continue
+            if relationship.get("TargetMode", "Internal") == "External":
+                continue
+            target_ref = relationship.get("Target")
+            if not target_ref:
+                raise UnsupportedStructureError(
+                    f"relationship part {rels_name!r} contains an internal"
+                    " relationship without a target"
+                )
+            target_uri = PackURI.from_rel_ref(source_uri.baseURI, target_ref)
+            target_name = target_uri.membername
+            if target_name not in parts:
+                raise UnsupportedStructureError(
+                    f"relationship part {rels_name!r} targets missing part"
+                    f" {target_name!r}"
+                )
+            if target_name not in reachable:
+                reachable.add(target_name)
+                pending.append(target_uri)
+    return reachable
+
+
+def _raw_content_type(
+    name: str, defaults: dict[str, str], overrides: dict[str, str]
+) -> str:
+    override = overrides.get(f"/{name}")
+    if override is not None:
+        return override
+    extension = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    return defaults.get(extension, "")
+
+
+def _raw_parts_have_revisions(
+    parts: dict[str, bytes], story_parts: frozenset[str]
+) -> bool:
+    from docx._paperpkg import _parse
+    from docx.revision import _MARKUP_SCAN_TAGS
+
+    revision_tags = frozenset(_MARKUP_SCAN_TAGS)
+    return any(
+        node.tag in revision_tags
+        for name in story_parts
+        for node in _parse(parts[name]).iter()
+    )
+
+
+def _refuse_unsupported_package_differences(
+    original: _RawPackage,
+    revised: _RawPackage,
+) -> None:
+    """Refuse raw package changes outside stories before document loading."""
+    from docx._paperpkg import (
+        _parts_semantically_equal,
+        is_xml_part_name,
+    )
+
+    original_parts = original.parts
+    revised_parts = revised.parts
+    added = sorted(set(revised_parts) - set(original_parts))
+    removed = sorted(set(original_parts) - set(revised_parts))
+    if added or removed:
+        raise UnsupportedStructureError(
+            "compare cannot redline package-part addition or removal"
+            f" (only-original: {removed}, only-revised: {added})"
+        )
+    for name in sorted(original_parts):
+        before, after = original_parts[name], revised_parts[name]
+        if before == after:
+            continue
+        if name in original.story_parts and name in revised.story_parts:
+            continue
+        if is_xml_part_name(name) and _parts_semantically_equal(
+            name, before, after, list(original.order), list(revised.order)
+        ):
+            continue
+        raise UnsupportedStructureError(
+            f"compare cannot redline a change in package part {name!r};"
+            " make that change separately or compare documents whose"
+            " non-story parts are equivalent"
+        )
+
+
+def _verify_compare_algebra(
+    redline: "Document",
+    *,
+    original_reference: bytes,
+    revised_reference: bytes,
+) -> None:
+    """Prove accept/reject on private copies before returning the redline."""
+    import docx as _docx
+
+    redline_bytes = _serialize_document(redline)
+    for verb, expected in (
+        ("accept", revised_reference),
+        ("reject", original_reference),
+    ):
+        candidate = _docx.Document(io.BytesIO(redline_bytes))
+        if verb == "accept":
+            candidate.revisions.accept_all()
+        else:
+            candidate.revisions.reject_all()
+        from docx.revision import _remaining_markup
+
+        leftover = _remaining_markup(candidate)
+        if leftover:
+            raise UnsupportedStructureError(
+                f"compare could not prove its {verb} contract; revision"
+                f" markup remains after verification: {leftover}"
+            )
+        _assert_packages_match(
+            _serialize_document(candidate),
+            expected,
+            outcome=verb,
+        )
+
+
+def _assert_packages_match(
+    actual_bytes: bytes, expected_bytes: bytes, *, outcome: str
+) -> None:
+    """Compare every part, allowing only inert run fragmentation in stories."""
+    import docx as _docx
+    from docx._paperpkg import (
+        _parts_semantically_equal,
+        _read_zip,
+        is_xml_part_name,
+    )
+
+    actual = _docx.Document(io.BytesIO(actual_bytes))
+    expected = _docx.Document(io.BytesIO(expected_bytes))
+    stories_actual = dict(_story_elements(actual))
+    stories_expected = dict(_story_elements(expected))
+    if set(stories_actual) != set(stories_expected):
+        raise UnsupportedStructureError(
+            f"compare could not prove its {outcome} contract; story parts differ"
+        )
+    for name in sorted(stories_actual):
+        if _canonical_story_bytes(stories_actual[name]) != _canonical_story_bytes(
+            stories_expected[name]
+        ):
+            raise UnsupportedStructureError(
+                f"compare could not prove its {outcome} contract;"
+                f" story {name!r} does not match"
+            )
+
+    actual_parts, actual_order = _read_zip(actual_bytes)
+    expected_parts, expected_order = _read_zip(expected_bytes)
+    if set(actual_parts) != set(expected_parts):
+        raise UnsupportedStructureError(
+            f"compare could not prove its {outcome} contract; package parts differ"
+        )
+    story_names = set(stories_actual)
+    for name in sorted(actual_parts):
+        if name in story_names:
+            continue
+        before, after = actual_parts[name], expected_parts[name]
+        if before == after:
+            continue
+        if is_xml_part_name(name) and _parts_semantically_equal(
+            name, before, after, actual_order, expected_order
+        ):
+            continue
+        raise UnsupportedStructureError(
+            f"compare could not prove its {outcome} contract;"
+            f" package part {name!r} does not match"
+        )
+
+
+def _canonical_story_bytes(root: "_Element") -> bytes:
+    """Canonical story form for semantically inert redline run splitting."""
+    from lxml import etree
+
+    clone = copy.deepcopy(root)
+    xml_space = "{http://www.w3.org/XML/1998/namespace}space"
+    for property_tag in (_PPR, _RPR):
+        for node in list(clone.iter(property_tag)):
+            if not node.attrib and not len(node) and not (node.text or ""):
+                parent = node.getparent()
+                if parent is not None:
+                    parent.remove(node)
+    for parent in list(clone.iter()):
+        index = 0
+        while index + 1 < len(parent):
+            left, right = parent[index], parent[index + 1]
+            if not _mergeable_runs(left, right):
+                index += 1
+                continue
+            for child in list(right):
+                if child.tag != _RPR:
+                    left.append(child)
+            parent.remove(right)
+    for run in clone.iter(_R):
+        index = 0
+        while index + 1 < len(run):
+            left, right = run[index], run[index + 1]
+            if left.tag != _T or right.tag != _T:
+                index += 1
+                continue
+            left.text = (left.text or "") + (right.text or "")
+            run.remove(right)
+    for text_node in clone.iter(_T):
+        value = text_node.text or ""
+        if value[:1].isspace() or value[-1:].isspace():
+            text_node.set(xml_space, "preserve")
+        else:
+            text_node.attrib.pop(xml_space, None)
+    return etree.tostring(clone)
+
+
+def _mergeable_runs(left: "_Element", right: "_Element") -> bool:
+    if left.tag != _R or right.tag != _R or left.attrib != right.attrib:
+        return False
+    from lxml import etree
+
+    def shape(run):
+        children = list(run)
+        if not any(child.tag == _T for child in children):
+            return None
+        safe_content = (
+            _RPR,
+            _T,
+            qn("w:tab"),
+            qn("w:br"),
+            qn("w:cr"),
+            qn("w:noBreakHyphen"),
+        )
+        if any(child.tag not in safe_content for child in children):
+            return None
+        r_pr = run.find(_RPR)
+        return etree.tostring(r_pr) if r_pr is not None else b""
+
+    left_shape = shape(left)
+    return left_shape is not None and left_shape == shape(right)
 
 
 def _story_text_of(story: str, root) -> Optional[str]:
@@ -274,6 +645,9 @@ def _compare_story(ctx: _Ctx, root_o: "_Element", root_r: "_Element") -> None:
             f"story {ctx.story} exceeds the compare block budget"
             f" ({_MAX_BLOCKS} blocks); split the documents"
         )
+    _enforce_sequence_budget(
+        len(blocks_o), len(blocks_r), subject=f"story {ctx.story}"
+    )
     matcher = SequenceMatcher(
         None,
         [f"{k}\x00{t}" for k, _e, t in blocks_o],
@@ -297,10 +671,38 @@ def _compare_story(ctx: _Ctx, root_o: "_Element", root_r: "_Element") -> None:
         _compare_region(ctx, blocks_o[i1:i2], blocks_r[j1:j2])
 
 
+def _enforce_sequence_budget(left: int, right: int, *, subject: str) -> None:
+    cells = left * right
+    if cells > _MAX_SEQUENCE_CELLS:
+        raise UnsupportedStructureError(
+            f"{subject} exceeds the sequence-matching budget"
+            f" ({left} x {right} > {_MAX_SEQUENCE_CELLS} cells);"
+            " split the documents"
+        )
+
+
 def _pair_region(old_run, new_run) -> "List[Tuple[str, Optional[int], Optional[int]]]":
     """Order-preserving best-similarity block pairing within a changed region
     (LCS-style DP maximizing summed pair ratios above `_PAIR_RATIO`)."""
     m, n = len(old_run), len(new_run)
+    if m * n > _MAX_PAIR_CELLS:
+        raise UnsupportedStructureError(
+            "changed region exceeds the word-level compare pairing budget"
+            f" ({m} x {n} > {_MAX_PAIR_CELLS} cells); use"
+            " granularity='block' or split the documents"
+        )
+    text_cells = sum(
+        len(text_o) * len(text_r)
+        for kind_o, _element_o, text_o in old_run
+        for kind_r, _element_r, text_r in new_run
+        if kind_o == kind_r
+    )
+    if text_cells > _MAX_TEXT_SEQUENCE_CELLS:
+        raise UnsupportedStructureError(
+            "changed-region text exceeds the sequence-matching budget"
+            f" ({text_cells} > {_MAX_TEXT_SEQUENCE_CELLS} character cells);"
+            " use granularity='block' or split the documents"
+        )
     ratios: dict = {}
 
     def ratio(i: int, j: int) -> float:
@@ -343,6 +745,11 @@ def _pair_region(old_run, new_run) -> "List[Tuple[str, Optional[int], Optional[i
 def _compare_region(ctx: _Ctx, old_run, new_run) -> None:
     """Emit tracked changes for one changed region; a cursor threads the
     output position so unpaired insertions land in document order."""
+    if ctx.granularity == "block":
+        _insert_blocks(ctx, old_run, 0, new_run)
+        for kind, element, text in old_run:
+            _delete_block(ctx, kind, element, text)
+        return
     cursor: "Optional[_Element]" = None
     for op, index_o, index_r in _pair_region(old_run, new_run):
         if op == "pair":
@@ -352,14 +759,9 @@ def _compare_region(ctx: _Ctx, old_run, new_run) -> None:
                 _compare_table(ctx, element_o, element_r)
                 cursor = element_o
             elif ctx.granularity == "word":
+                _refuse_non_text_paragraph_change(ctx, element_o, element_r)
                 _replace_paragraph_text(ctx, element_o, text_o, text_r)
                 cursor = element_o
-            else:
-                _delete_block(ctx, kind_o, element_o, text_o)
-                clone = _cloned_as_insertion(ctx, "paragraph", element_r)
-                _require_container_anchor(ctx, element_o)
-                element_o.addnext(clone)
-                cursor = clone
         elif op == "delete":
             kind_o, element_o, text_o = old_run[index_o]
             _delete_block(ctx, kind_o, element_o, text_o)
@@ -378,21 +780,35 @@ def _compare_region(ctx: _Ctx, old_run, new_run) -> None:
 
 
 def _report_formatting_difference(ctx: _Ctx, block_o, block_r) -> None:
-    from lxml import etree
-
     _kind, element_o, text = block_o
     _kind_r, element_r, _text_r = block_r
-    if etree.tostring(element_o) != etree.tostring(element_r):
-        ctx.findings.append(
-            CompareFinding(
-                kind="formatting_only_difference",
-                story=ctx.story,
-                detail=(
-                    "identical visible text with differing markup"
-                    f" (formatting or metadata): {text[:80]!r}"
-                ),
-            )
+    if _canonical_story_bytes(element_o) != _canonical_story_bytes(element_r):
+        raise UnsupportedStructureError(
+            "compare cannot redline a formatting or structural difference"
+            f" in {ctx.story}: {text[:80]!r}"
         )
+
+
+def _refuse_non_text_paragraph_change(
+    ctx: _Ctx, original: "_Element", revised: "_Element"
+) -> None:
+    """Allow text changes only when the surrounding paragraph markup agrees."""
+    if _textless_story_bytes(original) == _textless_story_bytes(revised):
+        return
+    raise UnsupportedStructureError(
+        "compare cannot combine a text edit with a formatting or structural"
+        f" change in {ctx.story}; apply the formatting change separately"
+    )
+
+
+def _textless_story_bytes(element: "_Element") -> bytes:
+    clone = copy.deepcopy(element)
+    xml_space = "{http://www.w3.org/XML/1998/namespace}space"
+    for text_tag in (_T, _DEL_TEXT, _INSTR_TEXT, _DEL_INSTR_TEXT):
+        for text_node in clone.iter(text_tag):
+            text_node.text = ""
+            text_node.attrib.pop(xml_space, None)
+    return _canonical_story_bytes(clone)
 
 
 # ---------------------------------------------------------------------------
@@ -590,102 +1006,47 @@ def _cloned_as_insertion(ctx: _Ctx, kind: str, element: "_Element") -> "_Element
 
 
 def _sanitize_clone(ctx: _Ctx, clone: "_Element") -> None:
-    """Strip everything a clone cannot carry across packages (relationship
-    ids resolve against the ORIGINAL part) — each removal is a finding."""
-    for node in list(clone.iter(qn("w:drawing"), qn("w:object"), qn("w:pict"))):
-        holder = node.getparent()
-        target = holder if (holder is not None and holder.tag == _R) else node
-        if target.getparent() is None:
-            continue  # already removed with its sibling
-        target.getparent().remove(target)
-        ctx.findings.append(
-            CompareFinding(
-                kind="image_or_object_change",
-                story=ctx.story,
-                detail=(
-                    "an image/object in inserted content was not carried"
-                    " into the redline (relationships do not transfer;"
-                    " report-only)"
-                ),
+    """Validate that an inserted clone can be carried without degradation."""
+    refused = (
+        (qn("w:drawing"), "an image or drawing"),
+        (qn("w:object"), "an embedded object"),
+        (qn("w:pict"), "legacy VML content"),
+        (_HYPERLINK, "a hyperlink"),
+        (qn("w:sdt"), "a content control"),
+        (qn("w:sectPr"), "a section break"),
+        (qn("w:fldSimple"), "a field"),
+        (_FLD_CHAR, "a complex field"),
+    )
+    for tag, description in refused:
+        if clone.find(f".//{tag}") is not None:
+            raise UnsupportedStructureError(
+                f"compare cannot insert {description} in {ctx.story} without"
+                " changing its package relationships or behavior"
             )
-        )
-    for hyperlink in list(clone.iter(_HYPERLINK)):
-        parent = hyperlink.getparent()
-        for child in list(hyperlink):
-            hyperlink.addprevious(child)
-        parent.remove(hyperlink)
-        ctx.findings.append(
-            CompareFinding(
-                kind="hyperlink_flattened",
-                story=ctx.story,
-                detail=(
-                    "an inserted hyperlink was flattened to its text (its"
-                    " relationship id does not transfer)"
-                ),
-            )
-        )
-    for sdt in list(clone.iter(qn("w:sdt"))):
-        content = sdt.find(qn("w:sdtContent"))
-        parent = sdt.getparent()
-        if content is not None:
-            for child in list(content):
-                sdt.addprevious(child)
-        parent.remove(sdt)
-        ctx.findings.append(
-            CompareFinding(
-                kind="content_control_flattened",
-                story=ctx.story,
-                detail="an inserted content control was flattened to its content",
-            )
-        )
-    for sect_pr in list(clone.iter(qn("w:sectPr"))):
-        sect_pr.getparent().remove(sect_pr)
-        ctx.findings.append(
-            CompareFinding(
-                kind="section_break_not_carried",
-                story=ctx.story,
-                detail=(
-                    "a section break in inserted content was dropped (its"
-                    " header/footer relationships do not transfer)"
-                ),
-            )
-        )
     for num_pr in list(clone.iter(qn("w:numPr"))):
         num_id = num_pr.find(qn("w:numId"))
         value = num_id.get(qn("w:val")) if num_id is not None else None
-        if value is None or int(value) not in ctx.numbering_ids:
-            num_pr.getparent().remove(num_pr)
-            ctx.findings.append(
-                CompareFinding(
-                    kind="numbering_reference_stripped",
-                    story=ctx.story,
-                    detail=(
-                        f"inserted content referenced numbering id {value}"
-                        " which the original does not define; the reference"
-                        " was stripped"
-                    ),
-                )
+        try:
+            numeric_value = int(value) if value is not None else None
+        except ValueError:
+            numeric_value = None
+        if numeric_value is None or numeric_value not in ctx.numbering_ids:
+            raise UnsupportedStructureError(
+                f"compare cannot insert content referencing undefined"
+                f" numbering id {value!r} in {ctx.story}"
             )
-    for proof_err in list(clone.iter(_PROOF_ERR)):
-        proof_err.getparent().remove(proof_err)
-    stripped_anchor = False
-    for tag in ("w:bookmarkStart", "w:bookmarkEnd", "w:commentRangeStart",
-                "w:commentRangeEnd", "w:commentReference"):
-        for node in list(clone.iter(qn(tag))):
-            node.getparent().remove(node)
-            stripped_anchor = True
-    if stripped_anchor:
-        ctx.findings.append(
-            CompareFinding(
-                kind="anchor_not_carried",
-                story=ctx.story,
-                detail=(
-                    "bookmark or comment anchors in inserted content were"
-                    " dropped (their ids/targets do not transfer;"
-                    " report-only)"
-                ),
+    for tag in (
+        "w:bookmarkStart",
+        "w:bookmarkEnd",
+        "w:commentRangeStart",
+        "w:commentRangeEnd",
+        "w:commentReference",
+    ):
+        if clone.find(f".//{qn(tag)}") is not None:
+            raise UnsupportedStructureError(
+                f"compare cannot insert bookmark or comment anchors in"
+                f" {ctx.story}; their ids and targets cannot be transferred"
             )
-        )
     if _fldchar_unbalanced(clone):
         raise UnsupportedStructureError(
             f"compare cannot insert one paragraph of a multi-paragraph"
@@ -721,6 +1082,9 @@ def _row_text(row: "_Element") -> str:
 def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
     rows_o = table_o.findall(_TR)
     rows_r = table_r.findall(_TR)
+    _enforce_sequence_budget(
+        len(rows_o), len(rows_r), subject=f"table in {ctx.story}"
+    )
     matcher = SequenceMatcher(
         None, [_row_text(r) for r in rows_o], [_row_text(r) for r in rows_r],
         autojunk=False,
@@ -906,52 +1270,14 @@ def _replace_paragraph_text(
             span.replace(
                 replacement, tracked=True, author=ctx.author, date=ctx.stamp
             )
-    except PaperRefusal:
+    except PaperRefusal as exc:
         parent = paragraph.getparent()
         if parent is not None:
             parent.replace(paragraph, pristine)
-            paragraph = pristine
-        _fallback_paragraph_replace(ctx, paragraph, text_r)
-
-
-def _fallback_paragraph_replace(
-    ctx: _Ctx, paragraph: "_Element", text_r: str
-) -> None:
-    from docx.blocks import _stamp_paragraph_mark, _wrap_paragraph_content_as_insertion
-    from docx.oxml.parser import OxmlElement
-
-    if (
-        paragraph.find(f".//{_FLD_CHAR}") is not None
-        or paragraph.find(f".//{qn('w:fldSimple')}") is not None
-    ):
-        ctx.findings.append(
-            CompareFinding(
-                kind="field_flattened",
-                story=ctx.story,
-                detail=(
-                    "a changed paragraph containing a field was redlined as"
-                    " whole-paragraph delete+insert; the replacement carries"
-                    " the field's TEXT, not the field itself (report-only)"
-                ),
-            )
+        raise UnsupportedStructureError(
+            f"compare cannot safely redline this paragraph in {ctx.story};"
+            f" the text-edit primitive refused: {exc}"
         )
-
-    replacement = OxmlElement("w:p")
-    p_pr = paragraph.find(_PPR)
-    if p_pr is not None:
-        cloned_ppr = copy.deepcopy(p_pr)
-        for r_pr in list(cloned_ppr.findall(_RPR)):
-            cloned_ppr.remove(r_pr)  # mark stamps belong to the new mark only
-        replacement.append(cloned_ppr)
-    run = OxmlElement("w:r")
-    run.add_t(text_r)
-    replacement.append(run)
-    _wrap_paragraph_content_as_insertion(
-        replacement, _next_id(ctx), ctx.author, ctx.stamp
-    )
-    _stamp_paragraph_mark(replacement, "w:ins", _next_id(ctx), ctx.author, ctx.stamp)
-    _mark_paragraph_deleted(ctx, paragraph)
-    paragraph.addnext(replacement)
 
 
 def _token_regions(old: str, new: str) -> "List[Tuple[int, int, str]]":
@@ -960,6 +1286,13 @@ def _token_regions(old: str, new: str) -> "List[Tuple[int, int, str]]":
     every region maps to at least one atom."""
     tokens_o = re.findall(r"\S+|\s+", old)
     tokens_r = re.findall(r"\S+|\s+", new)
+    token_cells = len(tokens_o) * len(tokens_r)
+    if token_cells > _MAX_TEXT_SEQUENCE_CELLS:
+        raise UnsupportedStructureError(
+            "paragraph token diff exceeds the sequence-matching budget"
+            f" ({token_cells} > {_MAX_TEXT_SEQUENCE_CELLS} token cells);"
+            " use granularity='block' or split the documents"
+        )
     offsets = [0]
     for token in tokens_o:
         offsets.append(offsets[-1] + len(token))

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -548,6 +548,13 @@ def _canonical_story_bytes(root: "_Element") -> bytes:
 
     clone = copy.deepcopy(root)
     xml_space = "{http://www.w3.org/XML/1998/namespace}space"
+    # w:proofErr is the proofing tool's spell/grammar cache, not content: Word
+    # regenerates it freely and deletion paths legitimately drop it, so it
+    # must not defeat equality (or the reject-contract verification)
+    for node in list(clone.iter(_PROOF_ERR)):
+        parent = node.getparent()
+        if parent is not None:
+            parent.remove(node)
     for property_tag in (_PPR, _RPR):
         for node in list(clone.iter(property_tag)):
             if not node.attrib and not len(node) and not (node.text or ""):
@@ -645,16 +652,12 @@ def _compare_story(ctx: _Ctx, root_o: "_Element", root_r: "_Element") -> None:
             f"story {ctx.story} exceeds the compare block budget"
             f" ({_MAX_BLOCKS} blocks); split the documents"
         )
-    _enforce_sequence_budget(
-        len(blocks_o), len(blocks_r), subject=f"story {ctx.story}"
-    )
-    matcher = SequenceMatcher(
-        None,
+    opcodes = _aligned_opcodes(
         [f"{k}\x00{t}" for k, _e, t in blocks_o],
         [f"{k}\x00{t}" for k, _e, t in blocks_r],
-        autojunk=False,
+        subject=f"story {ctx.story}",
     )
-    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+    for tag, i1, i2, j1, j2 in opcodes:
         if tag == "equal":
             for offset in range(i2 - i1):
                 _report_formatting_difference(
@@ -679,6 +682,54 @@ def _enforce_sequence_budget(left: int, right: int, *, subject: str) -> None:
             f" ({left} x {right} > {_MAX_SEQUENCE_CELLS} cells);"
             " split the documents"
         )
+
+
+def _aligned_opcodes(
+    keys_o: "List[str]", keys_r: "List[str]", *, subject: str
+) -> "List[Tuple[str, int, int, int, int]]":
+    """SequenceMatcher opcodes with the common prefix/suffix pre-matched.
+
+    Identical leading and trailing runs are aligned directly and only the
+    differing middle is budgeted and fed to the quadratic matcher, so the
+    budget measures the change, not the document length — a one-edit diff of
+    a long document costs one cell, and an identical pair costs zero.
+    """
+    prefix = 0
+    limit = min(len(keys_o), len(keys_r))
+    while prefix < limit and keys_o[prefix] == keys_r[prefix]:
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < limit - prefix
+        and keys_o[len(keys_o) - 1 - suffix] == keys_r[len(keys_r) - 1 - suffix]
+    ):
+        suffix += 1
+    middle_o = len(keys_o) - prefix - suffix
+    middle_r = len(keys_r) - prefix - suffix
+    _enforce_sequence_budget(middle_o, middle_r, subject=subject)
+    opcodes: "List[Tuple[str, int, int, int, int]]" = []
+    if prefix:
+        opcodes.append(("equal", 0, prefix, 0, prefix))
+    if middle_o or middle_r:
+        matcher = SequenceMatcher(
+            None,
+            keys_o[prefix : len(keys_o) - suffix],
+            keys_r[prefix : len(keys_r) - suffix],
+            autojunk=False,
+        )
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            opcodes.append((tag, i1 + prefix, i2 + prefix, j1 + prefix, j2 + prefix))
+    if suffix:
+        opcodes.append(
+            (
+                "equal",
+                len(keys_o) - suffix,
+                len(keys_o),
+                len(keys_r) - suffix,
+                len(keys_r),
+            )
+        )
+    return opcodes
 
 
 def _pair_region(old_run, new_run) -> "List[Tuple[str, Optional[int], Optional[int]]]":
@@ -1082,14 +1133,12 @@ def _row_text(row: "_Element") -> str:
 def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
     rows_o = table_o.findall(_TR)
     rows_r = table_r.findall(_TR)
-    _enforce_sequence_budget(
-        len(rows_o), len(rows_r), subject=f"table in {ctx.story}"
+    opcodes = _aligned_opcodes(
+        [_row_text(r) for r in rows_o],
+        [_row_text(r) for r in rows_r],
+        subject=f"table in {ctx.story}",
     )
-    matcher = SequenceMatcher(
-        None, [_row_text(r) for r in rows_o], [_row_text(r) for r in rows_r],
-        autojunk=False,
-    )
-    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+    for tag, i1, i2, j1, j2 in opcodes:
         if tag == "equal":
             continue
         if tag == "delete":

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -37,6 +37,7 @@ from docx.story import (
     _build_block,
     _iter_block_elements,
     _story_elements,
+    _subtree_text,
     content_hash,
 )
 
@@ -1206,21 +1207,8 @@ def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
 
 
 def _visible_paragraph_text(paragraph: "_Element") -> str:
-    """Paragraph text with tabs/breaks as their synthetic characters —
-    matching the atom stream _paragraph_span slices, so word-diff offsets
-    never desynchronize."""
-    pieces: List[str] = []
-    for child in paragraph:
-        if child.tag == _PPR:
-            continue  # w:tabs STOP definitions live here, not tab chars
-        for node in child.iter():
-            if node.tag == _T:
-                pieces.append(node.text or "")
-            elif node.tag == qn("w:tab"):
-                pieces.append("\t")
-            elif node.tag in (qn("w:br"), qn("w:cr")):
-                pieces.append("\n")
-    return "".join(pieces)
+    """Current-view paragraph text using the canonical story projection."""
+    return _subtree_text(paragraph, "current", skip_text_boxes=True).text
 
 
 def _replace_row_cells(ctx: _Ctx, row_o: "_Element", row_r: "_Element") -> bool:
@@ -1415,8 +1403,12 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     ]
     if not atoms or start >= end:
         return None
-    positions = []  # (atom_index, offset) per character
+    positions = []  # (atom_index, offset) per visible character
+    visible_pieces = []
     for index, atom in enumerate(atoms):
+        if atom.barrier:
+            continue
+        visible_pieces.append(atom.text)
         for offset in range(len(atom.text)):
             positions.append((index, offset))
     if end > len(positions):
@@ -1424,7 +1416,9 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     start_atom, start_offset = positions[start]
     end_atom, end_offset = positions[end - 1]
     span_atoms = atoms[start_atom : end_atom + 1]
-    text = "".join(a.text for a in atoms)[start:end]
+    if any(atom.barrier for atom in span_atoms):
+        return None
+    text = "".join(visible_pieces)[start:end]
     return Span(
         text=text,
         story=ctx.story,

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -491,6 +491,10 @@ def _verify_compare_algebra(
         ("reject", original_reference),
     ):
         candidate = _docx.Document(io.BytesIO(redline_bytes))
+        from docx.protection import acknowledge_protection, protection_status
+
+        if protection_status(candidate).enforced:
+            acknowledge_protection(candidate)
         if verb == "accept":
             candidate.revisions.accept_all()
         else:

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -373,9 +373,27 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             raise UnsupportedStructureError(
                 f"relationship part {rels_name!r} has unexpected root {root.tag!r}"
             )
+        relationship_ids = set()
         for relationship in root:
             if relationship.tag != relationship_tag:
                 continue
+            relationship_id = relationship.get("Id")
+            if relationship_id is None:
+                raise UnsupportedStructureError(
+                    f"relationship part {rels_name!r} contains a relationship"
+                    " with a missing Id"
+                )
+            if not relationship_id.strip():
+                raise UnsupportedStructureError(
+                    f"relationship part {rels_name!r} contains a relationship"
+                    " with an empty Id"
+                )
+            if relationship_id in relationship_ids:
+                raise UnsupportedStructureError(
+                    f"relationship part {rels_name!r} contains duplicate"
+                    f" relationship Id {relationship_id!r}"
+                )
+            relationship_ids.add(relationship_id)
             if relationship.get("TargetMode", "Internal") == "External":
                 continue
             target_ref = relationship.get("Target")

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -383,17 +383,18 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
                     f"relationship part {rels_name!r} contains a relationship"
                     " with a missing Id"
                 )
-            if not relationship_id.strip():
+            normalized_relationship_id = " ".join(relationship_id.split())
+            if not normalized_relationship_id:
                 raise UnsupportedStructureError(
                     f"relationship part {rels_name!r} contains a relationship"
                     " with an empty Id"
                 )
-            if relationship_id in relationship_ids:
+            if normalized_relationship_id in relationship_ids:
                 raise UnsupportedStructureError(
                     f"relationship part {rels_name!r} contains duplicate"
                     f" relationship Id {relationship_id!r}"
                 )
-            relationship_ids.add(relationship_id)
+            relationship_ids.add(normalized_relationship_id)
             if relationship.get("TargetMode", "Internal") == "External":
                 continue
             target_ref = relationship.get("Target")

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -182,8 +182,10 @@ def compare(
             f"materialize must be None, 'accept' or 'reject', got {materialize!r}"
         )
     stamp = date if date is not None else _clock.now()
-    raw_original = _read_raw_package(original, label="original")
-    raw_revised = _read_raw_package(revised, label="revised")
+    original_bytes = _source_bytes(original)
+    revised_bytes = _source_bytes(revised)
+    raw_original = _read_raw_package(original_bytes, label="original")
+    raw_revised = _read_raw_package(revised_bytes, label="revised")
     if materialize is None:
         for which, raw_package in (
             ("original", raw_original),
@@ -197,8 +199,8 @@ def compare(
                     " copies first (the input files are not modified)"
                 )
     _refuse_unsupported_package_differences(raw_original, raw_revised)
-    document = _docx.Document(_document_source(original))
-    revised_doc = _docx.Document(_document_source(revised))
+    document = _docx.Document(io.BytesIO(original_bytes))
+    revised_doc = _docx.Document(io.BytesIO(revised_bytes))
     findings: List[CompareFinding] = []
     for which, doc in (("original", document), ("revised", revised_doc)):
         if len(doc.revisions):
@@ -292,9 +294,13 @@ def _serialize_document(document: "Document") -> bytes:
     return stream.getvalue()
 
 
-def _document_source(source):
-    """Return a fresh source suitable for ``Document()`` after raw inspection."""
-    return io.BytesIO(source) if isinstance(source, bytes) else str(source)
+def _source_bytes(source) -> bytes:
+    """Read one bounded input snapshot for validation and document loading."""
+    if isinstance(source, bytes):
+        return source
+    from docx._zipguard import read_compressed_bytes
+
+    return read_compressed_bytes(source)
 
 
 def _read_raw_package(source, *, label: str) -> _RawPackage:

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -242,13 +242,15 @@ def compare(
             f" only-revised: {sorted(names_r - names_o)}); compare cannot"
             " redline story-part addition or removal"
         )
-    if names_o != set(raw_original.story_parts):
+    raw_names_o = {name.casefold() for name in raw_original.story_parts}
+    raw_names_r = {name.casefold() for name in raw_revised.story_parts}
+    if names_o != raw_names_o:
         raise UnsupportedStructureError(
             "the original package contains a story part compare could not load"
             f" safely (raw: {sorted(raw_original.story_parts)},"
             f" loaded: {sorted(names_o)})"
         )
-    if names_r != set(raw_revised.story_parts):
+    if names_r != raw_names_r:
         raise UnsupportedStructureError(
             "the revised package contains a story part compare could not load"
             f" safely (raw: {sorted(raw_revised.story_parts)},"
@@ -316,7 +318,11 @@ def _read_raw_package(source, *, label: str) -> _RawPackage:
             raise UnsupportedStructureError(
                 f"the {label} package has no [Content_Types].xml part"
             )
-        defaults, overrides = _effective_content_types(content_types, order)
+        defaults, raw_overrides = _effective_content_types(content_types, order)
+        overrides = {
+            partname.casefold(): content_type
+            for partname, content_type in raw_overrides.items()
+        }
         supported_types = frozenset(
             (
                 CT.WML_DOCUMENT_MAIN,
@@ -356,6 +362,7 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
     relationships_tag = f"{{{rel_ns}}}Relationships"
     relationship_tag = f"{{{rel_ns}}}Relationship"
     reachable = {"[Content_Types].xml"}
+    member_name_by_fold = {name.casefold(): name for name in parts}
     pending = [PACKAGE_URI]
     visited = set()
     while pending:
@@ -364,14 +371,15 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             continue
         visited.add(source_uri)
         rels_name = source_uri.rels_uri.membername
-        rels_bytes = parts.get(rels_name)
+        actual_rels_name = member_name_by_fold.get(rels_name.casefold())
+        rels_bytes = parts.get(actual_rels_name) if actual_rels_name else None
         if rels_bytes is None:
             continue
-        reachable.add(rels_name)
+        reachable.add(actual_rels_name)
         root = _parse(rels_bytes)
         if root.tag != relationships_tag:
             raise UnsupportedStructureError(
-                f"relationship part {rels_name!r} has unexpected root {root.tag!r}"
+                f"relationship part {actual_rels_name!r} has unexpected root {root.tag!r}"
             )
         relationship_ids = set()
         for relationship in root:
@@ -405,21 +413,22 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
                 )
             target_uri = PackURI.from_rel_ref(source_uri.baseURI, target_ref)
             target_name = target_uri.membername
-            if target_name not in parts:
+            actual_target_name = member_name_by_fold.get(target_name.casefold())
+            if actual_target_name is None:
                 raise UnsupportedStructureError(
-                    f"relationship part {rels_name!r} targets missing part"
+                    f"relationship part {actual_rels_name!r} targets missing part"
                     f" {target_name!r}"
                 )
-            if target_name not in reachable:
-                reachable.add(target_name)
-                pending.append(target_uri)
+            if actual_target_name not in reachable:
+                reachable.add(actual_target_name)
+                pending.append(PackURI(f"/{actual_target_name}"))
     return reachable
 
 
 def _raw_content_type(
     name: str, defaults: dict[str, str], overrides: dict[str, str]
 ) -> str:
-    override = overrides.get(f"/{name}")
+    override = overrides.get(f"/{name}".casefold())
     if override is not None:
         return override
     extension = name.rsplit(".", 1)[-1].lower() if "." in name else ""

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -37,6 +37,7 @@ from docx.story import (
     _build_block,
     _iter_block_elements,
     _story_elements,
+    _subtree_text,
     content_hash,
 )
 
@@ -173,13 +174,9 @@ def compare(
     if not author:
         raise ValueError("author is required")
     if granularity not in ("word", "block"):
-        raise ValueError(
-            f"granularity must be 'word' or 'block', got {granularity!r}"
-        )
+        raise ValueError(f"granularity must be 'word' or 'block', got {granularity!r}")
     if materialize not in (None, "accept", "reject"):
-        raise ValueError(
-            f"materialize must be None, 'accept' or 'reject', got {materialize!r}"
-        )
+        raise ValueError(f"materialize must be None, 'accept' or 'reject', got {materialize!r}")
     stamp = date if date is not None else _clock.now()
     raw_original = _read_raw_package(original, label="original")
     raw_revised = _read_raw_package(revised, label="revised")
@@ -315,13 +312,10 @@ def _read_raw_package(source, *, label: str) -> _RawPackage:
 
         content_types = parts.get("[Content_Types].xml")
         if content_types is None:
-            raise UnsupportedStructureError(
-                f"the {label} package has no [Content_Types].xml part"
-            )
+            raise UnsupportedStructureError(f"the {label} package has no [Content_Types].xml part")
         defaults, raw_overrides = _effective_content_types(content_types, order)
         overrides = {
-            partname.casefold(): content_type
-            for partname, content_type in raw_overrides.items()
+            partname.casefold(): content_type for partname, content_type in raw_overrides.items()
         }
         supported_types = frozenset(
             (
@@ -388,14 +382,12 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             relationship_id = relationship.get("Id")
             if relationship_id is None:
                 raise UnsupportedStructureError(
-                    f"relationship part {rels_name!r} contains a relationship"
-                    " with a missing Id"
+                    f"relationship part {rels_name!r} contains a relationship with a missing Id"
                 )
             normalized_relationship_id = " ".join(relationship_id.split())
             if not normalized_relationship_id:
                 raise UnsupportedStructureError(
-                    f"relationship part {rels_name!r} contains a relationship"
-                    " with an empty Id"
+                    f"relationship part {rels_name!r} contains a relationship with an empty Id"
                 )
             if normalized_relationship_id in relationship_ids:
                 raise UnsupportedStructureError(
@@ -416,8 +408,7 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             actual_target_name = member_name_by_fold.get(target_name.casefold())
             if actual_target_name is None:
                 raise UnsupportedStructureError(
-                    f"relationship part {actual_rels_name!r} targets missing part"
-                    f" {target_name!r}"
+                    f"relationship part {actual_rels_name!r} targets missing part {target_name!r}"
                 )
             if actual_target_name not in reachable:
                 reachable.add(actual_target_name)
@@ -425,9 +416,7 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
     return reachable
 
 
-def _raw_content_type(
-    name: str, defaults: dict[str, str], overrides: dict[str, str]
-) -> str:
+def _raw_content_type(name: str, defaults: dict[str, str], overrides: dict[str, str]) -> str:
     override = overrides.get(f"/{name}".casefold())
     if override is not None:
         return override
@@ -435,17 +424,13 @@ def _raw_content_type(
     return defaults.get(extension, "")
 
 
-def _raw_parts_have_revisions(
-    parts: dict[str, bytes], story_parts: frozenset[str]
-) -> bool:
+def _raw_parts_have_revisions(parts: dict[str, bytes], story_parts: frozenset[str]) -> bool:
     from docx._paperpkg import _parse
     from docx.revision import _MARKUP_SCAN_TAGS
 
     revision_tags = frozenset(_MARKUP_SCAN_TAGS)
     return any(
-        node.tag in revision_tags
-        for name in story_parts
-        for node in _parse(parts[name]).iter()
+        node.tag in revision_tags for name in story_parts for node in _parse(parts[name]).iter()
     )
 
 
@@ -523,9 +508,7 @@ def _verify_compare_algebra(
         )
 
 
-def _assert_packages_match(
-    actual_bytes: bytes, expected_bytes: bytes, *, outcome: str
-) -> None:
+def _assert_packages_match(actual_bytes: bytes, expected_bytes: bytes, *, outcome: str) -> None:
     """Compare every part, allowing only inert run fragmentation in stories."""
     import docx as _docx
     from docx._paperpkg import (
@@ -547,8 +530,7 @@ def _assert_packages_match(
             stories_expected[name]
         ):
             raise UnsupportedStructureError(
-                f"compare could not prove its {outcome} contract;"
-                f" story {name!r} does not match"
+                f"compare could not prove its {outcome} contract; story {name!r} does not match"
             )
 
     actual_parts, actual_order = _read_zip(actual_bytes)
@@ -569,8 +551,7 @@ def _assert_packages_match(
         ):
             continue
         raise UnsupportedStructureError(
-            f"compare could not prove its {outcome} contract;"
-            f" package part {name!r} does not match"
+            f"compare could not prove its {outcome} contract; package part {name!r} does not match"
         )
 
 
@@ -658,10 +639,7 @@ def _numbering_ids(document: "Document") -> frozenset:
     try:
         from docx.numbering import list_numbering
 
-        return frozenset(
-            definition.num_id
-            for definition in list_numbering(document).definitions
-        )
+        return frozenset(definition.num_id for definition in list_numbering(document).definitions)
     except Exception:
         return frozenset()
 
@@ -669,9 +647,7 @@ def _numbering_ids(document: "Document") -> frozenset:
 def _story_blocks(story: str, root: "_Element") -> "List[Tuple[str, _Element, str]]":
     blocks = []
     for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-        block = _build_block(
-            story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx
-        )
+        block = _build_block(story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx)
         blocks.append((kind, element, block.text))
     return blocks
 
@@ -692,9 +668,7 @@ def _compare_story(ctx: _Ctx, root_o: "_Element", root_r: "_Element") -> None:
     for tag, i1, i2, j1, j2 in opcodes:
         if tag == "equal":
             for offset in range(i2 - i1):
-                _report_formatting_difference(
-                    ctx, blocks_o[i1 + offset], blocks_r[j1 + offset]
-                )
+                _report_formatting_difference(ctx, blocks_o[i1 + offset], blocks_r[j1 + offset])
             continue
         if tag == "delete":
             for kind, element, text in blocks_o[i1:i2]:
@@ -872,9 +846,7 @@ def _report_formatting_difference(ctx: _Ctx, block_o, block_r) -> None:
         )
 
 
-def _refuse_non_text_paragraph_change(
-    ctx: _Ctx, original: "_Element", revised: "_Element"
-) -> None:
+def _refuse_non_text_paragraph_change(ctx: _Ctx, original: "_Element", revised: "_Element") -> None:
     """Allow text changes only when the surrounding paragraph markup agrees."""
     if _textless_story_bytes(original) == _textless_story_bytes(revised):
         return
@@ -936,15 +908,11 @@ def _mark_paragraph_deleted(ctx: _Ctx, paragraph: "_Element") -> None:
             current_del = None
             continue
         if current_del is None:
-            current_del = CT_RunTrackChange.new(
-                "w:del", revision_id, ctx.author, ctx.stamp
-            )
+            current_del = CT_RunTrackChange.new("w:del", revision_id, ctx.author, ctx.stamp)
             child.addprevious(current_del)
         _retag_deleted_text(child)
         current_del.append(child)
-    _stamp_paragraph_mark(
-        paragraph, "w:del", _next_id(ctx), ctx.author, ctx.stamp
-    )
+    _stamp_paragraph_mark(paragraph, "w:del", _next_id(ctx), ctx.author, ctx.stamp)
 
 
 def _wrap_children_deleted(ctx: _Ctx, container: "_Element", revision_id: int) -> None:
@@ -956,9 +924,7 @@ def _wrap_children_deleted(ctx: _Ctx, container: "_Element", revision_id: int) -
             wrapper = None
             continue
         if wrapper is None:
-            wrapper = CT_RunTrackChange.new(
-                "w:del", revision_id, ctx.author, ctx.stamp
-            )
+            wrapper = CT_RunTrackChange.new("w:del", revision_id, ctx.author, ctx.stamp)
             child.addprevious(wrapper)
         _retag_deleted_text(child)
         wrapper.append(child)
@@ -991,9 +957,7 @@ def _fldchar_unbalanced(element: "_Element") -> bool:
     return depth != 0
 
 
-def _refuse_unrepresentable_children(
-    ctx: _Ctx, paragraph: "_Element", *, verb: str
-) -> None:
+def _refuse_unrepresentable_children(ctx: _Ctx, paragraph: "_Element", *, verb: str) -> None:
     for child in paragraph:
         if child.tag in _UNREPRESENTABLE_IN_DELETE:
             local = child.tag.rsplit("}", 1)[-1]
@@ -1028,9 +992,7 @@ def _insert_blocks(
 ) -> None:
     """Insert sanitized clones of `new_blocks` as tracked insertions, before
     the original block at `insert_index` (or after `after_element`)."""
-    clones = [
-        _cloned_as_insertion(ctx, kind, element) for kind, element, _t in new_blocks
-    ]
+    clones = [_cloned_as_insertion(ctx, kind, element) for kind, element, _t in new_blocks]
     if after_element is not None:
         reference = after_element
         for clone in clones:
@@ -1044,9 +1006,7 @@ def _insert_blocks(
             reference.addprevious(clone)
         return
     if not blocks_o:
-        raise UnsupportedStructureError(
-            f"compare cannot insert into the empty story {ctx.story}"
-        )
+        raise UnsupportedStructureError(f"compare cannot insert into the empty story {ctx.story}")
     reference = blocks_o[-1][1]
     _require_container_anchor(ctx, reference)
     for clone in clones:
@@ -1064,9 +1024,7 @@ def _require_container_anchor(ctx: _Ctx, reference: "_Element") -> None:
             f"compare cannot add or remove whole blocks next to text-box"
             f" content in {ctx.story} (a declared limit)"
         )
-    if ctx.story.startswith("word/footnotes") or ctx.story.startswith(
-        "word/endnotes"
-    ):
+    if ctx.story.startswith("word/footnotes") or ctx.story.startswith("word/endnotes"):
         raise UnsupportedStructureError(
             f"compare cannot add or remove whole blocks in {ctx.story};"
             " note-content edits must stay within existing notes"
@@ -1157,9 +1115,7 @@ def _refuse_merged_rows(ctx: _Ctx, rows) -> None:
 
 
 def _row_text(row: "_Element") -> str:
-    return "\x00".join(
-        "".join(t.text or "" for t in cell.iter(_T)) for cell in row.findall(_TC)
-    )
+    return "\x00".join("".join(t.text or "" for t in cell.iter(_T)) for cell in row.findall(_TC))
 
 
 def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
@@ -1191,36 +1147,24 @@ def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
                 cursor = old_rows[k]
             else:
                 _mark_row_deleted(ctx, old_rows[k])
-                inserted = _insert_rows(
-                    ctx, rows_o, i1 + k, [new_rows[k]], after=old_rows[k]
-                )
+                inserted = _insert_rows(ctx, rows_o, i1 + k, [new_rows[k]], after=old_rows[k])
                 cursor = inserted[-1]
         for row in old_rows[paired:]:
             _mark_row_deleted(ctx, row)
             cursor = row
         if len(new_rows) > paired:
             _insert_rows(
-                ctx, rows_o, i2, new_rows[paired:],
+                ctx,
+                rows_o,
+                i2,
+                new_rows[paired:],
                 after=cursor if cursor is not None else old_rows[-1],
             )
 
 
 def _visible_paragraph_text(paragraph: "_Element") -> str:
-    """Paragraph text with tabs/breaks as their synthetic characters —
-    matching the atom stream _paragraph_span slices, so word-diff offsets
-    never desynchronize."""
-    pieces: List[str] = []
-    for child in paragraph:
-        if child.tag == _PPR:
-            continue  # w:tabs STOP definitions live here, not tab chars
-        for node in child.iter():
-            if node.tag == _T:
-                pieces.append(node.text or "")
-            elif node.tag == qn("w:tab"):
-                pieces.append("\t")
-            elif node.tag in (qn("w:br"), qn("w:cr")):
-                pieces.append("\n")
-    return "".join(pieces)
+    """Current-view paragraph text using the canonical story projection."""
+    return _subtree_text(paragraph, "current", skip_text_boxes=True).text
 
 
 def _replace_row_cells(ctx: _Ctx, row_o: "_Element", row_r: "_Element") -> bool:
@@ -1286,12 +1230,8 @@ def _mark_cloned_row_inserted(ctx: _Ctx, row: "_Element") -> None:
     tr_pr.append(marker)
     for cell in row.findall(_TC):
         for paragraph in cell.findall(_P):
-            _wrap_paragraph_content_as_insertion(
-                paragraph, _next_id(ctx), ctx.author, ctx.stamp
-            )
-            _stamp_paragraph_mark(
-                paragraph, "w:ins", _next_id(ctx), ctx.author, ctx.stamp
-            )
+            _wrap_paragraph_content_as_insertion(paragraph, _next_id(ctx), ctx.author, ctx.stamp)
+            _stamp_paragraph_mark(paragraph, "w:ins", _next_id(ctx), ctx.author, ctx.stamp)
 
 
 def _insert_rows(ctx: _Ctx, rows_o, index: int, new_rows, after=None) -> list:
@@ -1331,9 +1271,7 @@ def _iso(stamp: "dt.datetime") -> str:
 # ---------------------------------------------------------------------------
 
 
-def _replace_paragraph_text(
-    ctx: _Ctx, paragraph: "_Element", text_o: str, text_r: str
-) -> None:
+def _replace_paragraph_text(ctx: _Ctx, paragraph: "_Element", text_o: str, text_r: str) -> None:
     """Token-level tracked edits inside one matched paragraph; whole-block
     del+ins fallback when the span machinery refuses a region.
 
@@ -1348,9 +1286,7 @@ def _replace_paragraph_text(
             span = _paragraph_span(ctx, paragraph, start, end)
             if span is None:
                 raise UnsupportedStructureError("region unmappable to atoms")
-            span.replace(
-                replacement, tracked=True, author=ctx.author, date=ctx.stamp
-            )
+            span.replace(replacement, tracked=True, author=ctx.author, date=ctx.stamp)
     except PaperRefusal as exc:
         parent = paragraph.getparent()
         if parent is not None:
@@ -1403,9 +1339,7 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     with the exact conventions of `docx.search._spans_for_story`."""
     from docx.search import Span, _include_atom, _story_atoms
 
-    root = next(
-        (root for s, root in _story_elements(ctx.document) if s == ctx.story), None
-    )
+    root = next((root for s, root in _story_elements(ctx.document) if s == ctx.story), None)
     if root is None:
         return None
     atoms = [
@@ -1415,8 +1349,12 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     ]
     if not atoms or start >= end:
         return None
-    positions = []  # (atom_index, offset) per character
+    positions = []  # (atom_index, offset) per visible character
+    visible_pieces = []
     for index, atom in enumerate(atoms):
+        if atom.barrier:
+            continue
+        visible_pieces.append(atom.text)
         for offset in range(len(atom.text)):
             positions.append((index, offset))
     if end > len(positions):
@@ -1424,7 +1362,9 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     start_atom, start_offset = positions[start]
     end_atom, end_offset = positions[end - 1]
     span_atoms = atoms[start_atom : end_atom + 1]
-    text = "".join(a.text for a in atoms)[start:end]
+    if any(atom.barrier for atom in span_atoms):
+        return None
+    text = "".join(visible_pieces)[start:end]
     return Span(
         text=text,
         story=ctx.story,

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -37,7 +37,6 @@ from docx.story import (
     _build_block,
     _iter_block_elements,
     _story_elements,
-    _subtree_text,
     content_hash,
 )
 
@@ -174,9 +173,13 @@ def compare(
     if not author:
         raise ValueError("author is required")
     if granularity not in ("word", "block"):
-        raise ValueError(f"granularity must be 'word' or 'block', got {granularity!r}")
+        raise ValueError(
+            f"granularity must be 'word' or 'block', got {granularity!r}"
+        )
     if materialize not in (None, "accept", "reject"):
-        raise ValueError(f"materialize must be None, 'accept' or 'reject', got {materialize!r}")
+        raise ValueError(
+            f"materialize must be None, 'accept' or 'reject', got {materialize!r}"
+        )
     stamp = date if date is not None else _clock.now()
     raw_original = _read_raw_package(original, label="original")
     raw_revised = _read_raw_package(revised, label="revised")
@@ -312,10 +315,13 @@ def _read_raw_package(source, *, label: str) -> _RawPackage:
 
         content_types = parts.get("[Content_Types].xml")
         if content_types is None:
-            raise UnsupportedStructureError(f"the {label} package has no [Content_Types].xml part")
+            raise UnsupportedStructureError(
+                f"the {label} package has no [Content_Types].xml part"
+            )
         defaults, raw_overrides = _effective_content_types(content_types, order)
         overrides = {
-            partname.casefold(): content_type for partname, content_type in raw_overrides.items()
+            partname.casefold(): content_type
+            for partname, content_type in raw_overrides.items()
         }
         supported_types = frozenset(
             (
@@ -382,12 +388,14 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             relationship_id = relationship.get("Id")
             if relationship_id is None:
                 raise UnsupportedStructureError(
-                    f"relationship part {rels_name!r} contains a relationship with a missing Id"
+                    f"relationship part {rels_name!r} contains a relationship"
+                    " with a missing Id"
                 )
             normalized_relationship_id = " ".join(relationship_id.split())
             if not normalized_relationship_id:
                 raise UnsupportedStructureError(
-                    f"relationship part {rels_name!r} contains a relationship with an empty Id"
+                    f"relationship part {rels_name!r} contains a relationship"
+                    " with an empty Id"
                 )
             if normalized_relationship_id in relationship_ids:
                 raise UnsupportedStructureError(
@@ -408,7 +416,8 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
             actual_target_name = member_name_by_fold.get(target_name.casefold())
             if actual_target_name is None:
                 raise UnsupportedStructureError(
-                    f"relationship part {actual_rels_name!r} targets missing part {target_name!r}"
+                    f"relationship part {actual_rels_name!r} targets missing part"
+                    f" {target_name!r}"
                 )
             if actual_target_name not in reachable:
                 reachable.add(actual_target_name)
@@ -416,7 +425,9 @@ def _reachable_raw_parts(parts: dict[str, bytes]) -> set[str]:
     return reachable
 
 
-def _raw_content_type(name: str, defaults: dict[str, str], overrides: dict[str, str]) -> str:
+def _raw_content_type(
+    name: str, defaults: dict[str, str], overrides: dict[str, str]
+) -> str:
     override = overrides.get(f"/{name}".casefold())
     if override is not None:
         return override
@@ -424,13 +435,17 @@ def _raw_content_type(name: str, defaults: dict[str, str], overrides: dict[str, 
     return defaults.get(extension, "")
 
 
-def _raw_parts_have_revisions(parts: dict[str, bytes], story_parts: frozenset[str]) -> bool:
+def _raw_parts_have_revisions(
+    parts: dict[str, bytes], story_parts: frozenset[str]
+) -> bool:
     from docx._paperpkg import _parse
     from docx.revision import _MARKUP_SCAN_TAGS
 
     revision_tags = frozenset(_MARKUP_SCAN_TAGS)
     return any(
-        node.tag in revision_tags for name in story_parts for node in _parse(parts[name]).iter()
+        node.tag in revision_tags
+        for name in story_parts
+        for node in _parse(parts[name]).iter()
     )
 
 
@@ -508,7 +523,9 @@ def _verify_compare_algebra(
         )
 
 
-def _assert_packages_match(actual_bytes: bytes, expected_bytes: bytes, *, outcome: str) -> None:
+def _assert_packages_match(
+    actual_bytes: bytes, expected_bytes: bytes, *, outcome: str
+) -> None:
     """Compare every part, allowing only inert run fragmentation in stories."""
     import docx as _docx
     from docx._paperpkg import (
@@ -530,7 +547,8 @@ def _assert_packages_match(actual_bytes: bytes, expected_bytes: bytes, *, outcom
             stories_expected[name]
         ):
             raise UnsupportedStructureError(
-                f"compare could not prove its {outcome} contract; story {name!r} does not match"
+                f"compare could not prove its {outcome} contract;"
+                f" story {name!r} does not match"
             )
 
     actual_parts, actual_order = _read_zip(actual_bytes)
@@ -551,7 +569,8 @@ def _assert_packages_match(actual_bytes: bytes, expected_bytes: bytes, *, outcom
         ):
             continue
         raise UnsupportedStructureError(
-            f"compare could not prove its {outcome} contract; package part {name!r} does not match"
+            f"compare could not prove its {outcome} contract;"
+            f" package part {name!r} does not match"
         )
 
 
@@ -639,7 +658,10 @@ def _numbering_ids(document: "Document") -> frozenset:
     try:
         from docx.numbering import list_numbering
 
-        return frozenset(definition.num_id for definition in list_numbering(document).definitions)
+        return frozenset(
+            definition.num_id
+            for definition in list_numbering(document).definitions
+        )
     except Exception:
         return frozenset()
 
@@ -647,7 +669,9 @@ def _numbering_ids(document: "Document") -> frozenset:
 def _story_blocks(story: str, root: "_Element") -> "List[Tuple[str, _Element, str]]":
     blocks = []
     for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-        block = _build_block(story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx)
+        block = _build_block(
+            story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx
+        )
         blocks.append((kind, element, block.text))
     return blocks
 
@@ -668,7 +692,9 @@ def _compare_story(ctx: _Ctx, root_o: "_Element", root_r: "_Element") -> None:
     for tag, i1, i2, j1, j2 in opcodes:
         if tag == "equal":
             for offset in range(i2 - i1):
-                _report_formatting_difference(ctx, blocks_o[i1 + offset], blocks_r[j1 + offset])
+                _report_formatting_difference(
+                    ctx, blocks_o[i1 + offset], blocks_r[j1 + offset]
+                )
             continue
         if tag == "delete":
             for kind, element, text in blocks_o[i1:i2]:
@@ -846,7 +872,9 @@ def _report_formatting_difference(ctx: _Ctx, block_o, block_r) -> None:
         )
 
 
-def _refuse_non_text_paragraph_change(ctx: _Ctx, original: "_Element", revised: "_Element") -> None:
+def _refuse_non_text_paragraph_change(
+    ctx: _Ctx, original: "_Element", revised: "_Element"
+) -> None:
     """Allow text changes only when the surrounding paragraph markup agrees."""
     if _textless_story_bytes(original) == _textless_story_bytes(revised):
         return
@@ -908,11 +936,15 @@ def _mark_paragraph_deleted(ctx: _Ctx, paragraph: "_Element") -> None:
             current_del = None
             continue
         if current_del is None:
-            current_del = CT_RunTrackChange.new("w:del", revision_id, ctx.author, ctx.stamp)
+            current_del = CT_RunTrackChange.new(
+                "w:del", revision_id, ctx.author, ctx.stamp
+            )
             child.addprevious(current_del)
         _retag_deleted_text(child)
         current_del.append(child)
-    _stamp_paragraph_mark(paragraph, "w:del", _next_id(ctx), ctx.author, ctx.stamp)
+    _stamp_paragraph_mark(
+        paragraph, "w:del", _next_id(ctx), ctx.author, ctx.stamp
+    )
 
 
 def _wrap_children_deleted(ctx: _Ctx, container: "_Element", revision_id: int) -> None:
@@ -924,7 +956,9 @@ def _wrap_children_deleted(ctx: _Ctx, container: "_Element", revision_id: int) -
             wrapper = None
             continue
         if wrapper is None:
-            wrapper = CT_RunTrackChange.new("w:del", revision_id, ctx.author, ctx.stamp)
+            wrapper = CT_RunTrackChange.new(
+                "w:del", revision_id, ctx.author, ctx.stamp
+            )
             child.addprevious(wrapper)
         _retag_deleted_text(child)
         wrapper.append(child)
@@ -957,7 +991,9 @@ def _fldchar_unbalanced(element: "_Element") -> bool:
     return depth != 0
 
 
-def _refuse_unrepresentable_children(ctx: _Ctx, paragraph: "_Element", *, verb: str) -> None:
+def _refuse_unrepresentable_children(
+    ctx: _Ctx, paragraph: "_Element", *, verb: str
+) -> None:
     for child in paragraph:
         if child.tag in _UNREPRESENTABLE_IN_DELETE:
             local = child.tag.rsplit("}", 1)[-1]
@@ -992,7 +1028,9 @@ def _insert_blocks(
 ) -> None:
     """Insert sanitized clones of `new_blocks` as tracked insertions, before
     the original block at `insert_index` (or after `after_element`)."""
-    clones = [_cloned_as_insertion(ctx, kind, element) for kind, element, _t in new_blocks]
+    clones = [
+        _cloned_as_insertion(ctx, kind, element) for kind, element, _t in new_blocks
+    ]
     if after_element is not None:
         reference = after_element
         for clone in clones:
@@ -1006,7 +1044,9 @@ def _insert_blocks(
             reference.addprevious(clone)
         return
     if not blocks_o:
-        raise UnsupportedStructureError(f"compare cannot insert into the empty story {ctx.story}")
+        raise UnsupportedStructureError(
+            f"compare cannot insert into the empty story {ctx.story}"
+        )
     reference = blocks_o[-1][1]
     _require_container_anchor(ctx, reference)
     for clone in clones:
@@ -1024,7 +1064,9 @@ def _require_container_anchor(ctx: _Ctx, reference: "_Element") -> None:
             f"compare cannot add or remove whole blocks next to text-box"
             f" content in {ctx.story} (a declared limit)"
         )
-    if ctx.story.startswith("word/footnotes") or ctx.story.startswith("word/endnotes"):
+    if ctx.story.startswith("word/footnotes") or ctx.story.startswith(
+        "word/endnotes"
+    ):
         raise UnsupportedStructureError(
             f"compare cannot add or remove whole blocks in {ctx.story};"
             " note-content edits must stay within existing notes"
@@ -1115,7 +1157,9 @@ def _refuse_merged_rows(ctx: _Ctx, rows) -> None:
 
 
 def _row_text(row: "_Element") -> str:
-    return "\x00".join("".join(t.text or "" for t in cell.iter(_T)) for cell in row.findall(_TC))
+    return "\x00".join(
+        "".join(t.text or "" for t in cell.iter(_T)) for cell in row.findall(_TC)
+    )
 
 
 def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
@@ -1147,24 +1191,36 @@ def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
                 cursor = old_rows[k]
             else:
                 _mark_row_deleted(ctx, old_rows[k])
-                inserted = _insert_rows(ctx, rows_o, i1 + k, [new_rows[k]], after=old_rows[k])
+                inserted = _insert_rows(
+                    ctx, rows_o, i1 + k, [new_rows[k]], after=old_rows[k]
+                )
                 cursor = inserted[-1]
         for row in old_rows[paired:]:
             _mark_row_deleted(ctx, row)
             cursor = row
         if len(new_rows) > paired:
             _insert_rows(
-                ctx,
-                rows_o,
-                i2,
-                new_rows[paired:],
+                ctx, rows_o, i2, new_rows[paired:],
                 after=cursor if cursor is not None else old_rows[-1],
             )
 
 
 def _visible_paragraph_text(paragraph: "_Element") -> str:
-    """Current-view paragraph text using the canonical story projection."""
-    return _subtree_text(paragraph, "current", skip_text_boxes=True).text
+    """Paragraph text with tabs/breaks as their synthetic characters —
+    matching the atom stream _paragraph_span slices, so word-diff offsets
+    never desynchronize."""
+    pieces: List[str] = []
+    for child in paragraph:
+        if child.tag == _PPR:
+            continue  # w:tabs STOP definitions live here, not tab chars
+        for node in child.iter():
+            if node.tag == _T:
+                pieces.append(node.text or "")
+            elif node.tag == qn("w:tab"):
+                pieces.append("\t")
+            elif node.tag in (qn("w:br"), qn("w:cr")):
+                pieces.append("\n")
+    return "".join(pieces)
 
 
 def _replace_row_cells(ctx: _Ctx, row_o: "_Element", row_r: "_Element") -> bool:
@@ -1230,8 +1286,12 @@ def _mark_cloned_row_inserted(ctx: _Ctx, row: "_Element") -> None:
     tr_pr.append(marker)
     for cell in row.findall(_TC):
         for paragraph in cell.findall(_P):
-            _wrap_paragraph_content_as_insertion(paragraph, _next_id(ctx), ctx.author, ctx.stamp)
-            _stamp_paragraph_mark(paragraph, "w:ins", _next_id(ctx), ctx.author, ctx.stamp)
+            _wrap_paragraph_content_as_insertion(
+                paragraph, _next_id(ctx), ctx.author, ctx.stamp
+            )
+            _stamp_paragraph_mark(
+                paragraph, "w:ins", _next_id(ctx), ctx.author, ctx.stamp
+            )
 
 
 def _insert_rows(ctx: _Ctx, rows_o, index: int, new_rows, after=None) -> list:
@@ -1271,7 +1331,9 @@ def _iso(stamp: "dt.datetime") -> str:
 # ---------------------------------------------------------------------------
 
 
-def _replace_paragraph_text(ctx: _Ctx, paragraph: "_Element", text_o: str, text_r: str) -> None:
+def _replace_paragraph_text(
+    ctx: _Ctx, paragraph: "_Element", text_o: str, text_r: str
+) -> None:
     """Token-level tracked edits inside one matched paragraph; whole-block
     del+ins fallback when the span machinery refuses a region.
 
@@ -1286,7 +1348,9 @@ def _replace_paragraph_text(ctx: _Ctx, paragraph: "_Element", text_o: str, text_
             span = _paragraph_span(ctx, paragraph, start, end)
             if span is None:
                 raise UnsupportedStructureError("region unmappable to atoms")
-            span.replace(replacement, tracked=True, author=ctx.author, date=ctx.stamp)
+            span.replace(
+                replacement, tracked=True, author=ctx.author, date=ctx.stamp
+            )
     except PaperRefusal as exc:
         parent = paragraph.getparent()
         if parent is not None:
@@ -1339,7 +1403,9 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     with the exact conventions of `docx.search._spans_for_story`."""
     from docx.search import Span, _include_atom, _story_atoms
 
-    root = next((root for s, root in _story_elements(ctx.document) if s == ctx.story), None)
+    root = next(
+        (root for s, root in _story_elements(ctx.document) if s == ctx.story), None
+    )
     if root is None:
         return None
     atoms = [
@@ -1349,12 +1415,8 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     ]
     if not atoms or start >= end:
         return None
-    positions = []  # (atom_index, offset) per visible character
-    visible_pieces = []
+    positions = []  # (atom_index, offset) per character
     for index, atom in enumerate(atoms):
-        if atom.barrier:
-            continue
-        visible_pieces.append(atom.text)
         for offset in range(len(atom.text)):
             positions.append((index, offset))
     if end > len(positions):
@@ -1362,9 +1424,7 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
     start_atom, start_offset = positions[start]
     end_atom, end_offset = positions[end - 1]
     span_atoms = atoms[start_atom : end_atom + 1]
-    if any(atom.barrier for atom in span_atoms):
-        return None
-    text = "".join(visible_pieces)[start:end]
+    text = "".join(a.text for a in atoms)[start:end]
     return Span(
         text=text,
         story=ctx.story,

--- a/src/docx/_contenttypes.py
+++ b/src/docx/_contenttypes.py
@@ -1,0 +1,10 @@
+"""Small content-type helpers used by OPC validation."""
+
+
+def media_type(content_type: str) -> str:
+    """Return a normalized MIME type without parameters."""
+    return content_type.partition(";")[0].strip().casefold()
+
+
+def content_type_matches(actual: str, expected: str) -> bool:
+    return media_type(actual) == media_type(expected)

--- a/src/docx/_fieldcode.py
+++ b/src/docx/_fieldcode.py
@@ -1,0 +1,179 @@
+"""Minimal, position-preserving parser for bookmark-bearing Word field codes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional, Tuple
+
+from docx.errors import UnsupportedStructureError
+
+_FIELD_COMMANDS = frozenset(
+    """
+    ADDRESSBLOCK ADVANCE ASK AUTHOR AUTONUM AUTONUMLGL AUTONUMOUT AUTOTEXT
+    AUTOTEXTLIST BARCODE BIBLIOGRAPHY BIDIOUTLINE CITATION COMMENTS COMPARE
+    CREATEDATE DATABASE DATE DISPLAYBARCODE DOCVARIABLE DOCPROPERTY EDITTIME EMBED EQ
+    FILENAME FILESIZE FILLIN FORMCHECKBOX FORMDROPDOWN FORMTEXT GLOSSARY
+    GOTOBUTTON GREETINGLINE HYPERLINK IF INCLUDEPICTURE INCLUDETEXT INDEX INFO
+    KEYWORDS LASTSAVEDBY LINK LISTNUM MACROBUTTON MERGEBARCODE MERGEFIELD
+    MERGEREC MERGESEQ NEXT NEXTIF NOTEREF NUMCHARS NUMPAGES NUMWORDS PAGE
+    PAGEREF PRINT PRINTDATE PRIVATE QUOTE RD REF REVNUM SAVEDATE SECTION
+    SECTIONPAGES SEQ SET SKIPIF STYLEREF SUBJECT SYMBOL TA TC TEMPLATE TIME
+    TITLE TOA TOC USERADDRESS USERINITIALS USERNAME XE
+    """.split()  # noqa: SIM905 - compact explicit vocabulary
+)
+
+
+@dataclass(frozen=True)
+class FieldOperand:
+    value: str
+    start: int
+    end: int
+    quoted: bool
+
+    def render(self, value: str) -> str:
+        quoted = self.quoted or any(character.isspace() for character in value)
+        if not quoted:
+            return value
+        escaped = value.replace('"', '\\"')
+        return f'"{escaped}"'
+
+
+def _tokens(instruction: str) -> "Tuple[FieldOperand, ...]":
+    tokens: list[FieldOperand] = []
+    index = 0
+    while index < len(instruction):
+        while index < len(instruction) and instruction[index].isspace():
+            index += 1
+        if index >= len(instruction):
+            break
+        start = index
+        if instruction[index] != '"':
+            while index < len(instruction) and not instruction[index].isspace():
+                index += 1
+            tokens.append(FieldOperand(instruction[start:index], start, index, False))
+            continue
+        index += 1
+        value: list[str] = []
+        while index < len(instruction):
+            char = instruction[index]
+            if char == '"':
+                index += 1
+                tokens.append(FieldOperand("".join(value), start, index, True))
+                break
+            if char == "\\" and index + 1 < len(instruction) and instruction[index + 1] == '"':
+                value.append('"')
+                index += 2
+                continue
+            value.append(char)
+            index += 1
+        else:
+            raise UnsupportedStructureError(
+                "field instruction contains an unterminated quoted operand; nothing was changed"
+            )
+    return tuple(tokens)
+
+
+def command_operand(instruction: str, command: str) -> "Optional[FieldOperand]":
+    tokens = _tokens(instruction)
+    if (
+        not tokens
+        or tokens[0].quoted
+        or tokens[0].value.upper() != command.upper()
+        or len(tokens) < 2
+    ):
+        return None
+    operand = tokens[1]
+    return None if not operand.quoted and operand.value.startswith("\\") else operand
+
+
+def bookmark_operands(
+    instruction: str, *, implicit_names: "Iterable[str]" = ()
+) -> "Tuple[FieldOperand, ...]":
+    tokens = _tokens(instruction)
+    command = "" if not tokens or tokens[0].quoted else tokens[0].value.upper()
+    if instruction.lstrip().startswith("="):
+        return _formula_bookmark_operands(instruction, implicit_names)
+    if command in ("REF", "PAGEREF", "NOTEREF", "GOTOBUTTON"):
+        operand = command_operand(instruction, command)
+        return (operand,) if operand is not None else ()
+    switch = "\\l" if command == "HYPERLINK" else "\\b" if command == "TOC" else None
+    if switch:
+        return tuple(
+            tokens[index + 1]
+            for index, token in enumerate(tokens[:-1])
+            if not token.quoted
+            and token.value.casefold() == switch
+            and (tokens[index + 1].quoted or not tokens[index + 1].value.startswith("\\"))
+        )
+    implicit = {name.casefold() for name in implicit_names}
+    if (
+        tokens
+        and not tokens[0].quoted
+        and command not in _FIELD_COMMANDS
+        and tokens[0].value.casefold() in implicit
+    ):
+        return (tokens[0],)
+    return ()
+
+
+def _formula_bookmark_operands(
+    instruction: str, names: "Iterable[str]"
+) -> "Tuple[FieldOperand, ...]":
+    """Known bookmark identifiers in a Word formula, excluding functions/literals."""
+    wanted = {name.casefold() for name in names}
+    operands: list[FieldOperand] = []
+    index = 0
+    quoted = False
+    while index < len(instruction):
+        character = instruction[index]
+        if character == '"':
+            quoted = not quoted
+            index += 1
+            continue
+        if quoted or not (character.isalpha() or character == "_"):
+            index += 1
+            continue
+        start = index
+        index += 1
+        while index < len(instruction) and (
+            instruction[index].isalnum() or instruction[index] == "_"
+        ):
+            index += 1
+        value = instruction[start:index]
+        following = index
+        while following < len(instruction) and instruction[following].isspace():
+            following += 1
+        if (
+            value.casefold() in wanted
+            and (following >= len(instruction) or instruction[following] != "(")
+        ):
+            operands.append(FieldOperand(value, start, index, False))
+    return tuple(operands)
+
+
+def rewrite_bookmark_operands(instruction: str, renames: "Mapping[str, str]") -> str:
+    lookup = {old.casefold(): new for old, new in renames.items()}
+    replacements = [
+        (operand, lookup[operand.value.casefold()])
+        for operand in bookmark_operands(instruction, implicit_names=renames)
+        if operand.value.casefold() in lookup
+    ]
+    return _rewrite(instruction, replacements)
+
+
+def rewrite_command_operand(instruction: str, command: str, renames: "Mapping[str, str]") -> str:
+    operand = command_operand(instruction, command)
+    lookup = {old.casefold(): new for old, new in renames.items()}
+    if operand is None or operand.value.casefold() not in lookup:
+        return instruction
+    return _rewrite(instruction, [(operand, lookup[operand.value.casefold()])])
+
+
+def _rewrite(
+    instruction: str, replacements: "Iterable[tuple[FieldOperand, str]]"
+) -> str:
+    for operand, replacement in sorted(replacements, key=lambda item: item[0].start, reverse=True):
+        instruction = (
+            instruction[: operand.start] + operand.render(replacement) + instruction[operand.end :]
+        )
+    return instruction

--- a/src/docx/_ownership.py
+++ b/src/docx/_ownership.py
@@ -1,0 +1,68 @@
+"""Ownership checks for live document proxies used by paper-docx verbs.
+
+Value anchors are re-resolved against the document passed to an operation.
+Live proxies such as ``Span`` and ``Comment`` are different: they retain XML
+elements from the package that created them, so accepting one from another
+document can mutate that other package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from docx.errors import BoundaryViolationError, TargetNotFoundError
+
+if TYPE_CHECKING:
+    from docx.comments import Comment
+    from docx.document import Document
+    from docx.search import Span
+
+
+def require_span_owner(
+    document: "Document", span: "Span", *, argument: str = "span"
+) -> None:
+    """Refuse a live span captured from a different document package."""
+    owner = getattr(span, "_document", None)
+    owner_part = getattr(owner, "part", None)
+    if owner_part is not document.part:
+        raise BoundaryViolationError(
+            f"{argument} belongs to a different document; re-find the text"
+            " in the document passed to this operation"
+        )
+
+
+def require_anchor_owner(
+    document: "Document", anchor: object, *, argument: str = "anchor"
+) -> None:
+    """Check ownership for live anchor forms; value/string anchors are inert."""
+    if getattr(anchor, "_document", None) is not None:
+        require_span_owner(document, cast("Span", anchor), argument=argument)
+
+
+def require_comment_owner(
+    document: "Document", comment: "Comment", *, argument: str = "comment"
+) -> None:
+    """Refuse a comment proxy from another part and detect detached proxies."""
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    try:
+        comment_part = comment.part
+    except (AttributeError, ValueError):
+        comment_part = None
+    try:
+        expected_part = document.part.part_related_by(RT.COMMENTS)
+    except KeyError:
+        expected_part = None
+
+    if comment_part is not expected_part or expected_part is None:
+        raise BoundaryViolationError(
+            f"{argument} belongs to a different document; select the comment"
+            " from the document passed to this operation"
+        )
+
+    element = getattr(comment, "_comment_elm", None)
+    expected_element = getattr(expected_part, "_element", None)
+    if element is None or element.getparent() is not expected_element:
+        raise TargetNotFoundError(
+            f"{argument} is stale: its comment was removed from the document"
+        )

--- a/src/docx/_ownership.py
+++ b/src/docx/_ownership.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from docx.errors import BoundaryViolationError, TargetNotFoundError
+from docx.errors import (
+    BoundaryViolationError,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
 
 if TYPE_CHECKING:
     from docx.comments import Comment
@@ -53,6 +57,11 @@ def require_comment_owner(
         expected_part = document.part.part_related_by(RT.COMMENTS)
     except KeyError:
         expected_part = None
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple comments relationships make comment ownership"
+            " ambiguous; nothing was changed"
+        ) from None
 
     if comment_part is not expected_part or expected_part is None:
         raise BoundaryViolationError(

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -567,7 +567,7 @@ def patch_save(
         output_bytes = original_bytes
     else:
         output_bytes = _deterministic_zip_bytes(candidate_parts, candidate_order)
-    enforce_compressed_size(io.BytesIO(output_bytes))
+    _read_zip(output_bytes)
     _write_bytes_atomically(output_file, output_bytes, output_mode)
     return PatchSaveResult(
         restored_parts=tuple(restored),

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 import io
 import os
+import stat
 import tempfile
 import zipfile
 from dataclasses import dataclass
@@ -34,6 +35,14 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Dict, List, Tuple, Union
 
 from lxml import etree
+
+from docx._zipguard import (
+    GuardedZipReader,
+    enforce_compressed_size,
+    preflight_zip,
+    read_compressed_bytes,
+)
+from docx.errors import PackageLimitError
 
 if TYPE_CHECKING:
     from docx.document import Document
@@ -97,9 +106,10 @@ def _elements_equal(a: etree._Element, b: etree._Element) -> bool:
     if a.tag != b.tag:
         return False
     # processing instructions share one tag object; the target is identity
-    if not isinstance(a.tag, str):
-        if getattr(a, "target", None) != getattr(b, "target", None):
-            return False
+    if not isinstance(a.tag, str) and getattr(a, "target", None) != getattr(
+        b, "target", None
+    ):
+        return False
     if dict(a.attrib) != dict(b.attrib):
         return False
     if (a.text or "") != (b.text or ""):
@@ -205,15 +215,15 @@ def _parts_semantically_equal(
         return False
 
 
-def _read_zip(data: bytes) -> Tuple[Dict[str, bytes], List[str]]:
-    """(member-name -> bytes, member order). Duplicate names collapse per
-    `zipfile` resolution (last entry wins) and appear once in the order."""
-    with zipfile.ZipFile(io.BytesIO(data)) as zf:
-        order: List[str] = []
-        for name in zf.namelist():
-            if name not in order:
-                order.append(name)
-        return {name: zf.read(name) for name in order}, order
+def _read_zip(
+    source: Union[_PathLike, IO[bytes], bytes]
+) -> Tuple[Dict[str, bytes], List[str]]:
+    """Return validated member bytes and central-directory order."""
+    source = io.BytesIO(source) if isinstance(source, bytes) else source
+    enforce_compressed_size(source)
+    preflight_zip(source)
+    with zipfile.ZipFile(source) as zf:
+        return GuardedZipReader(zf).read_all()
 
 
 def _sha256(data: bytes) -> str:
@@ -276,8 +286,8 @@ def diff_package(path_a: _PathLike, path_b: _PathLike) -> PackageDiff:
     bytes. A byte-changed XML part that fails to parse counts as semantically
     changed — never silently equal.
     """
-    a_parts, a_order = _read_zip(Path(path_a).read_bytes())
-    b_parts, b_order = _read_zip(Path(path_b).read_bytes())
+    a_parts, a_order = _read_zip(Path(path_a))
+    b_parts, b_order = _read_zip(Path(path_b))
 
     added = tuple(sorted(set(b_parts) - set(a_parts)))
     removed = tuple(sorted(set(a_parts) - set(b_parts)))
@@ -345,7 +355,7 @@ def _deterministic_zip_bytes(parts: Dict[str, bytes], order: List[str]) -> bytes
     return buf.getvalue()
 
 
-def _write_bytes_atomically(out_path: Path, data: bytes) -> None:
+def _write_bytes_atomically(out_path: Path, data: bytes, mode: int) -> None:
     """Write via a same-directory temp file + `os.replace`.
 
     A failure anywhere before the final rename leaves any existing file at
@@ -359,6 +369,7 @@ def _write_bytes_atomically(out_path: Path, data: bytes) -> None:
     try:
         with os.fdopen(fd, "wb") as stream:
             stream.write(data)
+        os.chmod(temp_path, mode)
         os.replace(temp_path, out_path)
     finally:
         if temp_path.exists():
@@ -418,7 +429,8 @@ def diagnose(path: _PathLike) -> PackageDiagnosis:
 
     if not file_path.is_file():
         return result(False, "missing", "file does not exist")
-    header = file_path.read_bytes()[:8]
+    with file_path.open("rb") as stream:
+        header = stream.read(8)
     if header.startswith(_CFB_MAGIC):
         return result(
             False,
@@ -429,7 +441,9 @@ def diagnose(path: _PathLike) -> PackageDiagnosis:
     if not header.startswith(b"PK"):
         return result(False, "not-a-zip", "not a ZIP archive, so not an OPC package")
     try:
-        parts, _ = _read_zip(file_path.read_bytes())
+        parts, _ = _read_zip(file_path)
+    except PackageLimitError as exc:
+        return result(False, "unsafe-archive", str(exc))
     except zipfile.BadZipFile as exc:
         return result(False, "corrupt-zip", f"ZIP structure is damaged: {exc}")
 
@@ -487,7 +501,7 @@ def diagnose(path: _PathLike) -> PackageDiagnosis:
 
 
 def patch_save(
-    original_path: _PathLike, document: "Document | IO[bytes]", out_path: _PathLike
+    original_path: _PathLike, document: "Document", out_path: _PathLike
 ) -> PatchSaveResult:
     """Save `document` to `out_path`, restoring original bytes wherever possible.
 
@@ -500,16 +514,25 @@ def patch_save(
 
     `original_path == out_path` is permitted; the original bytes are read up
     front and the write is atomic (temp file + rename), so the original
-    survives any mid-write failure.
+    survives any mid-write failure. An existing destination keeps its current
+    permission bits; a newly created destination inherits `original_path`'s
+    permission bits.
     """
-    original_bytes = Path(original_path).read_bytes()
+    original_file = Path(original_path)
+    output_file = Path(out_path)
+    try:
+        output_mode = stat.S_IMODE(output_file.stat().st_mode)
+    except FileNotFoundError:
+        output_mode = stat.S_IMODE(original_file.stat().st_mode)
+
+    original_bytes = read_compressed_bytes(original_file)
+    original_parts, _ = _read_zip(io.BytesIO(original_bytes))
 
     buf = io.BytesIO()
-    document.save(buf)  # type: ignore[union-attr]
+    document.save(buf)
     candidate_bytes = buf.getvalue()
 
-    original_parts, _ = _read_zip(original_bytes)
-    candidate_parts, candidate_order = _read_zip(candidate_bytes)
+    candidate_parts, candidate_order = _read_zip(io.BytesIO(candidate_bytes))
     original_names = list(original_parts)
     candidate_names = list(candidate_parts)
 
@@ -538,11 +561,11 @@ def patch_save(
         and all(candidate_parts[name] == original_parts[name] for name in candidate_parts)
     )
     if is_noop:
-        _write_bytes_atomically(Path(out_path), original_bytes)
+        output_bytes = original_bytes
     else:
-        _write_bytes_atomically(
-            Path(out_path), _deterministic_zip_bytes(candidate_parts, candidate_order)
-        )
+        output_bytes = _deterministic_zip_bytes(candidate_parts, candidate_order)
+    enforce_compressed_size(io.BytesIO(output_bytes))
+    _write_bytes_atomically(output_file, output_bytes, output_mode)
     return PatchSaveResult(
         restored_parts=tuple(restored),
         changed_parts=tuple(changed),

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -219,6 +219,9 @@ def _read_zip(
     source: Union[_PathLike, IO[bytes], bytes]
 ) -> Tuple[Dict[str, bytes], List[str]]:
     """Return validated member bytes and central-directory order."""
+    if isinstance(source, (str, os.PathLike)):
+        with open(source, "rb") as stream:
+            return _read_zip(stream)
     source = io.BytesIO(source) if isinstance(source, bytes) else source
     enforce_compressed_size(source)
     preflight_zip(source)

--- a/src/docx/_rels.py
+++ b/src/docx/_rels.py
@@ -1,0 +1,34 @@
+"""Small relationship helpers used by OPC validation."""
+
+from lxml import etree
+
+TRANSITIONAL_OFFICE_RELATIONSHIPS = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/"
+)
+STRICT_OFFICE_RELATIONSHIPS = "http://purl.oclc.org/ooxml/officeDocument/relationships/"
+
+
+def relationship_type_variants(reltype: str) -> tuple[str, ...]:
+    """Return transitional and strict spellings for an Office relationship."""
+    if reltype.startswith(TRANSITIONAL_OFFICE_RELATIONSHIPS):
+        suffix = reltype[len(TRANSITIONAL_OFFICE_RELATIONSHIPS) :]
+        return reltype, STRICT_OFFICE_RELATIONSHIPS + suffix
+    if reltype.startswith(STRICT_OFFICE_RELATIONSHIPS):
+        suffix = reltype[len(STRICT_OFFICE_RELATIONSHIPS) :]
+        return TRANSITIONAL_OFFICE_RELATIONSHIPS + suffix, reltype
+    return (reltype,)
+
+
+def is_relationship_type(actual: str, expected: str) -> bool:
+    return actual in relationship_type_variants(expected)
+
+
+def is_xml_id(value: object) -> bool:
+    """Whether ``value`` has the XML Schema ID/NCName lexical form."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        name = etree.QName(value)
+    except ValueError:
+        return False
+    return name.namespace is None and name.localname == value

--- a/src/docx/_textatoms.py
+++ b/src/docx/_textatoms.py
@@ -1,0 +1,81 @@
+"""Shared projection rules for text-bearing WordprocessingML run children.
+
+The inspection and editing surfaces must agree on which run children produce
+plain text. Unknown run content is not silently transparent: it contributes a
+private object-replacement barrier to search so a match cannot jump across a
+visible symbol, reference, drawing, or extension that we do not model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from docx.oxml.ns import qn
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+
+BARRIER_TEXT = "\ufffc"
+
+T = qn("w:t")
+DEL_TEXT = qn("w:delText")
+INSTR_TEXT = qn("w:instrText")
+TEXT_TAGS = (T, DEL_TEXT, INSTR_TEXT)
+
+R = qn("w:r")
+RPR = qn("w:rPr")
+TAB = qn("w:tab")
+PTAB = qn("w:ptab")
+BR = qn("w:br")
+CR = qn("w:cr")
+NO_BREAK_HYPHEN = qn("w:noBreakHyphen")
+FLD_CHAR = qn("w:fldChar")
+LAST_RENDERED_PAGE_BREAK = qn("w:lastRenderedPageBreak")
+
+_W_TYPE = qn("w:type")
+_TRANSPARENT_RUN_CHILDREN = frozenset((RPR, FLD_CHAR, LAST_RENDERED_PAGE_BREAK))
+
+
+@dataclass(frozen=True)
+class RunChildProjection:
+    """Plain-text contribution of one direct ``w:r`` child.
+
+    ``barrier`` means the child is visible but has no safe plain-text model.
+    Search uses :data:`BARRIER_TEXT` to split otherwise adjacent text; outline
+    traversal omits the sentinel while still refusing to recurse into content
+    it cannot honestly interpret.
+    """
+
+    text: str
+    barrier: bool = False
+
+
+def project_run_child(element: "_Element") -> RunChildProjection:
+    """Return the conservative text projection for a direct ``w:r`` child."""
+    tag = element.tag
+    if tag in TEXT_TAGS:
+        return RunChildProjection(element.text or "")
+    if tag in (TAB, PTAB):
+        return RunChildProjection("\t")
+    if tag == CR:
+        return RunChildProjection("\n")
+    if tag == BR:
+        # Only a text-wrapping break has a newline text equivalent. A page or
+        # column break remains a visible boundary but contributes no character.
+        if (element.get(_W_TYPE) or "textWrapping") == "textWrapping":
+            return RunChildProjection("\n")
+        return RunChildProjection(BARRIER_TEXT, barrier=True)
+    if tag == NO_BREAK_HYPHEN:
+        # Match python-docx's public Run.text representation.
+        return RunChildProjection("-")
+    if tag in _TRANSPARENT_RUN_CHILDREN:
+        return RunChildProjection("")
+    return RunChildProjection(BARRIER_TEXT, barrier=True)
+
+
+def is_direct_run_child(element: "_Element") -> bool:
+    """Whether ``element`` is a direct child of a ``w:r`` element."""
+    parent = element.getparent()
+    return parent is not None and parent.tag == R

--- a/src/docx/_transaction.py
+++ b/src/docx/_transaction.py
@@ -1,0 +1,334 @@
+# pyright: reportPrivateUsage=false
+
+"""In-place rollback for compound paper-docx mutations."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    cast,
+)
+
+from lxml import etree
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+    from docx.document import Document
+    from docx.opc.package import OpcPackage
+    from docx.opc.part import Part
+    from docx.opc.rel import Relationships, _Relationship
+    from docx.package import ImageParts
+
+
+_RAW_TAG = etree._Element.tag
+_RAW_TEXT = etree._Element.text
+_RAW_TAIL = etree._Element.tail
+
+
+@dataclass(frozen=True)
+class _ElementState:
+    element: "_Element"
+    tag: Any
+    attributes: "Tuple[Tuple[str, str], ...]"
+    text: Optional[str]
+    tail: Optional[str]
+    children: "Tuple[_Element, ...]"
+    proxy_attributes: "Optional[Dict[str, Any]]"
+
+
+@dataclass(frozen=True)
+class _TreeState:
+    elements: "Tuple[_ElementState, ...]"
+
+    @classmethod
+    def capture(cls, root: "_Element") -> "_TreeState":
+        return cls(
+            tuple(
+                _ElementState(
+                    element=element,
+                    tag=_RAW_TAG.__get__(element),
+                    attributes=tuple(element.attrib.items()),
+                    text=_RAW_TEXT.__get__(element),
+                    tail=_RAW_TAIL.__get__(element),
+                    children=tuple(element),
+                    proxy_attributes=(
+                        dict(element.__dict__) if hasattr(element, "__dict__") else None
+                    ),
+                )
+                for element in root.iter()
+            )
+        )
+
+    def restore(self) -> None:
+        # Preserve every unchanged edge. Detaching and re-appending an unchanged
+        # node can make lxml reconcile namespace prefixes and invalidate QName
+        # values held in ordinary string attributes.
+        for state in self.elements:
+            self._restore_children(state)
+
+        for state in self.elements:
+            element = state.element
+            if _RAW_TAG.__get__(element) != state.tag:
+                _RAW_TAG.__set__(element, state.tag)
+            if tuple(element.attrib.items()) != state.attributes:
+                element.attrib.clear()
+                for name, value in state.attributes:
+                    element.set(name, value)
+            if _RAW_TEXT.__get__(element) != state.text:
+                _RAW_TEXT.__set__(element, state.text)
+            if _RAW_TAIL.__get__(element) != state.tail:
+                _RAW_TAIL.__set__(element, state.tail)
+            if state.proxy_attributes is not None:
+                element.__dict__.clear()
+                element.__dict__.update(state.proxy_attributes)
+
+    @staticmethod
+    def _restore_children(state: _ElementState) -> None:
+        element = state.element
+        desired = state.children
+        if _same_nodes(tuple(element), desired):
+            return
+        desired_ids = {id(child) for child in desired}
+        for child in tuple(element):
+            if id(child) not in desired_ids:
+                element.remove(child)
+        for index, child in enumerate(desired):
+            if child.getparent() is element and element.index(child) == index:
+                continue
+            element.insert(index, child)
+        for child in tuple(element):
+            if id(child) not in desired_ids:
+                element.remove(child)
+        if not _same_nodes(tuple(element), desired):
+            raise RuntimeError("package rollback could not restore XML topology")
+
+
+def _same_nodes(left: "Tuple[_Element, ...]", right: "Tuple[_Element, ...]") -> bool:
+    return len(left) == len(right) and all(a is b for a, b in zip(left, right))
+
+
+@dataclass(frozen=True)
+class _ObjectState:
+    instance: Any
+    attributes: "Dict[str, Any]"
+
+    @classmethod
+    def capture(cls, instance: Any) -> "_ObjectState":
+        return cls(instance, dict(instance.__dict__))
+
+    def restore(self) -> None:
+        self.instance.__dict__.clear()
+        self.instance.__dict__.update(self.attributes)
+
+
+@dataclass(frozen=True)
+class _RelationshipsState:
+    relationships: "Relationships"
+    items: "Tuple[Tuple[str, _Relationship], ...]"
+    target_parts: "Dict[str, Any]"
+    target_items: "Tuple[Tuple[str, Any], ...]"
+    relationship_objects: "Tuple[_ObjectState, ...]"
+
+    @classmethod
+    def capture(cls, relationships: "Relationships") -> "_RelationshipsState":
+        target_parts = relationships._target_parts_by_rId  # noqa: SLF001
+        return cls(
+            relationships,
+            tuple(relationships.items()),
+            target_parts,
+            tuple(target_parts.items()),
+            tuple(_ObjectState.capture(relationship) for relationship in relationships.values()),
+        )
+
+    def restore(self) -> None:
+        for state in self.relationship_objects:
+            state.restore()
+        relationships = cast("Dict[str, _Relationship]", self.relationships)
+        relationships.clear()
+        relationships.update(self.items)
+        self.target_parts.clear()
+        self.target_parts.update(self.target_items)
+        self.relationships._target_parts_by_rId = self.target_parts  # noqa: SLF001
+
+    def is_restored(self) -> bool:
+        return (
+            _same_items(tuple(self.relationships.items()), self.items)
+            and _same_items(tuple(self.target_parts.items()), self.target_items)
+            and all(
+                state.instance.__dict__ == state.attributes for state in self.relationship_objects
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _ListState:
+    values: "List[Any]"
+    items: "Tuple[Any, ...]"
+
+    def restore(self) -> None:
+        self.values[:] = self.items
+
+    def is_restored(self) -> bool:
+        return _same_objects(tuple(self.values), self.items)
+
+
+@dataclass(frozen=True)
+class _PartBlobState:
+    part: "Part"
+    blob: bytes
+
+    def is_restored(self) -> bool:
+        return self.part.blob == self.blob
+
+
+@dataclass(frozen=True)
+class _PackageState:
+    objects: "Tuple[_ObjectState, ...]"
+    relationships: "Tuple[_RelationshipsState, ...]"
+    trees: "Tuple[_TreeState, ...]"
+    image_parts: "Optional[_ListState]"
+    part_blobs: "Tuple[_PartBlobState, ...]"
+
+    @classmethod
+    def capture(cls, document: "Document") -> "_PackageState":
+        package = document.part.package
+        assert package is not None
+        owners, parts = _reachable_package_objects(package)
+        image_parts = cast("Optional[ImageParts]", package.__dict__.get("image_parts"))
+        return cls(
+            objects=tuple(_ObjectState.capture(owner) for owner in owners),
+            relationships=tuple(
+                _RelationshipsState.capture(relationships)
+                for owner in owners
+                if (relationships := cast("Optional[Relationships]", owner.__dict__.get("rels")))
+                is not None
+            ),
+            trees=tuple(
+                _TreeState.capture(root)
+                for part in parts
+                if (root := cast("Optional[_Element]", getattr(part, "_element", None))) is not None
+            ),
+            image_parts=(
+                None
+                if image_parts is None
+                else _ListState(
+                    image_parts._image_parts,  # noqa: SLF001
+                    tuple(image_parts._image_parts),  # noqa: SLF001
+                )
+            ),
+            part_blobs=tuple(_PartBlobState(part, part.blob) for part in parts),
+        )
+
+    def restore(self) -> None:
+        package = cast("OpcPackage", self.objects[0].instance)
+        current_parts = _reachable_package_objects(package)[1]
+        original_part_ids = {id(state.part) for state in self.part_blobs}
+        # Restore owner attributes before the mutable collaborators they name.
+        # This also removes lazy properties created only by the failed edit.
+        for state in self.objects:
+            state.restore()
+        for state in self.relationships:
+            state.restore()
+        if self.image_parts is not None:
+            self.image_parts.restore()
+        for state in self.trees:
+            state.restore()
+        for part in current_parts:
+            if id(part) not in original_part_ids and getattr(part, "_package", None) is package:
+                part._package = None  # noqa: SLF001 - detach failed-transaction parts
+        failures = [
+            str(state.part.partname) for state in self.part_blobs if not state.is_restored()
+        ]
+        if any(not state.is_restored() for state in self.relationships):
+            failures.append("<relationships>")
+        if self.image_parts is not None and not self.image_parts.is_restored():
+            failures.append("<image-parts>")
+        if failures:
+            raise RuntimeError(
+                "package rollback could not restore serialized state: "
+                + ", ".join(sorted(failures))
+            )
+
+
+def _same_objects(left: "Tuple[Any, ...]", right: "Tuple[Any, ...]") -> bool:
+    return len(left) == len(right) and all(a is b for a, b in zip(left, right))
+
+
+def _same_items(
+    left: "Tuple[Tuple[Any, Any], ...]",
+    right: "Tuple[Tuple[Any, Any], ...]",
+) -> bool:
+    return len(left) == len(right) and all(
+        left_key == right_key and left_value is right_value
+        for (left_key, left_value), (right_key, right_value) in zip(left, right)
+    )
+
+
+def _reachable_package_objects(
+    package: "OpcPackage",
+) -> "Tuple[Tuple[OpcPackage | Part, ...], Tuple[Part, ...]]":
+    """Return every package-owned part without materializing lazy state."""
+    owners: "List[OpcPackage | Part]" = [package]
+    parts: "List[Part]" = []
+    seen: "set[int]" = set()
+
+    def add(part: "Part") -> None:
+        if id(part) in seen:
+            return
+        seen.add(id(part))
+        parts.append(part)
+        owners.append(part)
+
+    for owner in owners:
+        relationships = cast("Optional[Relationships]", owner.__dict__.get("rels"))
+        if relationships is not None:
+            for relationship in relationships.values():
+                if not relationship.is_external:
+                    add(relationship.target_part)
+            for part in relationships._target_parts_by_rId.values():  # noqa: SLF001
+                add(cast("Part", part))
+        if owner is package:
+            image_parts = cast("Optional[ImageParts]", package.__dict__.get("image_parts"))
+            if image_parts is not None:
+                for part in image_parts._image_parts:  # noqa: SLF001
+                    add(part)
+    return tuple(owners), tuple(parts)
+
+
+@contextmanager
+def rollback_on_error(document: "Document", *participants: Any) -> Generator[None, None, None]:
+    """Restore the live package and named mutable proxies after an error."""
+    state = _PackageState.capture(document)
+    participant_states = tuple(_ObjectState.capture(participant) for participant in participants)
+    try:
+        yield
+    except BaseException:
+        try:
+            state.restore()
+        finally:
+            for participant_state in participant_states:
+                participant_state.restore()
+        raise
+
+
+@contextmanager
+def rollback_xml_on_error(root: "_Element") -> Generator[None, None, None]:
+    """Restore one live XML tree after an error in a local compound edit."""
+    state = _TreeState.capture(root)
+    before = etree.tostring(root)
+    try:
+        yield
+    except BaseException:
+        state.restore()
+        if etree.tostring(root) != before:
+            raise RuntimeError("XML rollback could not restore serialized state")
+        raise

--- a/src/docx/_transaction.py
+++ b/src/docx/_transaction.py
@@ -120,19 +120,59 @@ def _same_nodes(left: "Tuple[_Element, ...]", right: "Tuple[_Element, ...]") -> 
 class _ObjectState:
     instance: Any
     attributes: "Dict[str, Any]"
+    mutable_values: "Tuple[_MutableValueState, ...]"
 
     @classmethod
     def capture(cls, instance: Any) -> "_ObjectState":
-        return cls(instance, dict(instance.__dict__))
+        attributes = dict(instance.__dict__)
+        return cls(
+            instance,
+            attributes,
+            tuple(
+                state
+                for value in attributes.values()
+                if (state := _MutableValueState.capture(value)) is not None
+            ),
+        )
 
     def restore(self) -> None:
+        for state in self.mutable_values:
+            state.restore()
         self.instance.__dict__.clear()
         self.instance.__dict__.update(self.attributes)
 
 
 @dataclass(frozen=True)
+class _MutableValueState:
+    value: Any
+    kind: str
+    items: Any
+
+    @classmethod
+    def capture(cls, value: Any) -> "Optional[_MutableValueState]":
+        if isinstance(value, list):
+            return cls(value, "list", tuple(value))
+        if isinstance(value, dict):
+            return cls(value, "dict", tuple(value.items()))
+        if isinstance(value, set):
+            return cls(value, "set", frozenset(value))
+        return None
+
+    def restore(self) -> None:
+        if self.kind == "list":
+            self.value[:] = self.items
+        elif self.kind == "dict":
+            self.value.clear()
+            self.value.update(self.items)
+        else:
+            self.value.clear()
+            self.value.update(self.items)
+
+
+@dataclass(frozen=True)
 class _RelationshipsState:
     relationships: "Relationships"
+    base_uri: str
     items: "Tuple[Tuple[str, _Relationship], ...]"
     target_parts: "Dict[str, Any]"
     target_items: "Tuple[Tuple[str, Any], ...]"
@@ -143,6 +183,7 @@ class _RelationshipsState:
         target_parts = relationships._target_parts_by_rId  # noqa: SLF001
         return cls(
             relationships,
+            relationships._baseURI,  # noqa: SLF001
             tuple(relationships.items()),
             target_parts,
             tuple(target_parts.items()),
@@ -158,11 +199,13 @@ class _RelationshipsState:
         self.target_parts.clear()
         self.target_parts.update(self.target_items)
         self.relationships._target_parts_by_rId = self.target_parts  # noqa: SLF001
+        self.relationships._baseURI = self.base_uri  # noqa: SLF001
 
     def is_restored(self) -> bool:
         return (
             _same_items(tuple(self.relationships.items()), self.items)
             and _same_items(tuple(self.target_parts.items()), self.target_items)
+            and self.relationships._baseURI == self.base_uri  # noqa: SLF001
             and all(
                 state.instance.__dict__ == state.attributes for state in self.relationship_objects
             )
@@ -230,7 +273,9 @@ class _PackageState:
 
     def restore(self) -> None:
         package = cast("OpcPackage", self.objects[0].instance)
-        current_parts = _reachable_package_objects(package)[1]
+        current_parts = _current_package_parts(
+            package, tuple(state.instance for state in self.objects)
+        )
         original_part_ids = {id(state.part) for state in self.part_blobs}
         # Restore owner attributes before the mutable collaborators they name.
         # This also removes lazy properties created only by the failed edit.
@@ -302,6 +347,43 @@ def _reachable_package_objects(
                 for part in image_parts._image_parts:  # noqa: SLF001
                     add(part)
     return tuple(owners), tuple(parts)
+
+
+def _current_package_parts(package: "OpcPackage", seeds: "Tuple[Any, ...]") -> "Tuple[Part, ...]":
+    """Best-effort raw-reference scan tolerating a corrupted live graph."""
+    owners = list(seeds)
+    parts: "List[Part]" = []
+    seen = set()
+
+    def add(candidate: Any) -> None:
+        if id(candidate) in seen:
+            return
+        attributes = getattr(candidate, "__dict__", None)
+        if not isinstance(attributes, dict) or "_package" not in attributes:
+            return
+        seen.add(id(candidate))
+        parts.append(cast("Part", candidate))
+        owners.append(candidate)
+
+    for owner in owners:
+        attributes = getattr(owner, "__dict__", {})
+        relationships = attributes.get("rels")
+        if isinstance(relationships, dict):
+            for relationship in tuple(relationships.values()):
+                rel_attributes = getattr(relationship, "__dict__", {})
+                if not rel_attributes.get("_is_external", False):
+                    add(rel_attributes.get("_target"))
+            target_index = getattr(relationships, "_target_parts_by_rId", None)
+            if isinstance(target_index, dict):
+                for candidate in tuple(target_index.values()):
+                    add(candidate)
+        if owner is package:
+            image_parts = attributes.get("image_parts")
+            image_list = getattr(image_parts, "_image_parts", None)
+            if isinstance(image_list, list):
+                for candidate in tuple(image_list):
+                    add(candidate)
+    return tuple(parts)
 
 
 @contextmanager

--- a/src/docx/_version.py
+++ b/src/docx/_version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, distribution
 
-__paper_version__ = "0.1.1"
+__paper_version__ = "0.1.2"
 
 
 def assert_distribution_identity() -> None:

--- a/src/docx/_version.py
+++ b/src/docx/_version.py
@@ -1,0 +1,24 @@
+"""Fork identity and distribution-conflict guard."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, distribution
+
+__paper_version__ = "0.1.1"
+
+
+def assert_distribution_identity() -> None:
+    """Fail when both distributions claim the frozen ``docx`` import."""
+    try:
+        distribution("python-docx")
+    except PackageNotFoundError:
+        return
+    try:
+        distribution("paper-docx")
+    except PackageNotFoundError:
+        return
+    raise ImportError(
+        "paper-docx and python-docx are both installed, but both own the"
+        " same 'docx' import package. Uninstall both distributions, then"
+        " install paper-docx in a clean environment"
+    )

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -536,7 +536,7 @@ class GuardedZipReader:
                 )
 
     def _read_all_members(self) -> Dict[str, bytes]:
-        if not self._infos:
+        if not self._infos and not self._directory_infos:
             return {}
         stream = self._zip_file.fp
         if stream is None:

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -1,0 +1,920 @@
+"""Bounded, unambiguous ZIP reads for OPC packages.
+
+These limits are a safety envelope, not OOXML validity rules. They are
+deliberately generous for ordinary Word documents while keeping one package
+from consuming unbounded CPU, memory, or disk-backed input:
+
+* 256 MiB compressed package size;
+* 4,096 members;
+* 64 MiB for one XML member and 256 MiB for one binary member;
+* 512 MiB expanded across the package; and
+* a 100:1 expanded-to-compressed ratio for each non-empty member.
+
+Only the two compression methods permitted by the OPC ZIP mapping (stored and
+deflated) are accepted. Every member is inflated from its raw compressed bytes
+rather than through ``ZipFile.read()``. This allows actual output length and
+deflate end-of-stream to be checked even when central-directory sizes lie.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import struct
+import unicodedata
+import zlib
+from contextlib import suppress
+from typing import BinaryIO, Dict, List, Optional, Tuple, Union, cast
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
+
+from lxml import etree
+
+from docx.errors import PackageLimitError
+
+_MIB = 1024 * 1024
+
+#: Maximum physical size of a ZIP package before any member is expanded.
+MAX_COMPRESSED_BYTES = 256 * _MIB
+#: Maximum number of central-directory records in one package.
+MAX_MEMBER_COUNT = 4_096
+#: Maximum bytes occupied by central-directory records.
+MAX_CENTRAL_DIRECTORY_BYTES = 16 * _MIB
+#: Maximum expanded size of one XML or relationships part.
+MAX_XML_MEMBER_BYTES = 64 * _MIB
+#: Maximum expanded size of one non-XML part, such as an image or embedding.
+MAX_BINARY_MEMBER_BYTES = 256 * _MIB
+#: Maximum expanded bytes across all members in one package.
+MAX_TOTAL_EXPANDED_BYTES = 512 * _MIB
+#: Maximum expanded-to-compressed ratio for each non-empty member.
+MAX_COMPRESSION_RATIO = 100
+
+_READ_CHUNK_BYTES = 64 * 1024
+_LOCAL_HEADER = struct.Struct("<4s5H3L2H")
+_LOCAL_HEADER_SIGNATURE = b"PK\x03\x04"
+_CENTRAL_HEADER = struct.Struct("<4s6H3L5H2L")
+_CENTRAL_HEADER_SIGNATURE = b"PK\x01\x02"
+_END_RECORD = struct.Struct("<4s4H2LH")
+_END_RECORD_SIGNATURE = b"PK\x05\x06"
+_ZIP64_END_RECORD = struct.Struct("<4sQ2H2L4Q")
+_ZIP64_END_RECORD_SIGNATURE = b"PK\x06\x06"
+_ZIP64_LOCATOR = struct.Struct("<4sLQL")
+_ZIP64_LOCATOR_SIGNATURE = b"PK\x06\x07"
+_MAX_END_COMMENT_BYTES = 65_535
+
+_CONTENT_TYPES_NAME = "[Content_Types].xml"
+_CONTENT_TYPES_NAMESPACE = (
+    "http://schemas.openxmlformats.org/package/2006/content-types"
+)
+_CONTENT_TYPES_TAG = f"{{{_CONTENT_TYPES_NAMESPACE}}}Types"
+_DEFAULT_TAG = f"{{{_CONTENT_TYPES_NAMESPACE}}}Default"
+_OVERRIDE_TAG = f"{{{_CONTENT_TYPES_NAMESPACE}}}Override"
+_CONTENT_TYPES_PARSER = etree.XMLParser(
+    load_dtd=False,
+    no_network=True,
+    remove_blank_text=False,
+    resolve_entities=False,
+)
+
+_FLAG_ENCRYPTED = 0x0001
+_FLAG_DATA_DESCRIPTOR = 0x0008
+_FLAG_PATCHED_DATA = 0x0020
+_FLAG_STRONG_ENCRYPTION = 0x0040
+_FLAG_UTF8_NAME = 0x0800
+
+_SUPPORTED_COMPRESSION = (ZIP_STORED, ZIP_DEFLATED)
+_HEX_DIGITS = frozenset("0123456789ABCDEF")
+_URI_UNRESERVED = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+
+def compressed_size(source: object) -> Optional[int]:
+    """Return physical byte size for a path or seekable stream, if available."""
+    if isinstance(source, (str, os.PathLike)):
+        path = cast(Union[str, "os.PathLike[str]"], source)
+        return os.path.getsize(path)
+
+    fileno = getattr(source, "fileno", None)
+    if callable(fileno):
+        try:
+            descriptor = fileno()
+        except (AttributeError, OSError, TypeError, ValueError):
+            pass
+        else:
+            if isinstance(descriptor, int) and not isinstance(descriptor, bool):
+                try:
+                    return os.fstat(descriptor).st_size
+                except (OSError, ValueError):
+                    pass
+
+    tell = getattr(source, "tell", None)
+    seek = getattr(source, "seek", None)
+    if not callable(tell) or not callable(seek):
+        return None
+    try:
+        position = tell()
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+    try:
+        seek(0, os.SEEK_END)
+        size = tell()
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+    finally:
+        with suppress(AttributeError, OSError, TypeError, ValueError):
+            seek(position, os.SEEK_SET)
+    return size if isinstance(size, int) and not isinstance(size, bool) else None
+
+
+def enforce_compressed_size(source: object) -> Optional[int]:
+    """Refuse `source` when its physical size exceeds the package bound."""
+    size = compressed_size(source)
+    if size is not None and size > MAX_COMPRESSED_BYTES:
+        raise PackageLimitError(
+            "ZIP package compressed size "
+            f"{size} bytes exceeds the {MAX_COMPRESSED_BYTES}-byte limit"
+        )
+    return size
+
+
+def read_compressed_bytes(path: Union[str, "os.PathLike[str]"]) -> bytes:
+    """Read a package file in chunks while enforcing its actual byte count."""
+    enforce_compressed_size(path)
+    chunks: List[bytes] = []
+    total = 0
+    with open(path, "rb") as stream:
+        while True:
+            chunk = stream.read(min(_READ_CHUNK_BYTES, MAX_COMPRESSED_BYTES - total + 1))
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_COMPRESSED_BYTES:
+                raise PackageLimitError(
+                    "ZIP package actual compressed size exceeds the "
+                    f"{MAX_COMPRESSED_BYTES}-byte limit"
+                )
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def preflight_zip(source: object) -> None:
+    """Validate bounded central-directory metadata before ``ZipFile`` opens.
+
+    ``zipfile.ZipFile`` creates one ``ZipInfo`` object per central-directory
+    record. A forged but physically small archive can otherwise force an
+    unbounded allocation before the ordinary member-count guard runs. This
+    preflight reads only fixed-size records and skips variable fields without
+    retaining them.
+    """
+    enforce_compressed_size(source)
+    if isinstance(source, (str, os.PathLike)):
+        path = cast(Union[str, "os.PathLike[str]"], source)
+        with open(path, "rb") as stream:
+            _preflight_zip_stream(stream)
+        return
+
+    read = getattr(source, "read", None)
+    seek = getattr(source, "seek", None)
+    tell = getattr(source, "tell", None)
+    if not callable(read) or not callable(seek) or not callable(tell):
+        # ``ZipFile`` will reject objects that do not implement its stream
+        # protocol before it can parse or allocate central-directory entries.
+        return
+    _preflight_zip_stream(cast(BinaryIO, source))
+
+
+def _preflight_zip_stream(stream: BinaryIO) -> None:
+    try:
+        original_position = stream.tell()
+        stream.seek(0, os.SEEK_END)
+        archive_size_value = cast(object, stream.tell())
+    except (AttributeError, OSError, TypeError, ValueError) as exc:
+        raise PackageLimitError("ZIP package input must be a seekable binary stream") from exc
+
+    try:
+        if not isinstance(archive_size_value, int) or isinstance(archive_size_value, bool):
+            # Test doubles and invalid stream implementations cannot reach
+            # ZipFile's central-directory parser with this result type.
+            return
+        archive_size = archive_size_value
+        if archive_size > MAX_COMPRESSED_BYTES:
+            raise PackageLimitError(
+                "ZIP package compressed size "
+                f"{archive_size} bytes exceeds the {MAX_COMPRESSED_BYTES}-byte limit"
+            )
+
+        end_offset, end_fields = _find_end_record(stream, archive_size)
+        (
+            _signature,
+            disk_number,
+            central_disk,
+            disk_entries,
+            total_entries,
+            central_size,
+            central_offset,
+            _comment_length,
+        ) = end_fields
+        if disk_number != 0 or central_disk != 0:
+            raise PackageLimitError("multi-disk ZIP packages are not supported")
+
+        zip64_required = (
+            disk_entries == 0xFFFF
+            or total_entries == 0xFFFF
+            or central_size == 0xFFFFFFFF
+            or central_offset == 0xFFFFFFFF
+        )
+        central_end = end_offset
+        if zip64_required:
+            (
+                disk_entries,
+                total_entries,
+                central_size,
+                central_offset,
+                central_end,
+            ) = _read_zip64_end_record(stream, end_offset, end_fields)
+
+        if disk_entries != total_entries:
+            raise PackageLimitError("ZIP central-directory counts disagree across disks")
+        if total_entries > MAX_MEMBER_COUNT:
+            raise PackageLimitError(
+                f"ZIP member count {total_entries} exceeds the "
+                f"{MAX_MEMBER_COUNT}-member limit"
+            )
+        if central_size > MAX_CENTRAL_DIRECTORY_BYTES:
+            raise PackageLimitError(
+                f"ZIP central directory size {central_size} bytes exceeds the "
+                f"{MAX_CENTRAL_DIRECTORY_BYTES}-byte limit"
+            )
+        if central_offset < 0 or central_size < 0:
+            raise PackageLimitError("ZIP central-directory metadata is negative")
+        if central_offset + central_size != central_end:
+            raise PackageLimitError(
+                "ZIP central-directory offset and size do not identify one unambiguous region"
+            )
+        if total_entries == 0 and central_size != 0:
+            raise PackageLimitError("empty ZIP package has a non-empty central directory")
+        if total_entries and central_size < total_entries * _CENTRAL_HEADER.size:
+            raise PackageLimitError("ZIP central directory is too small for its member count")
+
+        _scan_central_directory(
+            stream,
+            central_offset,
+            central_size,
+            total_entries,
+        )
+    finally:
+        with suppress(AttributeError, OSError, TypeError, ValueError):
+            stream.seek(original_position, os.SEEK_SET)
+
+
+def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[int, ...]]:
+    tail_size = min(archive_size, _END_RECORD.size + _MAX_END_COMMENT_BYTES)
+    stream.seek(archive_size - tail_size, os.SEEK_SET)
+    tail = stream.read(tail_size)
+    if len(tail) != tail_size:
+        raise PackageLimitError("ZIP package ends before its declared physical size")
+
+    candidates: List[Tuple[int, Tuple[int, ...]]] = []
+    cursor = 0
+    while True:
+        index = tail.find(_END_RECORD_SIGNATURE, cursor)
+        if index < 0:
+            break
+        cursor = index + 1
+        if index + _END_RECORD.size > len(tail):
+            continue
+        fields = _END_RECORD.unpack_from(tail, index)
+        comment_length = fields[-1]
+        if index + _END_RECORD.size + comment_length == len(tail):
+            candidates.append((archive_size - tail_size + index, fields))
+
+    if not candidates:
+        raise PackageLimitError("ZIP package has no valid end-of-central-directory record")
+    if len(candidates) != 1:
+        raise PackageLimitError("ZIP package has ambiguous end-of-central-directory records")
+    return candidates[0]
+
+
+def _read_zip64_end_record(
+    stream: BinaryIO,
+    end_offset: int,
+    legacy_fields: Tuple[int, ...],
+) -> Tuple[int, int, int, int, int]:
+    locator_offset = end_offset - _ZIP64_LOCATOR.size
+    if locator_offset < 0:
+        raise PackageLimitError("ZIP64 package is missing its locator")
+    stream.seek(locator_offset, os.SEEK_SET)
+    locator_data = stream.read(_ZIP64_LOCATOR.size)
+    if len(locator_data) != _ZIP64_LOCATOR.size:
+        raise PackageLimitError("ZIP64 locator is truncated")
+    signature, record_disk, record_offset, disk_count = _ZIP64_LOCATOR.unpack(locator_data)
+    if signature != _ZIP64_LOCATOR_SIGNATURE:
+        raise PackageLimitError("ZIP64 package is missing its locator")
+    if record_disk != 0 or disk_count != 1:
+        raise PackageLimitError("multi-disk ZIP64 packages are not supported")
+    if record_offset < 0 or record_offset + _ZIP64_END_RECORD.size != locator_offset:
+        raise PackageLimitError("ZIP64 end record has an ambiguous offset or size")
+
+    stream.seek(record_offset, os.SEEK_SET)
+    record_data = stream.read(_ZIP64_END_RECORD.size)
+    if len(record_data) != _ZIP64_END_RECORD.size:
+        raise PackageLimitError("ZIP64 end record is truncated")
+    (
+        signature,
+        record_size,
+        _made_by,
+        _extract_version,
+        disk_number,
+        central_disk,
+        disk_entries,
+        total_entries,
+        central_size,
+        central_offset,
+    ) = _ZIP64_END_RECORD.unpack(record_data)
+    if signature != _ZIP64_END_RECORD_SIGNATURE or record_size != 44:
+        raise PackageLimitError("ZIP64 end record has an unsupported or ambiguous shape")
+    if disk_number != 0 or central_disk != 0 or disk_entries != total_entries:
+        raise PackageLimitError("multi-disk ZIP64 packages are not supported")
+
+    legacy_disk_entries = legacy_fields[3]
+    legacy_total_entries = legacy_fields[4]
+    legacy_central_size = legacy_fields[5]
+    legacy_central_offset = legacy_fields[6]
+    _validate_zip64_legacy_value(legacy_disk_entries, disk_entries, 0xFFFF, "member count")
+    _validate_zip64_legacy_value(legacy_total_entries, total_entries, 0xFFFF, "member count")
+    _validate_zip64_legacy_value(
+        legacy_central_size,
+        central_size,
+        0xFFFFFFFF,
+        "central-directory size",
+    )
+    _validate_zip64_legacy_value(
+        legacy_central_offset,
+        central_offset,
+        0xFFFFFFFF,
+        "central-directory offset",
+    )
+    return disk_entries, total_entries, central_size, central_offset, record_offset
+
+
+def _validate_zip64_legacy_value(
+    legacy: int,
+    actual: int,
+    sentinel: int,
+    label: str,
+) -> None:
+    if legacy != sentinel and legacy != actual:
+        raise PackageLimitError(f"ZIP64 {label} disagrees with the legacy end record")
+
+
+def _scan_central_directory(
+    stream: BinaryIO,
+    central_offset: int,
+    central_size: int,
+    expected_count: int,
+) -> None:
+    cursor = central_offset
+    central_end = central_offset + central_size
+    actual_count = 0
+    while cursor < central_end:
+        if cursor + _CENTRAL_HEADER.size > central_end:
+            raise PackageLimitError("ZIP central directory ends inside a member record")
+        stream.seek(cursor, os.SEEK_SET)
+        header = stream.read(_CENTRAL_HEADER.size)
+        if len(header) != _CENTRAL_HEADER.size:
+            raise PackageLimitError("ZIP central-directory member record is truncated")
+        fields = _CENTRAL_HEADER.unpack(header)
+        if fields[0] != _CENTRAL_HEADER_SIGNATURE:
+            raise PackageLimitError("ZIP central directory contains an unsupported record")
+        name_length, extra_length, comment_length = fields[10:13]
+        if fields[13] != 0:
+            raise PackageLimitError("multi-disk ZIP member records are not supported")
+        record_size = _CENTRAL_HEADER.size + name_length + extra_length + comment_length
+        if cursor + record_size > central_end:
+            raise PackageLimitError("ZIP central-directory member record exceeds its region")
+        cursor += record_size
+        actual_count += 1
+        if actual_count > MAX_MEMBER_COUNT:
+            raise PackageLimitError(
+                f"ZIP member count exceeds the {MAX_MEMBER_COUNT}-member limit"
+            )
+        if actual_count > expected_count:
+            raise PackageLimitError("ZIP central-directory member count exceeds its end record")
+
+    if cursor != central_end or actual_count != expected_count:
+        raise PackageLimitError("ZIP central-directory member count disagrees with its end record")
+
+
+class GuardedZipReader:
+    """Validate and stream every member of an already-open ``ZipFile``.
+
+    Construction fully validates the archive and caches bounded member bytes.
+    This makes ordinary ``Document()`` opens and package-kernel reads share the
+    same validation, including for members not reachable from OPC relationships.
+    """
+
+    def __init__(self, zip_file: ZipFile):
+        self._zip_file = zip_file
+        enforce_compressed_size(zip_file.fp)
+        self._infos = tuple(zip_file.infolist())
+        self._member_limits = {
+            info.filename: _member_limit(info.filename) for info in self._infos
+        }
+        self._validate_metadata()
+        self._parts = self._read_all_members()
+
+    @property
+    def order(self) -> Tuple[str, ...]:
+        """Member names in central-directory order."""
+        return tuple(info.filename for info in self._infos)
+
+    def read(self, name: str) -> bytes:
+        """Return validated bytes for member `name`."""
+        return self._parts[name]
+
+    def read_all(self) -> Tuple[Dict[str, bytes], List[str]]:
+        """Return a copy of validated parts and their archive order."""
+        return dict(self._parts), list(self.order)
+
+    def _validate_metadata(self) -> None:
+        if len(self._infos) > MAX_MEMBER_COUNT:
+            raise PackageLimitError(
+                f"ZIP member count {len(self._infos)} exceeds the {MAX_MEMBER_COUNT}-member limit"
+            )
+
+        seen_names: set[str] = set()
+        seen_equivalent_names: set[str] = set()
+        seen_offsets: set[int] = set()
+        expanded_total = 0
+        for info in self._infos:
+            name = info.orig_filename
+            if name != info.filename:
+                raise PackageLimitError(
+                    f"ZIP member name {name!r} contains a noncanonical NUL suffix"
+                )
+            _validate_member_name(name)
+
+            if name in seen_names:
+                raise PackageLimitError(f"ZIP contains duplicate member name {name!r}")
+            equivalent_name = name.casefold()
+            if equivalent_name in seen_equivalent_names:
+                raise PackageLimitError(f"ZIP contains case-ambiguous member name {name!r}")
+            seen_names.add(name)
+            seen_equivalent_names.add(equivalent_name)
+
+            if info.header_offset < 0 or info.header_offset in seen_offsets:
+                raise PackageLimitError(
+                    f"ZIP member {name!r} has an invalid or shared local-header offset"
+                )
+            seen_offsets.add(info.header_offset)
+
+            if info.flag_bits & (_FLAG_ENCRYPTED | _FLAG_STRONG_ENCRYPTION):
+                raise PackageLimitError(f"ZIP member {name!r} is encrypted")
+            if info.flag_bits & _FLAG_PATCHED_DATA:
+                raise PackageLimitError(
+                    f"ZIP member {name!r} uses unsupported patched-data encoding"
+                )
+            if info.compress_type not in _SUPPORTED_COMPRESSION:
+                raise PackageLimitError(
+                    f"ZIP member {name!r} uses unsupported compression method {info.compress_type}"
+                )
+            if info.is_dir() or info.external_attr & 0x10:
+                raise PackageLimitError(f"ZIP member {name!r} is a directory entry")
+
+            unix_mode = (info.external_attr >> 16) & 0xFFFF
+            file_type = stat.S_IFMT(unix_mode)
+            if file_type not in (0, stat.S_IFREG):
+                raise PackageLimitError(
+                    f"ZIP member {name!r} uses unsupported filesystem entry type"
+                )
+
+            if info.file_size < 0 or info.compress_size < 0:
+                raise PackageLimitError(f"ZIP member {name!r} has a negative size")
+            member_limit = self._limit_for(name)
+            if info.file_size > member_limit:
+                raise PackageLimitError(
+                    f"ZIP member {name!r} expanded size {info.file_size} bytes "
+                    f"exceeds the {member_limit}-byte limit"
+                )
+            expanded_total += info.file_size
+            if expanded_total > MAX_TOTAL_EXPANDED_BYTES:
+                raise PackageLimitError(
+                    f"ZIP total expanded size exceeds the {MAX_TOTAL_EXPANDED_BYTES}-byte limit"
+                )
+            _enforce_ratio(name, info.file_size, info.compress_size)
+            if info.compress_type == ZIP_STORED and info.file_size != info.compress_size:
+                raise PackageLimitError(
+                    f"stored ZIP member {name!r} has inconsistent size metadata"
+                )
+
+    def _read_all_members(self) -> Dict[str, bytes]:
+        if not self._infos:
+            return {}
+        stream = self._zip_file.fp
+        if stream is None:
+            raise PackageLimitError("ZIP package stream is closed")
+
+        start_dir = self._zip_file.start_dir
+        archive_size = compressed_size(stream)
+        if start_dir < 0:
+            raise PackageLimitError("ZIP central-directory offset is invalid")
+        if archive_size is not None and start_dir > archive_size:
+            raise PackageLimitError("ZIP central directory lies beyond the package")
+
+        sorted_infos = sorted(self._infos, key=lambda info: info.header_offset)
+        boundaries = {
+            info.header_offset: (
+                sorted_infos[index + 1].header_offset
+                if index + 1 < len(sorted_infos)
+                else start_dir
+            )
+            for index, info in enumerate(sorted_infos)
+        }
+
+        try:
+            original_position = stream.tell()
+        except (AttributeError, OSError, TypeError, ValueError):
+            original_position = None
+
+        parts: Dict[str, bytes] = {}
+        actual_total = 0
+        try:
+            content_types_info = next(
+                (info for info in self._infos if info.filename == _CONTENT_TYPES_NAME),
+                None,
+            )
+            if content_types_info is not None:
+                data_start = self._validate_local_header(
+                    content_types_info,
+                    boundaries[content_types_info.header_offset],
+                )
+                content_types, actual_total = self._inflate_member(
+                    content_types_info,
+                    data_start,
+                    actual_total,
+                )
+                parts[content_types_info.filename] = content_types
+                self._apply_content_type_limits(content_types)
+                self._validate_declared_member_limits()
+
+            for info in self._infos:
+                if info is content_types_info:
+                    continue
+                data_start = self._validate_local_header(info, boundaries[info.header_offset])
+                blob, actual_total = self._inflate_member(info, data_start, actual_total)
+                parts[info.filename] = blob
+        finally:
+            if original_position is not None:
+                with suppress(AttributeError, OSError, TypeError, ValueError):
+                    stream.seek(original_position, os.SEEK_SET)
+        return parts
+
+    def _apply_content_type_limits(self, content_types: bytes) -> None:
+        defaults, overrides = _parse_content_types(content_types)
+        for info in self._infos:
+            name = info.filename
+            content_type = overrides.get(f"/{name}".casefold())
+            if content_type is None and "." in name.rsplit("/", 1)[-1]:
+                extension = name.rsplit(".", 1)[-1].lower()
+                content_type = defaults.get(extension)
+            if content_type is not None and _is_xml_content_type(content_type):
+                self._member_limits[name] = MAX_XML_MEMBER_BYTES
+
+    def _validate_declared_member_limits(self) -> None:
+        for info in self._infos:
+            member_limit = self._limit_for(info.filename)
+            if info.file_size > member_limit:
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} expanded size {info.file_size} bytes "
+                    f"exceeds the {member_limit}-byte limit"
+                )
+
+    def _limit_for(self, name: str) -> int:
+        return self._member_limits[name]
+
+    def _validate_local_header(self, info: ZipInfo, boundary: int) -> int:
+        stream = self._zip_file.fp
+        if stream is None:
+            raise PackageLimitError("ZIP package stream is closed")
+        if info.header_offset + _LOCAL_HEADER.size > boundary:
+            raise PackageLimitError(f"ZIP member {info.filename!r} has an overlapping header")
+
+        stream.seek(info.header_offset, os.SEEK_SET)
+        header = stream.read(_LOCAL_HEADER.size)
+        if len(header) != _LOCAL_HEADER.size:
+            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated header")
+        (
+            signature,
+            _extract_version,
+            flags,
+            compression,
+            _mod_time,
+            _mod_date,
+            crc,
+            compressed,
+            expanded,
+            name_length,
+            extra_length,
+        ) = _LOCAL_HEADER.unpack(header)
+        if signature != _LOCAL_HEADER_SIGNATURE:
+            raise PackageLimitError(f"ZIP member {info.filename!r} has an invalid header")
+        if flags != info.flag_bits or compression != info.compress_type:
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} has inconsistent local-header metadata"
+            )
+
+        raw_name = stream.read(name_length)
+        if len(raw_name) != name_length:
+            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated name")
+        try:
+            local_name = raw_name.decode(
+                "utf-8"
+                if flags & _FLAG_UTF8_NAME
+                else (getattr(self._zip_file, "metadata_encoding", None) or "cp437")
+            )
+        except UnicodeDecodeError as exc:
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} has an invalid encoded name"
+            ) from exc
+        if local_name != info.orig_filename:
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} has conflicting local and central names"
+            )
+
+        if flags & _FLAG_DATA_DESCRIPTOR:
+            valid_crc = crc in (0, info.CRC)
+            valid_compressed = compressed in (0, info.compress_size, 0xFFFFFFFF)
+            valid_expanded = expanded in (0, info.file_size, 0xFFFFFFFF)
+        else:
+            valid_crc = crc == info.CRC
+            valid_compressed = compressed in (info.compress_size, 0xFFFFFFFF)
+            valid_expanded = expanded in (info.file_size, 0xFFFFFFFF)
+        if not (valid_crc and valid_compressed and valid_expanded):
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} has inconsistent local size or CRC metadata"
+            )
+
+        data_start = info.header_offset + _LOCAL_HEADER.size + name_length + extra_length
+        data_end = data_start + info.compress_size
+        if data_start > boundary or data_end > boundary:
+            raise PackageLimitError(f"ZIP member {info.filename!r} overlaps another ZIP record")
+        self._validate_data_descriptor(info, data_end, boundary)
+        return data_start
+
+    def _validate_data_descriptor(self, info: ZipInfo, data_end: int, boundary: int) -> None:
+        stream = self._zip_file.fp
+        if stream is None:
+            raise PackageLimitError("ZIP package stream is closed")
+        descriptor_size = boundary - data_end
+        if not info.flag_bits & _FLAG_DATA_DESCRIPTOR:
+            if descriptor_size:
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} has undeclared trailing data"
+                )
+            return
+        if descriptor_size not in (12, 16, 20, 24):
+            raise PackageLimitError(f"ZIP member {info.filename!r} has an invalid data descriptor")
+
+        stream.seek(data_end, os.SEEK_SET)
+        descriptor = stream.read(descriptor_size)
+        if len(descriptor) != descriptor_size:
+            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated data descriptor")
+        has_signature = descriptor_size in (16, 24)
+        if has_signature:
+            if descriptor[:4] != b"PK\x07\x08":
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} has an invalid data descriptor"
+                )
+            descriptor = descriptor[4:]
+        if len(descriptor) == 12:
+            crc, compressed, expanded = struct.unpack("<III", descriptor)
+        else:
+            crc, compressed, expanded = struct.unpack("<IQQ", descriptor)
+        if (crc, compressed, expanded) != (
+            info.CRC,
+            info.compress_size,
+            info.file_size,
+        ):
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} has inconsistent data-descriptor metadata"
+            )
+
+    def _inflate_member(
+        self, info: ZipInfo, data_start: int, actual_total: int
+    ) -> Tuple[bytes, int]:
+        stream = self._zip_file.fp
+        if stream is None:
+            raise PackageLimitError("ZIP package stream is closed")
+        stream.seek(data_start, os.SEEK_SET)
+
+        chunks: List[bytes] = []
+        actual_size = 0
+        crc = 0
+        member_limit = self._limit_for(info.filename)
+
+        def consume(data: bytes) -> None:
+            nonlocal actual_size, actual_total, crc
+            if not data:
+                return
+            actual_size += len(data)
+            actual_total += len(data)
+            if actual_size > member_limit:
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} actual expanded size exceeds the "
+                    f"{member_limit}-byte limit"
+                )
+            if actual_total > MAX_TOTAL_EXPANDED_BYTES:
+                raise PackageLimitError(
+                    "ZIP actual total expanded size exceeds the "
+                    f"{MAX_TOTAL_EXPANDED_BYTES}-byte limit"
+                )
+            _enforce_ratio(info.filename, actual_size, info.compress_size, actual=True)
+            crc = zlib.crc32(data, crc)
+            chunks.append(data)
+
+        remaining = info.compress_size
+        if info.compress_type == ZIP_STORED:
+            while remaining:
+                raw = stream.read(min(_READ_CHUNK_BYTES, remaining))
+                if not raw:
+                    raise PackageLimitError(
+                        f"ZIP member {info.filename!r} has truncated stored data"
+                    )
+                remaining -= len(raw)
+                consume(raw)
+        else:
+            decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+            try:
+                while remaining:
+                    raw = stream.read(min(_READ_CHUNK_BYTES, remaining))
+                    if not raw:
+                        raise PackageLimitError(
+                            f"ZIP member {info.filename!r} has truncated compressed data"
+                        )
+                    remaining -= len(raw)
+                    pending = raw
+                    while pending:
+                        if decompressor.eof:
+                            raise PackageLimitError(
+                                f"ZIP member {info.filename!r} has trailing compressed data"
+                            )
+                        output = decompressor.decompress(
+                            pending,
+                            self._next_output_size(member_limit, actual_size, actual_total),
+                        )
+                        pending = decompressor.unconsumed_tail
+                        consume(output)
+                        if decompressor.unused_data:
+                            raise PackageLimitError(
+                                f"ZIP member {info.filename!r} has trailing compressed data"
+                            )
+
+                while not decompressor.eof:
+                    output = decompressor.decompress(
+                        b"", self._next_output_size(member_limit, actual_size, actual_total)
+                    )
+                    consume(output)
+                    if not output:
+                        break
+            except zlib.error as exc:
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} has invalid deflate data"
+                ) from exc
+            if not decompressor.eof:
+                raise PackageLimitError(
+                    f"ZIP member {info.filename!r} compressed data ends before deflate EOF"
+                )
+
+        if actual_size != info.file_size:
+            raise PackageLimitError(
+                f"ZIP member {info.filename!r} actual expanded size {actual_size} bytes "
+                f"does not match declared size {info.file_size} bytes"
+            )
+        if crc & 0xFFFFFFFF != info.CRC:
+            raise PackageLimitError(f"ZIP member {info.filename!r} fails its CRC check")
+        return b"".join(chunks), actual_total
+
+    @staticmethod
+    def _next_output_size(member_limit: int, member_size: int, total_size: int) -> int:
+        member_remaining = member_limit - member_size + 1
+        total_remaining = MAX_TOTAL_EXPANDED_BYTES - total_size + 1
+        return max(1, min(_READ_CHUNK_BYTES, member_remaining, total_remaining))
+
+
+def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
+    try:
+        root = etree.fromstring(data, _CONTENT_TYPES_PARSER)
+    except etree.XMLSyntaxError as exc:
+        raise PackageLimitError("[Content_Types].xml is malformed") from exc
+    docinfo = root.getroottree().docinfo
+    if docinfo.doctype or docinfo.internalDTD is not None:
+        raise PackageLimitError("[Content_Types].xml contains a prohibited DTD")
+    if root.tag != _CONTENT_TYPES_TAG:
+        raise PackageLimitError("[Content_Types].xml has an unexpected root element")
+
+    defaults: Dict[str, str] = {}
+    overrides: Dict[str, str] = {}
+    for element in root:
+        if not isinstance(element.tag, str):
+            continue
+        if element.tag == _DEFAULT_TAG:
+            extension = element.get("Extension")
+            content_type = element.get("ContentType")
+            if (
+                not extension
+                or "." in extension
+                or "/" in extension
+                or extension != extension.strip()
+                or not content_type
+                or content_type != content_type.strip()
+            ):
+                raise PackageLimitError(
+                    "[Content_Types].xml contains an invalid Default declaration"
+                )
+            key = extension.lower()
+            if key in defaults:
+                raise PackageLimitError(
+                    "[Content_Types].xml contains an ambiguous Default declaration"
+                )
+            defaults[key] = content_type
+            continue
+        if element.tag == _OVERRIDE_TAG:
+            part_name = element.get("PartName")
+            content_type = element.get("ContentType")
+            if (
+                not part_name
+                or not part_name.startswith("/")
+                or part_name == "/"
+                or part_name != part_name.strip()
+                or not content_type
+                or content_type != content_type.strip()
+            ):
+                raise PackageLimitError(
+                    "[Content_Types].xml contains an invalid Override declaration"
+                )
+            key = part_name.casefold()
+            if key in overrides:
+                raise PackageLimitError(
+                    "[Content_Types].xml contains an ambiguous Override declaration"
+                )
+            overrides[key] = content_type
+            continue
+        raise PackageLimitError(
+            "[Content_Types].xml contains an unsupported declaration"
+        )
+    return defaults, overrides
+
+
+def _is_xml_content_type(content_type: str) -> bool:
+    media_type = content_type.partition(";")[0].strip().lower()
+    return media_type in ("application/xml", "text/xml") or media_type.endswith("+xml")
+
+
+def _member_limit(name: str) -> int:
+    lower_name = name.lower()
+    if lower_name.endswith(".xml") or lower_name.endswith(".rels"):
+        return MAX_XML_MEMBER_BYTES
+    return MAX_BINARY_MEMBER_BYTES
+
+
+def _enforce_ratio(name: str, expanded: int, compressed: int, *, actual: bool = False) -> None:
+    if expanded == 0:
+        return
+    if compressed <= 0 or expanded > compressed * MAX_COMPRESSION_RATIO:
+        qualifier = "actual " if actual else ""
+        raise PackageLimitError(
+            f"ZIP member {name!r} {qualifier}compression ratio exceeds "
+            f"the {MAX_COMPRESSION_RATIO}:1 limit"
+        )
+
+
+def _validate_member_name(name: str) -> None:
+    if not name:
+        raise PackageLimitError("ZIP contains an empty member name")
+    if name != unicodedata.normalize("NFC", name):
+        raise PackageLimitError(f"ZIP member name {name!r} is not Unicode-normalized")
+    if name.startswith("/") or name.endswith("/") or "\\" in name:
+        raise PackageLimitError(f"ZIP member name {name!r} is noncanonical")
+    if "?" in name or "#" in name:
+        raise PackageLimitError(f"ZIP member name {name!r} contains a URI query or fragment")
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in name):
+        raise PackageLimitError(f"ZIP member name {name!r} contains a control character")
+
+    segments = name.split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise PackageLimitError(f"ZIP member name {name!r} has a noncanonical path segment")
+    first_segment = segments[0]
+    if len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":":
+        raise PackageLimitError(f"ZIP member name {name!r} has a drive-qualified path")
+
+    index = 0
+    while index < len(name):
+        if name[index] != "%":
+            index += 1
+            continue
+        if index + 2 >= len(name) or any(
+            char not in _HEX_DIGITS for char in name[index + 1 : index + 3]
+        ):
+            raise PackageLimitError(f"ZIP member name {name!r} has a noncanonical percent escape")
+        value = int(name[index + 1 : index + 3], 16)
+        if value in _URI_UNRESERVED or value in (0x00, 0x2F, 0x5C, 0x7F) or value < 0x20:
+            raise PackageLimitError(f"ZIP member name {name!r} has an unsafe percent escape")
+        index += 3

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -8,7 +8,13 @@ from consuming unbounded CPU, memory, or disk-backed input:
 * 4,096 members;
 * 64 MiB for one XML member and 256 MiB for one binary member;
 * 512 MiB expanded across the package; and
-* a 100:1 expanded-to-compressed ratio for each non-empty member.
+* a 100:1 expanded-to-compressed ratio for each member larger than 16 MiB
+  expanded (repetitive WordprocessingML legitimately exceeds 100:1; below the
+  floor the absolute member and package limits alone bound resource use).
+
+Directory entries (folder records some archivers add) are structurally
+validated — they may occupy space but must carry no payload — and are then
+ignored, exactly as OPC readers treat them; they are not package parts.
 
 Only the two compression methods permitted by the OPC ZIP mapping (stored and
 deflated) are accepted. Every member is inflated from its raw compressed bytes
@@ -47,6 +53,12 @@ MAX_BINARY_MEMBER_BYTES = 256 * _MIB
 MAX_TOTAL_EXPANDED_BYTES = 512 * _MIB
 #: Maximum expanded-to-compressed ratio for each non-empty member.
 MAX_COMPRESSION_RATIO = 100
+#: Expanded size at or below which the ratio limit does not apply. Deflate
+#: reaches ~1000:1 on repetitive input and ordinary Word documents (uniform
+#: tables, blank-line padding) legitimately exceed 100:1; small members are
+#: already bounded by the absolute limits above, so the ratio only guards the
+#: amplification range where expansion itself is the resource risk.
+RATIO_ENFORCEMENT_FLOOR_BYTES = 16 * _MIB
 
 _READ_CHUNK_BYTES = 64 * 1024
 _LOCAL_HEADER = struct.Struct("<4s5H3L2H")
@@ -414,7 +426,16 @@ class GuardedZipReader:
     def __init__(self, zip_file: ZipFile):
         self._zip_file = zip_file
         enforce_compressed_size(zip_file.fp)
-        self._infos = tuple(zip_file.infolist())
+        members: "List[ZipInfo]" = []
+        directories: "List[ZipInfo]" = []
+        for info in zip_file.infolist():
+            if info.orig_filename.endswith("/"):
+                _validate_directory_entry(info)
+                directories.append(info)
+            else:
+                members.append(info)
+        self._infos = tuple(members)
+        self._directory_infos = tuple(directories)
         self._member_limits = {
             info.filename: _member_limit(info.filename) for info in self._infos
         }
@@ -443,6 +464,15 @@ class GuardedZipReader:
         seen_names: set[str] = set()
         seen_equivalent_names: set[str] = set()
         seen_offsets: set[int] = set()
+        for info in self._directory_infos:
+            # directory entries occupy archive space: they participate in the
+            # overlap accounting even though they are not members
+            if info.header_offset < 0 or info.header_offset in seen_offsets:
+                raise PackageLimitError(
+                    f"ZIP directory entry {info.orig_filename!r} has an invalid"
+                    " or shared local-header offset"
+                )
+            seen_offsets.add(info.header_offset)
         expanded_total = 0
         for info in self._infos:
             name = info.orig_filename
@@ -519,7 +549,9 @@ class GuardedZipReader:
         if archive_size is not None and start_dir > archive_size:
             raise PackageLimitError("ZIP central directory lies beyond the package")
 
-        sorted_infos = sorted(self._infos, key=lambda info: info.header_offset)
+        sorted_infos = sorted(
+            self._infos + self._directory_infos, key=lambda info: info.header_offset
+        )
         boundaries = {
             info.header_offset: (
                 sorted_infos[index + 1].header_offset
@@ -537,6 +569,12 @@ class GuardedZipReader:
         parts: Dict[str, bytes] = {}
         actual_total = 0
         try:
+            for info in self._directory_infos:
+                # structural validation only: the local record must be intact
+                # and must carry no payload (its declared sizes are zero, so a
+                # nonzero data region refuses as undeclared trailing data)
+                self._validate_local_header(info, boundaries[info.header_offset])
+
             content_types_info = next(
                 (info for info in self._infos if info.filename == _CONTENT_TYPES_NAME),
                 None,
@@ -878,12 +916,29 @@ def _member_limit(name: str) -> int:
 def _enforce_ratio(name: str, expanded: int, compressed: int, *, actual: bool = False) -> None:
     if expanded == 0:
         return
+    if compressed > 0 and expanded <= RATIO_ENFORCEMENT_FLOOR_BYTES:
+        return
     if compressed <= 0 or expanded > compressed * MAX_COMPRESSION_RATIO:
         qualifier = "actual " if actual else ""
         raise PackageLimitError(
             f"ZIP member {name!r} {qualifier}compression ratio exceeds "
             f"the {MAX_COMPRESSION_RATIO}:1 limit"
         )
+
+
+def _validate_directory_entry(info: "ZipInfo") -> None:
+    """A folder record may occupy archive space but must be inert."""
+    name = info.orig_filename
+    if name != info.filename:
+        raise PackageLimitError(
+            f"ZIP directory entry {name!r} contains a noncanonical NUL suffix"
+        )
+    if info.flag_bits & (_FLAG_ENCRYPTED | _FLAG_STRONG_ENCRYPTION | _FLAG_PATCHED_DATA):
+        raise PackageLimitError(
+            f"ZIP directory entry {name!r} uses unsupported encoding flags"
+        )
+    if info.file_size or info.compress_size:
+        raise PackageLimitError(f"ZIP directory entry {name!r} carries data")
 
 
 def _validate_member_name(name: str) -> None:

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
 from docx import _clock
+from docx._ownership import require_anchor_owner
 from docx.errors import (
     BoundaryViolationError,
     TargetNotFoundError,
@@ -32,8 +33,8 @@ from docx.errors import (
 )
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
-from docx.protection import _refuse_if_protected
 from docx.oxml.revision import CT_RunTrackChange
+from docx.protection import _refuse_if_protected
 from docx.search import Span, _validate_writable_text, find_one
 from docx.story import Anchor, Block, _iter_block_elements, _story_elements
 
@@ -113,6 +114,7 @@ def _resolve_anchor_paragraph(
     resolution (e.g. a composition SOURCE range) uses
     `_locate_anchor_paragraph` directly.
     """
+    require_anchor_owner(document, anchor)
     _refuse_if_protected(document, "insert or remove paragraphs")
     return _locate_anchor_paragraph(document, anchor)
 
@@ -126,6 +128,7 @@ def _locate_anchor_paragraph(
     are re-verified by content hash against the current-view text of the
     block at their recorded position.
     """
+    require_anchor_owner(document, anchor)
     if isinstance(anchor, str):
         span = find_one(document, anchor)
         paragraph = span._atoms[0].paragraph  # noqa: SLF001 - same-package access
@@ -387,6 +390,11 @@ def _select_paragraph_range(
 ) -> "Tuple[str, List[_Element]]":
     if count < 1:
         raise ValueError("count must be >= 1")
+    # Validate every live proxy before the first protection check. Otherwise
+    # a foreign end span can be masked by resolving the start anchor first.
+    require_anchor_owner(document, start_anchor, argument="start_anchor")
+    if end_anchor is not None:
+        require_anchor_owner(document, end_anchor, argument="end_anchor")
     story, start_p = _resolve_anchor_paragraph(document, start_anchor)
     root = dict(_story_elements(document))[story]
     _refuse_paragraph_in_open_field(story, root, start_p, for_insertion=False)

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -35,7 +35,12 @@ from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.oxml.revision import CT_RunTrackChange
 from docx.protection import _refuse_if_protected
-from docx.search import Span, _validate_writable_text, find_one
+from docx.search import (
+    Span,
+    _validate_writable_text,
+    _validate_xml_characters,
+    find_one,
+)
 from docx.story import Anchor, Block, _iter_block_elements, _story_elements
 
 if TYPE_CHECKING:
@@ -440,6 +445,20 @@ def _insert_after(anchor: "_Element", nodes: "Sequence[_Element]") -> None:
 # ---------------------------------------------------------------------------
 
 
+
+def _validate_tracked_identity(author: "Optional[str]", date: object) -> None:
+    """Refuse malformed revision identity BEFORE any mutation.
+
+    The w:author/w:date attributes are stamped near the end of each tracked
+    operation (and list blocks may add numbering definitions first), so a
+    value the XML layer would reject must fail while nothing has changed.
+    """
+    if author is not None:
+        _validate_xml_characters(author, argument="author")
+    if date is not None and not isinstance(date, dt.datetime):
+        raise TypeError("date must be a datetime or None")
+
+
 def insert_section_after(
     document: "Document",
     anchor: AnchorLike,
@@ -460,6 +479,8 @@ def insert_section_after(
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
+    if tracked:
+        _validate_tracked_identity(author, date)
     _validate_writable_text(heading, argument="heading")
     for index, text in enumerate(paragraphs):
         _validate_writable_text(text, argument=f"paragraphs[{index}]")
@@ -509,6 +530,7 @@ def tracked_delete_paragraphs(
     """
     if not author:
         raise ValueError("author is required")
+    _validate_tracked_identity(author, date)
     story, selected = _select_paragraph_range(document, start_anchor, end_anchor, count)
     for paragraph in selected:
         _validate_deletable_paragraph(paragraph)
@@ -545,6 +567,7 @@ def tracked_replace_paragraphs(
     """Tracked-delete a paragraph range and tracked-insert replacements after it."""
     if not author:
         raise ValueError("author is required")
+    _validate_tracked_identity(author, date)
     for index, text in enumerate(replacement_paragraphs):
         _validate_writable_text(text, argument=f"replacement_paragraphs[{index}]")
     body_style_id = _validated_style_id(document, body_style, argument="body_style")
@@ -741,6 +764,8 @@ def insert_blocks_after(
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
+    if tracked:
+        _validate_tracked_identity(author, date)
     _validate_rich_blocks(document, blocks, tracked=tracked)
     story, anchor_p = _resolve_anchor_paragraph(document, anchor)
     _refuse_cell_anchor(anchor_p)

--- a/src/docx/bookmarks.py
+++ b/src/docx/bookmarks.py
@@ -34,6 +34,16 @@ _NAME = qn("w:name")
 _INSTR_TEXT = qn("w:instrText")
 _FLD_SIMPLE = qn("w:fldSimple")
 _INSTR = qn("w:instr")
+_CONTENT_REVISION_WRAPPERS = frozenset(
+    (
+        qn("w:ins"),
+        qn("w:del"),
+        qn("w:moveFrom"),
+        qn("w:moveTo"),
+        qn("w14:conflictIns"),
+        qn("w14:conflictDel"),
+    )
+)
 
 #: Word's bookmark-name rules: start with a letter, then letters/digits/
 #: underscores, max 40 chars ("_"-prefixed names are Word-internal)
@@ -99,17 +109,9 @@ def _bookmark_text(root: "_Element", start: "_Element", raw_id: Optional[str]) -
         if node is start:
             collecting = True
             continue
-        if (
-            collecting
-            and node.tag == _BOOKMARK_END
-            and node.get(_ID) == raw_id
-        ):
+        if collecting and node.tag == _BOOKMARK_END and node.get(_ID) == raw_id:
             break
-        if (
-            collecting
-            and is_direct_run_child(node)
-            and node.tag not in (DEL_TEXT, INSTR_TEXT)
-        ):
+        if collecting and is_direct_run_child(node) and node.tag not in (DEL_TEXT, INSTR_TEXT):
             projection = project_run_child(node)
             if projection.barrier or not projection.text:
                 continue
@@ -131,6 +133,23 @@ def _next_bookmark_id(document: "Document") -> int:
     return highest + 1
 
 
+def _revision_scope(node: "_Element") -> tuple:
+    scope = []
+    current = node.getparent()
+    while current is not None:
+        if current.tag in _CONTENT_REVISION_WRAPPERS:
+            scope.append(current)
+        current = current.getparent()
+    return tuple(reversed(scope))
+
+
+def _same_revision_scope(left: "_Element", right: "_Element") -> bool:
+    left_scope, right_scope = _revision_scope(left), _revision_scope(right)
+    return len(left_scope) == len(right_scope) and all(
+        left is right for left, right in zip(left_scope, right_scope)
+    )
+
+
 def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkInfo:
     """Bookmark exactly `span`'s text under `name` (unique, Word-legal).
 
@@ -144,10 +163,9 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
             f"bookmark name {name!r} is not Word-legal (start with a letter;"
             " letters, digits and underscores only; max 40 chars)"
         )
-    if any(b.name == name for b in list_bookmarks(document)):
+    if any(b.name.casefold() == name.casefold() for b in list_bookmarks(document)):
         raise UnsupportedStructureError(
-            f"a bookmark named {name!r} already exists; bookmark names are"
-            " document-unique"
+            f"a bookmark named {name!r} already exists; bookmark names are document-unique"
         )
     span._validate_fresh()  # noqa: SLF001 - same-package machinery
     if span.in_field:
@@ -159,9 +177,13 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
     for atom in span._atoms:  # noqa: SLF001
         if atom.run is None:
             raise UnsupportedStructureError(
-                "the span includes content outside ordinary runs; bookmark"
-                " a plain text range"
+                "the span includes content outside ordinary runs; bookmark a plain text range"
             )
+    if not _same_revision_scope(span._atoms[0].run, span._atoms[-1].run):  # noqa: SLF001
+        raise UnsupportedStructureError(
+            "bookmark endpoints cross pending revision scopes; resolve the"
+            " revision or bookmark text within one revision scope. Nothing was changed"
+        )
     # Allocation parses every existing marker id, so it must happen before
     # edge isolation splits any source runs.
     bookmark_id = _next_bookmark_id(document)
@@ -175,9 +197,7 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
     last_run = span._atoms[-1].run  # noqa: SLF001
     first_run.addprevious(start_marker)
     last_run.addnext(end_marker)
-    return BookmarkInfo(
-        name=name, bookmark_id=bookmark_id, story=span.story, text=span.text
-    )
+    return BookmarkInfo(name=name, bookmark_id=bookmark_id, story=span.story, text=span.text)
 
 
 def delete_bookmark(document: "Document", name: str) -> None:
@@ -185,7 +205,17 @@ def delete_bookmark(document: "Document", name: str) -> None:
     instruction still references the name — a dangling REF/PAGEREF renders
     'Error! Reference source not found.' in Word."""
     _refuse_if_protected(document, "delete a bookmark")
-    referencing = _field_references(document, name)
+    matching_names = {
+        bookmark.name
+        for bookmark in list_bookmarks(document)
+        if bookmark.name.casefold() == name.casefold()
+    }
+    if len(matching_names) > 1:
+        raise UnsupportedStructureError(
+            f"bookmark name {name!r} is case-ambiguous; nothing was changed"
+        )
+    resolved_name = next(iter(matching_names), name)
+    referencing = _field_references(document, resolved_name)
     if referencing:
         raise UnsupportedStructureError(
             f"bookmark {name!r} is referenced by {referencing} field"
@@ -218,10 +248,15 @@ def delete_bookmark(document: "Document", name: str) -> None:
         pairs.extend(
             (start, ends_by_id[marker_id])
             for marker_id, start in starts_by_id.items()
-            if start.get(_NAME) == name
+            if (start.get(_NAME) or "").casefold() == resolved_name.casefold()
         )
     if not pairs:
         raise TargetNotFoundError(f"no bookmark named {name!r} exists")
+    if any(not _same_revision_scope(start, end) for start, end in pairs):
+        raise UnsupportedStructureError(
+            f"bookmark {name!r} has markers in different revision scopes;"
+            " deleting it could leave a dangling marker. Nothing was changed"
+        )
 
     # -- validated; mutate --
     for start, end in pairs:
@@ -257,27 +292,27 @@ def _iter_field_instructions(root: "_Element"):
                     break
 
 
-def _reference_pattern(name: str):
-    escaped = re.escape(name)
-    return re.compile(
-        rf'\b(?:PAGEREF|NOTEREF|REF)\s+(?:"{escaped}"|{escaped})(?=\s|$)',
-        re.IGNORECASE,
-    )
-
-
 def _field_references(document: "Document", name: str) -> int:
-    pattern = _reference_pattern(name)
+    from docx._fieldcode import bookmark_operands
+
+    target = name.casefold()
     count = 0
     for _story, root in _story_elements(document):
         for instruction, _nodes in _iter_field_instructions(root):
-            if pattern.search(instruction):
+            if any(
+                operand.value.casefold() == target
+                for operand in bookmark_operands(instruction, implicit_names=(name,))
+            ):
                 count += 1
         for node in root.iter(_FLD_SIMPLE):
             instr = node.get(_INSTR)
-            if instr and pattern.search(instr):
+            if instr and any(
+                operand.value.casefold() == target
+                for operand in bookmark_operands(instr, implicit_names=(name,))
+            ):
                 count += 1
         for link in root.iter(qn("w:hyperlink")):
             anchor = link.get(qn("w:anchor"))
-            if anchor is not None and anchor.casefold() == name.casefold():
+            if anchor is not None and anchor.casefold() == target:
                 count += 1  # internal links target bookmarks too
     return count

--- a/src/docx/bookmarks.py
+++ b/src/docx/bookmarks.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
+from docx._ownership import require_span_owner
+from docx._textatoms import DEL_TEXT, INSTR_TEXT, is_direct_run_child, project_run_child
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
@@ -29,7 +31,6 @@ _BOOKMARK_START = qn("w:bookmarkStart")
 _BOOKMARK_END = qn("w:bookmarkEnd")
 _ID = qn("w:id")
 _NAME = qn("w:name")
-_T = qn("w:t")
 _INSTR_TEXT = qn("w:instrText")
 _FLD_SIMPLE = qn("w:fldSimple")
 _INSTR = qn("w:instr")
@@ -104,12 +105,19 @@ def _bookmark_text(root: "_Element", start: "_Element", raw_id: Optional[str]) -
             and node.get(_ID) == raw_id
         ):
             break
-        if collecting and node.tag == _T:
+        if (
+            collecting
+            and is_direct_run_child(node)
+            and node.tag not in (DEL_TEXT, INSTR_TEXT)
+        ):
+            projection = project_run_child(node)
+            if projection.barrier or not projection.text:
+                continue
             paragraph = _paragraph_of(node)
             if last_paragraph is not None and paragraph is not last_paragraph:
                 pieces.append("\n")  # boundary, matching Span.text semantics
             last_paragraph = paragraph
-            pieces.append(node.text or "")
+            pieces.append(projection.text)
     return "".join(pieces)
 
 
@@ -129,6 +137,7 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
     Boundary runs are split so the markers wrap precisely the span's
     characters — the same isolation the comment-range machinery uses.
     """
+    require_span_owner(document, span)
     _refuse_if_protected(document, "create a bookmark")
     if not _NAME_RE.match(name or ""):
         raise ValueError(
@@ -153,13 +162,15 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
                 "the span includes content outside ordinary runs; bookmark"
                 " a plain text range"
             )
-    span._isolate_edge_runs()  # noqa: SLF001
+    # Allocation parses every existing marker id, so it must happen before
+    # edge isolation splits any source runs.
     bookmark_id = _next_bookmark_id(document)
     start_marker = OxmlElement("w:bookmarkStart")
     start_marker.set(_ID, str(bookmark_id))
     start_marker.set(_NAME, name)
     end_marker = OxmlElement("w:bookmarkEnd")
     end_marker.set(_ID, str(bookmark_id))
+    span._isolate_edge_runs()  # noqa: SLF001
     first_run = span._atoms[0].run  # noqa: SLF001
     last_run = span._atoms[-1].run  # noqa: SLF001
     first_run.addprevious(start_marker)
@@ -180,20 +191,42 @@ def delete_bookmark(document: "Document", name: str) -> None:
             f"bookmark {name!r} is referenced by {referencing} field"
             " instruction(s); update or remove those fields first"
         )
-    removed = 0
+    pairs = []
     for _story, root in _story_elements(document):
-        for start in list(root.iter(_BOOKMARK_START)):
-            if start.get(_NAME) != name:
-                continue
-            raw_id = start.get(_ID)
-            for end in list(root.iter(_BOOKMARK_END)):
-                if end.get(_ID) == raw_id:
-                    end.getparent().remove(end)
-                    break
-            start.getparent().remove(start)
-            removed += 1  # duplicate names all go — "deleted" must mean gone
-    if not removed:
+        starts_by_id = {}
+        ends_by_id = {}
+        for tag, destination in (
+            (_BOOKMARK_START, starts_by_id),
+            (_BOOKMARK_END, ends_by_id),
+        ):
+            for marker in root.iter(tag):
+                raw_id = marker.get(_ID)
+                try:
+                    marker_id = int(raw_id) if raw_id is not None else -1
+                except ValueError:
+                    marker_id = -1
+                if marker_id < 0 or marker_id in destination:
+                    raise UnsupportedStructureError(
+                        "bookmark markers have missing, non-numeric, or duplicate"
+                        f" w:id {raw_id!r}; nothing was changed"
+                    )
+                destination[marker_id] = marker
+        if set(starts_by_id) != set(ends_by_id):
+            raise UnsupportedStructureError(
+                "bookmark start/end markers are not one-to-one; nothing was changed"
+            )
+        pairs.extend(
+            (start, ends_by_id[marker_id])
+            for marker_id, start in starts_by_id.items()
+            if start.get(_NAME) == name
+        )
+    if not pairs:
         raise TargetNotFoundError(f"no bookmark named {name!r} exists")
+
+    # -- validated; mutate --
+    for start, end in pairs:
+        end.getparent().remove(end)
+        start.getparent().remove(start)
 
 
 _FLD_CHAR = qn("w:fldChar")
@@ -205,21 +238,31 @@ def _iter_field_instructions(root: "_Element"):
     Word freely SPLITS one instruction across several runs, so any scan
     matching single nodes silently misses references.
     """
-    stack: "List[List[_Element]]" = []
+    stack: "List[Tuple[List[_Element], bool]]" = []
     for node in root.iter():
         if node.tag == _FLD_CHAR:
             fld_type = node.get(_FLD_CHAR_TYPE)
             if fld_type == "begin":
-                stack.append([])
+                stack.append(([], True))
+            elif fld_type == "separate" and stack:
+                nodes, _collecting = stack[-1]
+                stack[-1] = (nodes, False)
             elif fld_type == "end" and stack:
-                nodes = stack.pop()
+                nodes, _collecting = stack.pop()
                 yield "".join(n.text or "" for n in nodes), nodes
         elif node.tag == _INSTR_TEXT and stack:
-            stack[-1].append(node)
+            for nodes, collecting in reversed(stack):
+                if collecting:
+                    nodes.append(node)
+                    break
 
 
 def _reference_pattern(name: str):
-    return re.compile(rf"\b(?:PAGEREF|NOTEREF|REF)\s+{re.escape(name)}(?=\s|$)")
+    escaped = re.escape(name)
+    return re.compile(
+        rf'\b(?:PAGEREF|NOTEREF|REF)\s+(?:"{escaped}"|{escaped})(?=\s|$)',
+        re.IGNORECASE,
+    )
 
 
 def _field_references(document: "Document", name: str) -> int:
@@ -234,6 +277,7 @@ def _field_references(document: "Document", name: str) -> int:
             if instr and pattern.search(instr):
                 count += 1
         for link in root.iter(qn("w:hyperlink")):
-            if link.get(qn("w:anchor")) == name:
+            anchor = link.get(qn("w:anchor"))
+            if anchor is not None and anchor.casefold() == name.casefold():
                 count += 1  # internal links target bookmarks too
     return count

--- a/src/docx/bookmarks.py
+++ b/src/docx/bookmarks.py
@@ -44,6 +44,9 @@ _CONTENT_REVISION_WRAPPERS = frozenset(
         qn("w14:conflictDel"),
     )
 )
+_CURRENT_HIDDEN_REVISION_WRAPPERS = frozenset(
+    (qn("w:del"), qn("w:moveFrom"), qn("w14:conflictDel"))
+)
 
 #: Word's bookmark-name rules: start with a letter, then letters/digits/
 #: underscores, max 40 chars ("_"-prefixed names are Word-internal)
@@ -112,6 +115,11 @@ def _bookmark_text(root: "_Element", start: "_Element", raw_id: Optional[str]) -
         if collecting and node.tag == _BOOKMARK_END and node.get(_ID) == raw_id:
             break
         if collecting and is_direct_run_child(node) and node.tag not in (DEL_TEXT, INSTR_TEXT):
+            if any(
+                wrapper.tag in _CURRENT_HIDDEN_REVISION_WRAPPERS
+                for wrapper in _revision_scope(node)
+            ):
+                continue
             projection = project_run_child(node)
             if projection.barrier or not projection.text:
                 continue
@@ -150,6 +158,19 @@ def _same_revision_scope(left: "_Element", right: "_Element") -> bool:
     )
 
 
+def _revision_wrapper_between(left: "_Element", right: "_Element") -> bool:
+    root = left.getroottree().getroot()
+    inside = False
+    for node in root.iter():
+        if node is left:
+            inside = True
+        if inside and node.tag in _CONTENT_REVISION_WRAPPERS:
+            return True
+        if node is right:
+            return not inside
+    return True
+
+
 def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkInfo:
     """Bookmark exactly `span`'s text under `name` (unique, Word-legal).
 
@@ -183,6 +204,13 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
         raise UnsupportedStructureError(
             "bookmark endpoints cross pending revision scopes; resolve the"
             " revision or bookmark text within one revision scope. Nothing was changed"
+        )
+    if _revision_wrapper_between(  # noqa: SLF001
+        span._atoms[0].run, span._atoms[-1].run
+    ):
+        raise UnsupportedStructureError(
+            "bookmark text crosses pending revision content; resolve the"
+            " revision first. Nothing was changed"
         )
     # Allocation parses every existing marker id, so it must happen before
     # edge isolation splits any source runs.

--- a/src/docx/bookmarks.py
+++ b/src/docx/bookmarks.py
@@ -206,9 +206,10 @@ def delete_bookmark(document: "Document", name: str) -> None:
     'Error! Reference source not found.' in Word."""
     _refuse_if_protected(document, "delete a bookmark")
     matching_names = {
-        bookmark.name
-        for bookmark in list_bookmarks(document)
-        if bookmark.name.casefold() == name.casefold()
+        start.get(_NAME) or ""
+        for _story, root in _story_elements(document)
+        for start in root.iter(_BOOKMARK_START)
+        if (start.get(_NAME) or "").casefold() == name.casefold()
     }
     if len(matching_names) > 1:
         raise UnsupportedStructureError(

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -303,7 +303,18 @@ def _anchor_elements(document: "Document", comment_id: int):
     body = document.element.body
     start = end = reference_run = None
     for node in body.iter(_RANGE_START, _RANGE_END, _REFERENCE):
-        if node.get(_W_ID) != str(comment_id):
+        raw = node.get(_W_ID)
+        try:
+            if raw is None:
+                raise ValueError
+            marker_id = int(raw)
+        except (TypeError, ValueError):
+            name = node.tag.rsplit("}", 1)[-1]
+            raise UnsupportedStructureError(
+                f"malformed {name} comment marker w:id={raw!r}; nothing was"
+                " changed"
+            ) from None
+        if marker_id != comment_id:
             continue
         if node.tag == _RANGE_START:
             start = node
@@ -415,8 +426,15 @@ def reply(
 def comment_thread(document: "Document") -> Tuple[dict, ...]:
     """Every comment with its thread state: (id, author, text, resolved,
     parent_id, anchored_text where available)."""
+    try:
+        comments = document.comments
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple comments relationships make comment inspection"
+            " ambiguous; nothing was changed"
+        ) from None
     entries = []
-    for comment in document.comments:
+    for comment in comments:
         try:
             anchor_text = anchored_text(document, comment)
         except TargetNotFoundError:

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -191,7 +191,7 @@ def _comment_element(document: "Document", comment: "Comment") -> "_Element":
 
 
 def _last_paragraph(comment_elm: "_Element") -> "_Element":
-    paragraphs = comment_elm.findall(_P)
+    paragraphs = list(comment_elm.iter(_P))
     if not paragraphs:
         raise UnsupportedStructureError("comment has no paragraph to key on")
     return paragraphs[-1]
@@ -287,6 +287,41 @@ def _preflight_comments_extended_write(document: "Document") -> None:
             "a package part already occupies /word/commentsExtended.xml"
             " without the commentsExtended relationship; nothing was changed"
         )
+
+
+def _migrate_comment_extension(
+    document: "Document",
+    comment_elm: "_Element",
+    previous_last: "_Element",
+) -> None:
+    """Move thread and resolution state when a comment gains a new last paragraph."""
+    current_last = _last_paragraph(comment_elm)
+    if current_last is previous_last:
+        return
+    previous_raw = previous_last.get(_PARA_ID_ATTR)
+    if previous_raw is None:
+        return
+    previous_id = _validate_para_id(previous_raw, attribute="w14:paraId")
+    root = _comments_extended_root(document, create=False)
+    if root is None:
+        return
+    own_entry = _entry_for(root, previous_id, create=False)
+    child_entries = [
+        entry
+        for entry in root.findall(_COMMENT_EX)
+        if entry.get(_PARA_ID_PARENT) is not None
+        and _validate_para_id(
+            entry.get(_PARA_ID_PARENT), attribute="w15:paraIdParent"
+        )
+        == previous_id
+    ]
+    if own_entry is None and not child_entries:
+        return
+    current_id = _ensure_para_id(document, current_last)
+    if own_entry is not None:
+        own_entry.set(_PARA_ID, current_id)
+    for entry in child_entries:
+        entry.set(_PARA_ID_PARENT, current_id)
 
 
 def _entry_for(root: "_Element", para_id: str, *, create: bool) -> "Optional[_Element]":
@@ -513,12 +548,18 @@ def reply(
 def comment_thread(document: "Document") -> Tuple[dict, ...]:
     """Every comment with its thread state: (id, author, text, resolved,
     parent_id, anchored_text where available)."""
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    _preflight_comment_add(document)
     try:
-        comments = document.comments
+        comments_part = document.part.part_related_by(RT.COMMENTS)
+    except KeyError:
+        return ()
     except ValueError:
         raise UnsupportedStructureError(
             "multiple comments relationships make comment inspection ambiguous; nothing was changed"
         ) from None
+    comments = comments_part.comments
     entries = []
     for comment in comments:
         try:

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 from docx import _clock
 from docx._ownership import require_comment_owner
 from docx._textatoms import DEL_TEXT, INSTR_TEXT, is_direct_run_child, project_run_child
+from docx._transaction import rollback_on_error
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.oxml.ns import nsdecls, qn
 from docx.oxml.parser import parse_xml
@@ -271,10 +272,11 @@ def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) 
     # Validate a pre-existing extension part before adding a paraId to the
     # comment. An opaque extension must refuse without touching comments.xml.
     _preflight_comments_extended_write(document)
-    para_id = _ensure_para_id(document, _last_paragraph(comment_elm))
-    root = _comments_extended_root(document, create=True)
-    entry = _entry_for(root, para_id, create=True)
-    entry.set(_DONE, "1" if resolved else "0")
+    with rollback_on_error(document):
+        para_id = _ensure_para_id(document, _last_paragraph(comment_elm))
+        root = _comments_extended_root(document, create=True)
+        entry = _entry_for(root, para_id, create=True)
+        entry.set(_DONE, "1" if resolved else "0")
 
 
 def parent_of(document: "Document", comment: "Comment") -> Optional[int]:
@@ -379,32 +381,35 @@ def reply(
         )
     _preflight_comment_add(document)
     _preflight_comments_extended_write(document)
-    parent_para_id = _ensure_para_id(document, _last_paragraph(parent_elm))
+    with rollback_on_error(document):
+        parent_para_id = _ensure_para_id(document, _last_paragraph(parent_elm))
 
-    new_comment = document.comments.add_comment(
-        text=text, author=author, initials=initials or ""
-    )
-    new_elm = _comment_element(document, new_comment)
-    new_elm.date = date if date is not None else _clock.now()
-    new_para_id = _ensure_para_id(document, _last_paragraph(new_elm))
-
-    new_id = new_comment.comment_id
-    start.addnext(
-        parse_xml(f'<w:commentRangeStart {_W_DECL} w:id="{new_id}"/>')
-    )
-    end.addprevious(parse_xml(f'<w:commentRangeEnd {_W_DECL} w:id="{new_id}"/>'))
-    reference_run.addnext(
-        parse_xml(
-            f"<w:r {_W_DECL}><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr>"
-            f'<w:commentReference w:id="{new_id}"/></w:r>'
+        new_comment = document.comments.add_comment(
+            text=text, author=author, initials=initials or ""
         )
-    )
+        new_elm = _comment_element(document, new_comment)
+        new_elm.date = date if date is not None else _clock.now()
+        new_para_id = _ensure_para_id(document, _last_paragraph(new_elm))
 
-    root = _comments_extended_root(document, create=True)
-    _entry_for(root, parent_para_id, create=True)
-    reply_entry = _entry_for(root, new_para_id, create=True)
-    reply_entry.set(_PARA_ID_PARENT, parent_para_id)
-    return new_comment
+        new_id = new_comment.comment_id
+        start.addnext(
+            parse_xml(f'<w:commentRangeStart {_W_DECL} w:id="{new_id}"/>')
+        )
+        end.addprevious(
+            parse_xml(f'<w:commentRangeEnd {_W_DECL} w:id="{new_id}"/>')
+        )
+        reference_run.addnext(
+            parse_xml(
+                f"<w:r {_W_DECL}><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr>"
+                f'<w:commentReference w:id="{new_id}"/></w:r>'
+            )
+        )
+
+        root = _comments_extended_root(document, create=True)
+        _entry_for(root, parent_para_id, create=True)
+        reply_entry = _entry_for(root, new_para_id, create=True)
+        reply_entry.set(_PARA_ID_PARENT, parent_para_id)
+        return new_comment
 
 
 def comment_thread(document: "Document") -> Tuple[dict, ...]:

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -13,6 +13,8 @@ import datetime as dt
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from docx import _clock
+from docx._ownership import require_comment_owner
+from docx._textatoms import DEL_TEXT, INSTR_TEXT, is_direct_run_child, project_run_child
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.oxml.ns import nsdecls, qn
 from docx.oxml.parser import parse_xml
@@ -32,14 +34,14 @@ _PARA_ID_ATTR = qn("w14:paraId")
 _PARA_ID = f"{{{_W15_NS}}}paraId"
 _PARA_ID_PARENT = f"{{{_W15_NS}}}paraIdParent"
 _DONE = f"{{{_W15_NS}}}done"
+_COMMENTS = qn("w:comments")
+_COMMENT = qn("w:comment")
 _P = qn("w:p")
 _R = qn("w:r")
 _W_ID = qn("w:id")
 _RANGE_START = qn("w:commentRangeStart")
 _RANGE_END = qn("w:commentRangeEnd")
 _REFERENCE = qn("w:commentReference")
-_T = qn("w:t")
-_DEL_TEXT = qn("w:delText")
 
 COMMENTS_EXTENDED_CONTENT_TYPE = (
     "application/vnd.openxmlformats-officedocument.wordprocessingml"
@@ -54,12 +56,79 @@ _COMMENTS_EX_TEMPLATE = (
     ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"/>'
 )
 
+_COMMENTS_PARTNAME = "/word/comments.xml"
+_COMMENTS_EXTENDED_PARTNAME = "/word/commentsExtended.xml"
+
+
+def _part_with_name(document: "Document", partname: str):
+    package = document.part.package
+    if package is None:
+        return None
+    return next(
+        (part for part in package.iter_parts() if str(part.partname) == partname),
+        None,
+    )
+
+
+def _preflight_comment_add(document: "Document") -> None:
+    """Validate the existing comments collection before upstream mutates it."""
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    try:
+        part = document.part.part_related_by(RT.COMMENTS)
+    except KeyError:
+        if _part_with_name(document, _COMMENTS_PARTNAME) is not None:
+            raise UnsupportedStructureError(
+                "a package part already occupies /word/comments.xml without"
+                " the document comments relationship; nothing was changed"
+            )
+        return
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple comments relationships make comment authoring"
+            " ambiguous; nothing was changed"
+        ) from None
+
+    root = getattr(part, "_element", None)
+    if root is None or root.tag != _COMMENTS:
+        raise UnsupportedStructureError(
+            "the comments relationship does not target a live w:comments"
+            " part; nothing was changed"
+        )
+    seen: "set[int]" = set()
+    for comment in root.findall(_COMMENT):
+        raw = comment.get(_W_ID)
+        try:
+            if raw is None:
+                raise ValueError
+            comment_id = int(raw)
+        except (TypeError, ValueError):
+            raise UnsupportedStructureError(
+                f"malformed comment w:id={raw!r}; nothing was changed"
+            ) from None
+        if comment_id in seen:
+            raise UnsupportedStructureError(
+                f"duplicate comment w:id={comment_id}; nothing was changed"
+            )
+        seen.add(comment_id)
+
+
+def _validate_para_id(raw: "Optional[str]", *, attribute: str) -> str:
+    if raw is None or len(raw) != 8 or any(
+        character not in "0123456789abcdefABCDEF" for character in raw
+    ):
+        raise UnsupportedStructureError(
+            f"malformed {attribute}={raw!r}; nothing was changed"
+        )
+    return raw
+
 
 def _comments_part(document: "Document"):
     return document.part._comments_part  # noqa: SLF001 - same-package broker
 
 
 def _comment_element(document: "Document", comment: "Comment") -> "_Element":
+    require_comment_owner(document, comment)
     return comment._comment_elm  # noqa: SLF001 - same-package access
 
 
@@ -74,18 +143,22 @@ def _existing_para_ids(comments_root: "_Element") -> "List[int]":
     values = []
     for paragraph in comments_root.iter(_P):
         raw = paragraph.get(_PARA_ID_ATTR)
-        if raw:
-            try:
-                values.append(int(raw, 16))
-            except ValueError:
-                continue
+        if raw is not None:
+            values.append(
+                int(_validate_para_id(raw, attribute="w14:paraId"), 16)
+            )
+    if len(values) != len(set(values)):
+        raise UnsupportedStructureError(
+            "duplicate w14:paraId values make comment threading ambiguous;"
+            " nothing was changed"
+        )
     return values
 
 
 def _ensure_para_id(document: "Document", paragraph: "_Element") -> str:
     existing = paragraph.get(_PARA_ID_ATTR)
-    if existing:
-        return existing
+    if existing is not None:
+        return _validate_para_id(existing, attribute="w14:paraId")
     comments_root = _comments_part(document)._element  # noqa: SLF001
     next_value = max(_existing_para_ids(comments_root), default=0x10000000) + 1
     para_id = f"{next_value:08X}"
@@ -99,6 +172,11 @@ def _comments_extended_root(document: "Document", *, create: bool) -> "Optional[
         extended = part.part_related_by(COMMENTS_EXTENDED_RELATIONSHIP_TYPE)
     except KeyError:
         extended = None
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple commentsExtended relationships make comment threading"
+            " ambiguous; nothing was changed"
+        ) from None
     if extended is not None:
         element = getattr(extended, "_element", None)
         if element is None:  # pragma: no cover - registration in docx/__init__
@@ -107,9 +185,34 @@ def _comments_extended_root(document: "Document", *, create: bool) -> "Optional[
                 " registration is missing, and writing to a parsed copy would"
                 " be silently lost on save"
             )
+        if element.tag != f"{{{_W15_NS}}}commentsEx":
+            raise UnsupportedStructureError(
+                "commentsExtended has an unexpected root element; nothing"
+                " was changed"
+            )
+        seen: "set[str]" = set()
+        for entry in element.findall(_COMMENT_EX):
+            para_id = _validate_para_id(
+                entry.get(_PARA_ID), attribute="w15:paraId"
+            )
+            parent_id = entry.get(_PARA_ID_PARENT)
+            if parent_id is not None:
+                _validate_para_id(parent_id, attribute="w15:paraIdParent")
+            normalized = para_id.upper()
+            if normalized in seen:
+                raise UnsupportedStructureError(
+                    "duplicate w15:paraId values make comment threading"
+                    " ambiguous; nothing was changed"
+                )
+            seen.add(normalized)
         return element
     if not create:
         return None
+    if _part_with_name(document, _COMMENTS_EXTENDED_PARTNAME) is not None:
+        raise UnsupportedStructureError(
+            "a package part already occupies /word/commentsExtended.xml"
+            " without the commentsExtended relationship; nothing was changed"
+        )
     from docx.opc.packuri import PackURI
     from docx.opc.part import XmlPart
 
@@ -122,6 +225,16 @@ def _comments_extended_root(document: "Document", *, create: bool) -> "Optional[
     )
     part.relate_to(new_part, COMMENTS_EXTENDED_RELATIONSHIP_TYPE)
     return root
+
+
+def _preflight_comments_extended_write(document: "Document") -> None:
+    """Validate extension state and any partname needed for its creation."""
+    root = _comments_extended_root(document, create=False)
+    if root is None and _part_with_name(document, _COMMENTS_EXTENDED_PARTNAME) is not None:
+        raise UnsupportedStructureError(
+            "a package part already occupies /word/commentsExtended.xml"
+            " without the commentsExtended relationship; nothing was changed"
+        )
 
 
 def _entry_for(root: "_Element", para_id: str, *, create: bool) -> "Optional[_Element]":
@@ -140,10 +253,11 @@ def _entry_for(root: "_Element", para_id: str, *, create: bool) -> "Optional[_El
 
 def is_resolved(document: "Document", comment: "Comment") -> bool:
     """Whether `comment` is marked resolved (`w15:done`)."""
+    comment_elm = _comment_element(document, comment)
     root = _comments_extended_root(document, create=False)
     if root is None:
         return False
-    para_id = _last_paragraph(_comment_element(document, comment)).get(_PARA_ID_ATTR)
+    para_id = _last_paragraph(comment_elm).get(_PARA_ID_ATTR)
     if not para_id:
         return False
     entry = _entry_for(root, para_id, create=False)
@@ -152,8 +266,12 @@ def is_resolved(document: "Document", comment: "Comment") -> bool:
 
 def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) -> None:
     """Mark `comment` resolved (or reopened) the way Word does."""
+    comment_elm = _comment_element(document, comment)
     _refuse_if_protected(document, "resolve a comment")
-    para_id = _ensure_para_id(document, _last_paragraph(_comment_element(document, comment)))
+    # Validate a pre-existing extension part before adding a paraId to the
+    # comment. An opaque extension must refuse without touching comments.xml.
+    _preflight_comments_extended_write(document)
+    para_id = _ensure_para_id(document, _last_paragraph(comment_elm))
     root = _comments_extended_root(document, create=True)
     entry = _entry_for(root, para_id, create=True)
     entry.set(_DONE, "1" if resolved else "0")
@@ -161,10 +279,11 @@ def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) 
 
 def parent_of(document: "Document", comment: "Comment") -> Optional[int]:
     """The comment-id this comment replies to, or None for a top-level one."""
+    comment_elm = _comment_element(document, comment)
     root = _comments_extended_root(document, create=False)
     if root is None:
         return None
-    para_id = _last_paragraph(_comment_element(document, comment)).get(_PARA_ID_ATTR)
+    para_id = _last_paragraph(comment_elm).get(_PARA_ID_ATTR)
     if not para_id:
         return None
     entry = _entry_for(root, para_id, create=False)
@@ -182,7 +301,7 @@ def _anchor_elements(document: "Document", comment_id: int):
     body = document.element.body
     start = end = reference_run = None
     for node in body.iter(_RANGE_START, _RANGE_END, _REFERENCE):
-        if int(node.get(_W_ID)) != comment_id:
+        if node.get(_W_ID) != str(comment_id):
             continue
         if node.tag == _RANGE_START:
             start = node
@@ -195,6 +314,7 @@ def _anchor_elements(document: "Document", comment_id: int):
 
 def anchored_text(document: "Document", comment: "Comment") -> str:
     """The document text `comment` is anchored to (its range marks' span)."""
+    _comment_element(document, comment)
     start, end, _ = _anchor_elements(document, comment.comment_id)
     if start is None or end is None:
         raise TargetNotFoundError(
@@ -205,14 +325,28 @@ def anchored_text(document: "Document", comment: "Comment") -> str:
     pieces: "List[str]" = []
     root = start.getroottree().getroot()
     inside = False
+    last_paragraph = None
     for node in root.iter():
         if node is start:
             inside = True
             continue
         if node is end:
             break
-        if inside and node.tag == _T:
-            pieces.append(node.text or "")
+        if (
+            inside
+            and is_direct_run_child(node)
+            and node.tag not in (DEL_TEXT, INSTR_TEXT)
+        ):
+            projection = project_run_child(node)
+            if projection.barrier or not projection.text:
+                continue
+            paragraph = node.getparent()
+            while paragraph is not None and paragraph.tag != qn("w:p"):
+                paragraph = paragraph.getparent()
+            if last_paragraph is not None and paragraph is not last_paragraph:
+                pieces.append("\n")
+            last_paragraph = paragraph
+            pieces.append(projection.text)
     return "".join(pieces)
 
 
@@ -228,13 +362,23 @@ def reply(
     """Add a threaded reply to `comment`, anchored to the same text range."""
     if not author:
         raise ValueError("author is required")
-    _refuse_if_protected(document, "reply to a comment")
+    from docx.search import _validate_xml_characters
+
+    _validate_xml_characters(text, argument="text")
+    _validate_xml_characters(author, argument="author")
+    if initials is not None:
+        _validate_xml_characters(initials, argument="initials")
+    if date is not None and not isinstance(date, dt.datetime):
+        raise TypeError("date must be a datetime or None")
     parent_elm = _comment_element(document, comment)
+    _refuse_if_protected(document, "reply to a comment")
     start, end, reference_run = _anchor_elements(document, comment.comment_id)
     if start is None or end is None or reference_run is None:
         raise TargetNotFoundError(
             f"comment {comment.comment_id} has no range anchor to thread onto"
         )
+    _preflight_comment_add(document)
+    _preflight_comments_extended_write(document)
     parent_para_id = _ensure_para_id(document, _last_paragraph(parent_elm))
 
     new_comment = document.comments.add_comment(
@@ -283,4 +427,3 @@ def comment_thread(document: "Document") -> Tuple[dict, ...]:
             }
         )
     return tuple(entries)
-

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -178,7 +178,7 @@ def _validate_para_id(raw: "Optional[str]", *, attribute: str) -> str:
         or any(character not in "0123456789abcdefABCDEF" for character in raw)
     ):
         raise UnsupportedStructureError(f"malformed {attribute}={raw!r}; nothing was changed")
-    return raw
+    return raw.upper()
 
 
 def _comments_part(document: "Document"):
@@ -290,14 +290,18 @@ def _preflight_comments_extended_write(document: "Document") -> None:
 
 
 def _entry_for(root: "_Element", para_id: str, *, create: bool) -> "Optional[_Element]":
+    normalized = _validate_para_id(para_id, attribute="paragraph id")
     for entry in root.findall(_COMMENT_EX):
-        if entry.get(_PARA_ID) == para_id:
+        existing = _validate_para_id(
+            entry.get(_PARA_ID), attribute="w15:paraId"
+        )
+        if existing == normalized:
             return entry
     if not create:
         return None
     entry = parse_xml(
         '<w15:commentEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"'
-        f' w15:paraId="{para_id}" w15:done="0"/>'
+        f' w15:paraId="{normalized}" w15:done="0"/>'
     )
     root.append(entry)
     return entry
@@ -340,12 +344,18 @@ def parent_of(document: "Document", comment: "Comment") -> Optional[int]:
     if not para_id:
         return None
     entry = _entry_for(root, para_id, create=False)
-    parent_para = entry.get(_PARA_ID_PARENT) if entry is not None else None
-    if not parent_para:
+    raw_parent_para = entry.get(_PARA_ID_PARENT) if entry is not None else None
+    if not raw_parent_para:
         return None
+    parent_para = _validate_para_id(
+        raw_parent_para, attribute="w15:paraIdParent"
+    )
     for candidate in document.comments:
         candidate_elm = _comment_element(document, candidate)
-        if _last_paragraph(candidate_elm).get(_PARA_ID_ATTR) == parent_para:
+        raw_candidate = _last_paragraph(candidate_elm).get(_PARA_ID_ATTR)
+        if raw_candidate is not None and _validate_para_id(
+            raw_candidate, attribute="w14:paraId"
+        ) == parent_para:
             return candidate.comment_id
     return None
 

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -43,10 +43,11 @@ _W_ID = qn("w:id")
 _RANGE_START = qn("w:commentRangeStart")
 _RANGE_END = qn("w:commentRangeEnd")
 _REFERENCE = qn("w:commentReference")
+_SDT = qn("w:sdt")
+_FLD_SIMPLE = qn("w:fldSimple")
 
 COMMENTS_EXTENDED_CONTENT_TYPE = (
-    "application/vnd.openxmlformats-officedocument.wordprocessingml"
-    ".commentsExtended+xml"
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml"
 )
 COMMENTS_EXTENDED_RELATIONSHIP_TYPE = (
     "http://schemas.microsoft.com/office/2011/relationships/commentsExtended"
@@ -65,8 +66,13 @@ def _part_with_name(document: "Document", partname: str):
     package = document.part.package
     if package is None:
         return None
+    folded = partname.casefold()
     return next(
-        (part for part in package.iter_parts() if str(part.partname) == partname),
+        (
+            part
+            for part in package.iter_parts()
+            if str(part.partname).casefold() == folded
+        ),
         None,
     )
 
@@ -86,15 +92,13 @@ def _preflight_comment_add(document: "Document") -> None:
         return
     except ValueError:
         raise UnsupportedStructureError(
-            "multiple comments relationships make comment authoring"
-            " ambiguous; nothing was changed"
+            "multiple comments relationships make comment authoring ambiguous; nothing was changed"
         ) from None
 
     root = getattr(part, "_element", None)
     if root is None or root.tag != _COMMENTS:
         raise UnsupportedStructureError(
-            "the comments relationship does not target a live w:comments"
-            " part; nothing was changed"
+            "the comments relationship does not target a live w:comments part; nothing was changed"
         )
     seen: "set[int]" = set()
     for comment in root.findall(_COMMENT):
@@ -114,13 +118,66 @@ def _preflight_comment_add(document: "Document") -> None:
         seen.add(comment_id)
 
 
-def _validate_para_id(raw: "Optional[str]", *, attribute: str) -> str:
-    if raw is None or len(raw) != 8 or any(
-        character not in "0123456789abcdefABCDEF" for character in raw
-    ):
+def _preflight_comment_range(
+    document: "Document", first_run: "_Element", last_run: "_Element", *, operation: str
+) -> None:
+    """Validate only the selected run interval before adding range markers."""
+    _refuse_if_protected(document, operation)
+    nodes = tuple(document.element.iter())
+    positions = {id(node): index for index, node in enumerate(nodes)}
+    first = positions.get(id(first_run))
+    last = positions.get(id(last_run))
+    if first is None or last is None:
+        raise TargetNotFoundError("comment range runs are stale or detached; reacquire the span")
+    if first > last:
+        raise UnsupportedStructureError("comment range endpoints are reversed; nothing was changed")
+    interval = nodes[first : last + 1]
+    selected_runs = [node for node in interval if node.tag == _R]
+    if any(next(run.iter(qn("w:fldChar")), None) is not None for run in selected_runs):
         raise UnsupportedStructureError(
-            f"malformed {attribute}={raw!r}; nothing was changed"
+            "cannot anchor a comment across a complex field boundary; nothing was changed"
         )
+    selected_ids = {id(run) for run in selected_runs}
+    depth = 0
+    for node in nodes:
+        if node.tag == qn("w:fldChar"):
+            kind = node.get(qn("w:fldCharType"))
+            if kind == "begin":
+                depth += 1
+            elif kind == "end" and depth:
+                depth -= 1
+        if id(node) in selected_ids and depth:
+            raise UnsupportedStructureError(
+                "cannot anchor a comment inside a complex field; nothing was changed"
+            )
+    for run in selected_runs:
+        current = run.getparent()
+        while current is not None:
+            if current.tag == _FLD_SIMPLE:
+                raise UnsupportedStructureError(
+                    "cannot anchor a comment inside a field; nothing was changed"
+                )
+            current = current.getparent()
+    from docx.controls import _refuse_control_write_restrictions
+
+    controls = []
+    for node in interval:
+        current = node
+        while current is not None:
+            if current.tag == _SDT and not any(current is item for item in controls):
+                controls.append(current)
+            current = current.getparent()
+    for control in controls:
+        _refuse_control_write_restrictions(control)
+
+
+def _validate_para_id(raw: "Optional[str]", *, attribute: str) -> str:
+    if (
+        raw is None
+        or len(raw) != 8
+        or any(character not in "0123456789abcdefABCDEF" for character in raw)
+    ):
+        raise UnsupportedStructureError(f"malformed {attribute}={raw!r}; nothing was changed")
     return raw
 
 
@@ -145,13 +202,10 @@ def _existing_para_ids(comments_root: "_Element") -> "List[int]":
     for paragraph in comments_root.iter(_P):
         raw = paragraph.get(_PARA_ID_ATTR)
         if raw is not None:
-            values.append(
-                int(_validate_para_id(raw, attribute="w14:paraId"), 16)
-            )
+            values.append(int(_validate_para_id(raw, attribute="w14:paraId"), 16))
     if len(values) != len(set(values)):
         raise UnsupportedStructureError(
-            "duplicate w14:paraId values make comment threading ambiguous;"
-            " nothing was changed"
+            "duplicate w14:paraId values make comment threading ambiguous; nothing was changed"
         )
     return values
 
@@ -188,14 +242,11 @@ def _comments_extended_root(document: "Document", *, create: bool) -> "Optional[
             )
         if element.tag != f"{{{_W15_NS}}}commentsEx":
             raise UnsupportedStructureError(
-                "commentsExtended has an unexpected root element; nothing"
-                " was changed"
+                "commentsExtended has an unexpected root element; nothing was changed"
             )
         seen: "set[str]" = set()
         for entry in element.findall(_COMMENT_EX):
-            para_id = _validate_para_id(
-                entry.get(_PARA_ID), attribute="w15:paraId"
-            )
+            para_id = _validate_para_id(entry.get(_PARA_ID), attribute="w15:paraId")
             parent_id = entry.get(_PARA_ID_PARENT)
             if parent_id is not None:
                 _validate_para_id(parent_id, attribute="w15:paraIdParent")
@@ -301,7 +352,9 @@ def parent_of(document: "Document", comment: "Comment") -> Optional[int]:
 
 def _anchor_elements(document: "Document", comment_id: int):
     body = document.element.body
-    start = end = reference_run = None
+    starts = []
+    ends = []
+    reference_runs = []
     for node in body.iter(_RANGE_START, _RANGE_END, _REFERENCE):
         raw = node.get(_W_ID)
         try:
@@ -311,18 +364,25 @@ def _anchor_elements(document: "Document", comment_id: int):
         except (TypeError, ValueError):
             name = node.tag.rsplit("}", 1)[-1]
             raise UnsupportedStructureError(
-                f"malformed {name} comment marker w:id={raw!r}; nothing was"
-                " changed"
+                f"malformed {name} comment marker w:id={raw!r}; nothing was changed"
             ) from None
         if marker_id != comment_id:
             continue
         if node.tag == _RANGE_START:
-            start = node
+            starts.append(node)
         elif node.tag == _RANGE_END:
-            end = node
+            ends.append(node)
         else:
-            reference_run = node.getparent()
-    return start, end, reference_run
+            reference_runs.append(node.getparent())
+    if any(len(markers) > 1 for markers in (starts, ends, reference_runs)):
+        raise UnsupportedStructureError(
+            f"comment {comment_id} has duplicate anchor markers; nothing was changed"
+        )
+    return (
+        starts[0] if starts else None,
+        ends[0] if ends else None,
+        reference_runs[0] if reference_runs else None,
+    )
 
 
 def anchored_text(document: "Document", comment: "Comment") -> str:
@@ -330,9 +390,7 @@ def anchored_text(document: "Document", comment: "Comment") -> str:
     _comment_element(document, comment)
     start, end, _ = _anchor_elements(document, comment.comment_id)
     if start is None or end is None:
-        raise TargetNotFoundError(
-            f"comment {comment.comment_id} has no range anchor in the body"
-        )
+        raise TargetNotFoundError(f"comment {comment.comment_id} has no range anchor in the body")
     # document-order walk over the whole story tree: comment ranges may
     # cross paragraph boundaries, where sibling iteration would truncate
     pieces: "List[str]" = []
@@ -345,11 +403,7 @@ def anchored_text(document: "Document", comment: "Comment") -> str:
             continue
         if node is end:
             break
-        if (
-            inside
-            and is_direct_run_child(node)
-            and node.tag not in (DEL_TEXT, INSTR_TEXT)
-        ):
+        if inside and is_direct_run_child(node) and node.tag not in (DEL_TEXT, INSTR_TEXT):
             projection = project_run_child(node)
             if projection.barrier or not projection.text:
                 continue
@@ -390,6 +444,33 @@ def reply(
         raise TargetNotFoundError(
             f"comment {comment.comment_id} has no range anchor to thread onto"
         )
+    ordered = tuple(document.element.iter())
+    positions = {id(node): index for index, node in enumerate(ordered)}
+    start_position = positions.get(id(start))
+    end_position = positions.get(id(end))
+    if (
+        start_position is None
+        or end_position is None
+        or start_position >= end_position
+    ):
+        raise UnsupportedStructureError(
+            "comment range markers are stale, reversed, or detached; nothing was changed"
+        )
+    anchored_runs = [
+        node
+        for node in ordered[start_position + 1 : end_position]
+        if node.tag == _R
+    ]
+    if not anchored_runs:
+        raise UnsupportedStructureError(
+            "comment range contains no live runs to anchor a reply; nothing was changed"
+        )
+    _preflight_comment_range(
+        document,
+        anchored_runs[0],
+        anchored_runs[-1],
+        operation="reply to a comment",
+    )
     _preflight_comment_add(document)
     _preflight_comments_extended_write(document)
     with rollback_on_error(document):
@@ -403,15 +484,11 @@ def reply(
         new_para_id = _ensure_para_id(document, _last_paragraph(new_elm))
 
         new_id = new_comment.comment_id
-        start.addnext(
-            parse_xml(f'<w:commentRangeStart {_W_DECL} w:id="{new_id}"/>')
-        )
-        end.addprevious(
-            parse_xml(f'<w:commentRangeEnd {_W_DECL} w:id="{new_id}"/>')
-        )
+        start.addnext(parse_xml(f'<w:commentRangeStart {_W_DECL} w:id="{new_id}"/>'))
+        end.addprevious(parse_xml(f'<w:commentRangeEnd {_W_DECL} w:id="{new_id}"/>'))
         reference_run.addnext(
             parse_xml(
-                f"<w:r {_W_DECL}><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr>"
+                f'<w:r {_W_DECL}><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr>'
                 f'<w:commentReference w:id="{new_id}"/></w:r>'
             )
         )
@@ -430,8 +507,7 @@ def comment_thread(document: "Document") -> Tuple[dict, ...]:
         comments = document.comments
     except ValueError:
         raise UnsupportedStructureError(
-            "multiple comments relationships make comment inspection"
-            " ambiguous; nothing was changed"
+            "multiple comments relationships make comment inspection ambiguous; nothing was changed"
         ) from None
     entries = []
     for comment in comments:

--- a/src/docx/comments.py
+++ b/src/docx/comments.py
@@ -25,7 +25,11 @@ def _document_for_comments_part(comments_part: "CommentsPart") -> "Optional[Docu
     package = comments_part.package
     if package is None:
         return None
-    document = getattr(package.main_document_part, "document", None)
+    try:
+        document_part = package.main_document_part
+    except KeyError:
+        return None
+    document = getattr(document_part, "document", None)
     from docx.document import Document
     from docx.opc.constants import RELATIONSHIP_TYPE as RT
 

--- a/src/docx/comments.py
+++ b/src/docx/comments.py
@@ -29,6 +29,11 @@ def _document_for_comments_part(comments_part: "CommentsPart") -> "Optional[Docu
         document_part = package.main_document_part
     except KeyError:
         return None
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple main-document relationships make comment mutation"
+            " ambiguous; nothing was changed"
+        ) from None
     document = getattr(document_part, "document", None)
     from docx.document import Document
     from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -179,16 +184,30 @@ class Comment(BlockItemContainer):
         the default style for comments.
         """
         document = self._validate_live("edit a comment")
+        previous_last = None
         if document is not None:
-            from docx.commentops import _preflight_comment_add
+            from docx.commentops import (
+                _last_paragraph,
+                _preflight_comment_add,
+                _preflight_comments_extended_write,
+            )
 
             _preflight_comment_add(document)
+            _preflight_comments_extended_write(document)
+            previous_last = _last_paragraph(self._comment_elm)
 
         def add() -> Paragraph:
             paragraph = super(Comment, self).add_paragraph(text, style)
             # Assign directly because paragraph.style raises when the style is absent.
             if style is None:
                 paragraph._p.style = "CommentText"
+            if document is not None:
+                from docx.commentops import _migrate_comment_extension
+
+                assert previous_last is not None
+                _migrate_comment_extension(
+                    document, self._comment_elm, previous_last
+                )
             return paragraph
 
         if document is not None:
@@ -204,13 +223,28 @@ class Comment(BlockItemContainer):
     def add_table(self, rows: int, cols: int, width: Length) -> Table:
         """Return a table appended to this comment."""
         document = self._validate_live("edit a comment")
+        previous_last = None
         if document is not None:
-            from docx.commentops import _preflight_comment_add
+            from docx.commentops import (
+                _last_paragraph,
+                _preflight_comment_add,
+                _preflight_comments_extended_write,
+            )
 
             _preflight_comment_add(document)
+            _preflight_comments_extended_write(document)
+            previous_last = _last_paragraph(self._comment_elm)
 
         def add() -> Table:
-            return super(Comment, self).add_table(rows, cols, width)
+            table = super(Comment, self).add_table(rows, cols, width)
+            if document is not None:
+                from docx.commentops import _migrate_comment_extension
+
+                assert previous_last is not None
+                _migrate_comment_extension(
+                    document, self._comment_elm, previous_last
+                )
+            return table
 
         if document is not None:
             from docx._transaction import rollback_on_error

--- a/src/docx/comments.py
+++ b/src/docx/comments.py
@@ -1,17 +1,59 @@
+# pyright: reportPrivateUsage=false
+
 """Collection providing access to comments added to this document."""
 
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Callable, Iterator, Optional, cast
 
 from docx.blkcntnr import BlockItemContainer
+from docx.errors import TargetNotFoundError, UnsupportedStructureError
 
 if TYPE_CHECKING:
+    from docx.document import Document
     from docx.oxml.comments import CT_Comment, CT_Comments
     from docx.parts.comments import CommentsPart
+    from docx.shared import Length
     from docx.styles.style import ParagraphStyle
+    from docx.table import Table
     from docx.text.paragraph import Paragraph
+
+
+def _document_for_comments_part(comments_part: "CommentsPart") -> "Optional[Document]":
+    """Return the live owning document, or None for a standalone test part."""
+    package = comments_part.package
+    if package is None:
+        return None
+    document = getattr(package.main_document_part, "document", None)
+    from docx.document import Document
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    if not isinstance(document, Document):
+        return None
+    try:
+        live_part = document.part.part_related_by(RT.COMMENTS)
+    except KeyError:
+        raise TargetNotFoundError(
+            "comment proxy is stale: its part was removed from the document"
+        ) from None
+    except ValueError:
+        raise UnsupportedStructureError(
+            "multiple comments relationships make comment mutation ambiguous;"
+            " nothing was changed"
+        ) from None
+    if live_part is not comments_part:
+        raise TargetNotFoundError(
+            "comment proxy is stale: its part was replaced in the document"
+        )
+    return document
+
+
+def _refuse_document_protection(document: "Document", operation: str) -> None:
+    from docx.protection import _refuse_if_protected  # pyright: ignore[reportUnknownVariableType]
+
+    refuse = cast("Callable[[Document, str], None]", _refuse_if_protected)
+    refuse(document, operation)
 
 
 class Comments:
@@ -54,25 +96,40 @@ class Comments:
         `initials` is an optional attribute, set to the empty string by default. Passing |None|
         for the `initials` parameter causes that attribute to be omitted from the XML.
         """
-        comment_elm = self._comments_elm.add_comment()
-        comment_elm.author = author
-        comment_elm.initials = initials
-        comment_elm.date = dt.datetime.now(dt.timezone.utc)
-        comment = Comment(comment_elm, self._comments_part)
+        if self._comments_elm is not self._comments_part._element:
+            raise TargetNotFoundError(
+                "comments collection is stale: reacquire it from the document"
+            )
+        document = _document_for_comments_part(self._comments_part)
+        if document is not None:
+            from docx.commentops import _preflight_comment_add
 
-        if text == "":
+            _refuse_document_protection(document, "add a comment")
+            _preflight_comment_add(document)
+
+        def add() -> Comment:
+            comment_elm = self._comments_elm.add_comment()
+            comment_elm.author = author
+            comment_elm.initials = initials
+            comment_elm.date = dt.datetime.now(dt.timezone.utc)
+            comment = Comment(comment_elm, self._comments_part)
+            if text == "":
+                return comment
+            para_text_iter = iter(text.split("\n"))
+            comment.paragraphs[0].add_run(next(para_text_iter))
+            for paragraph_text in para_text_iter:
+                comment.add_paragraph(text=paragraph_text)
             return comment
 
-        para_text_iter = iter(text.split("\n"))
+        if document is not None:
+            from docx._transaction import rollback_on_error
 
-        first_para_text = next(para_text_iter)
-        first_para = comment.paragraphs[0]
-        first_para.add_run(first_para_text)
+            with rollback_on_error(document, self):
+                return add()
+        from docx._transaction import rollback_xml_on_error
 
-        for s in para_text_iter:
-            comment.add_paragraph(text=s)
-
-        return comment
+        with rollback_xml_on_error(self._comments_elm):
+            return add()
 
     def get(self, comment_id: int) -> Comment | None:
         """Return the comment identified by `comment_id`, or |None| if not found."""
@@ -98,6 +155,18 @@ class Comment(BlockItemContainer):
         super().__init__(comment_elm, comments_part)
         self._comment_elm = comment_elm
 
+    def _validate_live(self, operation: str):
+        comments_part = cast("CommentsPart", self._parent)
+        document = _document_for_comments_part(comments_part)
+        if document is None:
+            return None
+        if self._comment_elm.getparent() is not comments_part._element:
+            raise TargetNotFoundError(
+                "comment proxy is stale: reacquire it from document.comments"
+            )
+        _refuse_document_protection(document, operation)
+        return document
+
     def add_paragraph(self, text: str = "", style: str | ParagraphStyle | None = None) -> Paragraph:
         """Return paragraph newly added to the end of the content in this container.
 
@@ -105,14 +174,49 @@ class Comment(BlockItemContainer):
         When `style` is |None| or ommitted, the "CommentText" paragraph style is applied, which is
         the default style for comments.
         """
-        paragraph = super().add_paragraph(text, style)
+        document = self._validate_live("edit a comment")
+        if document is not None:
+            from docx.commentops import _preflight_comment_add
 
-        # -- have to assign style directly to element because `paragraph.style` raises when
-        # -- a style is not present in the styles part
-        if style is None:
-            paragraph._p.style = "CommentText"  # pyright: ignore[reportPrivateUsage]
+            _preflight_comment_add(document)
 
-        return paragraph
+        def add() -> Paragraph:
+            paragraph = super(Comment, self).add_paragraph(text, style)
+            # Assign directly because paragraph.style raises when the style is absent.
+            if style is None:
+                paragraph._p.style = "CommentText"
+            return paragraph
+
+        if document is not None:
+            from docx._transaction import rollback_on_error
+
+            with rollback_on_error(document, self):
+                return add()
+        from docx._transaction import rollback_xml_on_error
+
+        with rollback_xml_on_error(self._comment_elm):
+            return add()
+
+    def add_table(self, rows: int, cols: int, width: Length) -> Table:
+        """Return a table appended to this comment."""
+        document = self._validate_live("edit a comment")
+        if document is not None:
+            from docx.commentops import _preflight_comment_add
+
+            _preflight_comment_add(document)
+
+        def add() -> Table:
+            return super(Comment, self).add_table(rows, cols, width)
+
+        if document is not None:
+            from docx._transaction import rollback_on_error
+
+            with rollback_on_error(document, self):
+                return add()
+        from docx._transaction import rollback_xml_on_error
+
+        with rollback_xml_on_error(self._comment_elm):
+            return add()
 
     @property
     def author(self) -> str:
@@ -124,6 +228,7 @@ class Comment(BlockItemContainer):
 
     @author.setter
     def author(self, value: str):
+        self._validate_live("edit a comment")
         self._comment_elm.author = value
 
     @property
@@ -142,6 +247,7 @@ class Comment(BlockItemContainer):
 
     @initials.setter
     def initials(self, value: str | None):
+        self._validate_live("edit a comment")
         self._comment_elm.initials = value
 
     @property

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -26,6 +26,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+from docx._ownership import require_anchor_owner
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
@@ -38,7 +39,10 @@ if TYPE_CHECKING:
 
 _P = qn("w:p")
 _TBL = qn("w:tbl")
+_SDT = qn("w:sdt")
 _SECT_PR = qn("w:sectPr")
+_CUSTOM_XML = qn("w:customXml")
+_DATA_BINDING = qn("w:dataBinding")
 _BOOKMARK_START = qn("w:bookmarkStart")
 _BOOKMARK_END = qn("w:bookmarkEnd")
 _ID = qn("w:id")
@@ -52,8 +56,15 @@ _BLIP = qn("a:blip")
 _IMAGEDATA = "{urn:schemas-microsoft-com:vml}imagedata"
 _R_EMBED = qn("r:embed")
 _R_ID = qn("r:id")
+_R_LINK = qn("r:link")
+_RELATIONSHIP_ATTRIBUTE_PREFIX = (
+    "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+)
+_OFFICE_REL_ID = "{urn:schemas-microsoft-com:office:office}relid"
 _HYPERLINK = qn("w:hyperlink")
 _SDT_ID = qn("w:id")
+
+_BODY_BLOCK_TAGS = frozenset((_P, _TBL, _SDT))
 
 _STYLE_REF_TAGS = (qn("w:pStyle"), qn("w:rStyle"), qn("w:tblStyle"))
 _STYLE_CHAIN_TAGS = (qn("w:basedOn"), qn("w:link"), qn("w:next"))
@@ -62,6 +73,8 @@ _STYLE_CHAIN_TAGS = (qn("w:basedOn"), qn("w:link"), qn("w:next"))
 _REFUSED_TAGS = {
     qn("w:object"): "an embedded OLE object",
     qn("w:altChunk"): "an altChunk import",
+    _CUSTOM_XML: "customXml content whose backing part cannot be carried",
+    _DATA_BINDING: ("a data-bound content control whose custom XML binding cannot be carried"),
     qn("w:footnoteReference"): "a footnote reference (its note cannot be carried)",
     qn("w:endnoteReference"): "an endnote reference (its note cannot be carried)",
     qn("w:commentRangeStart"): "a comment anchor (scrub the source's comments first)",
@@ -102,14 +115,26 @@ class CompositionReport:
             "style_map": dict(sorted(self.style_map.items())),
             "imported_styles": sorted(self.imported_styles),
             "renamed_styles": dict(sorted(self.renamed_styles.items())),
-            "numbering_map": {
-                str(k): v for k, v in sorted(self.numbering_map.items())
-            },
+            "numbering_map": {str(k): v for k, v in sorted(self.numbering_map.items())},
             "media_copied": sorted(self.media_copied),
             "bookmarks_renamed": dict(sorted(self.bookmarks_renamed.items())),
             "findings": [finding.to_dict() for finding in self.findings],
             "declared_parts": sorted(set(self.declared_parts)),
         }
+
+
+@dataclass(frozen=True)
+class _NumberingRemap:
+    source_num_id: int
+    destination_num_id: int
+    destination_abstract_id: int
+    source_num: "_Element"
+    source_abstract: "_Element"
+
+
+@dataclass(frozen=True)
+class _NumberingPlan:
+    remaps: "Tuple[_NumberingRemap, ...]" = ()
 
 
 def insert_blocks_from(
@@ -131,6 +156,10 @@ def insert_blocks_from(
     `anchor` addresses the DESTINATION paragraph to insert after.
     """
     _validate_styles_mode(styles)
+    require_anchor_owner(source, start_anchor, argument="start_anchor")
+    if end_anchor is not None:
+        require_anchor_owner(source, end_anchor, argument="end_anchor")
+    require_anchor_owner(document, anchor)
     _refuse_if_protected(document, "compose content into the document")
     range_elements = _source_range(source, start_anchor, end_anchor, count)
     return _compose(document, source, range_elements, anchor, styles)
@@ -152,24 +181,20 @@ def append_document(
     """
     _validate_styles_mode(styles)
     if section not in ("new_page", "continuous"):
-        raise ValueError(
-            f"section must be 'new_page' or 'continuous', got {section!r}"
-        )
+        raise ValueError(f"section must be 'new_page' or 'continuous', got {section!r}")
     _refuse_if_protected(document, "append a document")
-    range_elements = [
-        child
-        for child in source.element.body
-        if child.tag in (_P, _TBL)
-    ]
+    range_elements = [child for child in source.element.body if child.tag != _SECT_PR]
     if not range_elements:
         raise TargetNotFoundError("the source document body has no blocks")
-    destination_blocks = [
-        child for child in document.element.body if child.tag in (_P, _TBL)
-    ]
+    destination_blocks = [child for child in document.element.body if child.tag in _BODY_BLOCK_TAGS]
     if not destination_blocks:
         raise TargetNotFoundError("the destination document body has no blocks")
     report = _compose(
-        document, source, range_elements, destination_blocks[-1], styles,
+        document,
+        source,
+        range_elements,
+        destination_blocks[-1],
+        styles,
         anchor_is_element=True,
     )
     if section == "new_page":
@@ -185,14 +210,10 @@ def append_document(
 
 def _validate_styles_mode(styles: str) -> None:
     if styles not in ("match_by_name", "import_renamed"):
-        raise ValueError(
-            f"styles must be 'match_by_name' or 'import_renamed', got {styles!r}"
-        )
+        raise ValueError(f"styles must be 'match_by_name' or 'import_renamed', got {styles!r}")
 
 
-def _source_range(
-    source: "Document", start_anchor, end_anchor, count: int
-) -> "List[_Element]":
+def _source_range(source: "Document", start_anchor, end_anchor, count: int) -> "List[_Element]":
     from docx.blocks import _locate_anchor_paragraph
 
     if count < 1:
@@ -200,29 +221,28 @@ def _source_range(
     story, start_p = _locate_anchor_paragraph(source, start_anchor)
     if story != "word/document.xml":
         raise UnsupportedStructureError(
-            f"composition copies from the main document body only"
-            f" (start anchor is in {story})"
+            f"composition copies from the main document body only (start anchor is in {story})"
         )
     body = source.element.body
-    blocks = [child for child in body if child.tag in (_P, _TBL)]
-    if start_p not in blocks:
+    body_children = [child for child in body if child.tag != _SECT_PR]
+    blocks = [child for child in body_children if child.tag in _BODY_BLOCK_TAGS]
+    start_block = _body_block_for_paragraph(body, start_p)
+    if start_block not in blocks:
         raise UnsupportedStructureError(
             "the start anchor is not a top-level body block (text boxes and"
             " table cells cannot anchor a composition range)"
         )
-    start_index = blocks.index(start_p)
+    start_index = blocks.index(start_block)
     if end_anchor is not None:
         end_story, end_p = _locate_anchor_paragraph(source, end_anchor)
-        if end_story != story or end_p not in blocks:
+        end_block = _body_block_for_paragraph(body, end_p)
+        if end_story != story or end_block not in blocks:
             raise UnsupportedStructureError(
-                "the end anchor must be a top-level body block of the same"
-                " source document"
+                "the end anchor must be a top-level body block of the same source document"
             )
-        end_index = blocks.index(end_p)
+        end_index = blocks.index(end_block)
         if end_index < start_index:
-            raise TargetNotFoundError(
-                "end anchor precedes start anchor in the source body"
-            )
+            raise TargetNotFoundError("end anchor precedes start anchor in the source body")
     else:
         end_index = start_index + count - 1
         if end_index >= len(blocks):
@@ -230,7 +250,30 @@ def _source_range(
                 f"the source body has only {len(blocks) - start_index} blocks"
                 f" from the start anchor; {count} requested"
             )
-    return blocks[start_index : end_index + 1]
+    first = body_children.index(blocks[start_index])
+    last = body_children.index(blocks[end_index])
+    # Keep the physical slice. Unsupported body children between selected
+    # blocks must reach preflight and refuse, never disappear by filtering.
+    return body_children[first : last + 1]
+
+
+def _body_block_for_paragraph(body: "_Element", paragraph: "_Element"):
+    """Top-level body block containing `paragraph`, or None.
+
+    A paragraph directly under a top-level block content control addresses
+    that whole control. Paragraphs in top-level tables and other wrappers do
+    not become range anchors merely because they are descendants of `body`.
+    """
+    current = paragraph
+    while current.getparent() is not None and current.getparent() is not body:
+        current = current.getparent()
+    if current.getparent() is not body:
+        return None
+    if current.tag == _P:
+        return current
+    if current.tag == _SDT:
+        return current
+    return None
 
 
 def _compose(
@@ -260,27 +303,27 @@ def _compose(
         story, anchor_p = _resolve_anchor_paragraph(document, anchor)
         if story != "word/document.xml":
             raise UnsupportedStructureError(
-                f"composition inserts into the main document body only"
-                f" (anchor is in {story})"
+                f"composition inserts into the main document body only (anchor is in {story})"
             )
         _refuse_cell_anchor(anchor_p)
-        root = next(
-            r for s, r in _story_elements_of(document) if s == story
-        )
+        root = next(r for s, r in _story_elements_of(document) if s == story)
         _refuse_paragraph_in_open_field(story, root, anchor_p, for_insertion=True)
+    _refuse_malformed_numeric_ids(document, range_elements)
+    _preflight_relationships(source, range_elements)
     chained_definitions = _chained_source_definitions(source, range_elements)
-    _refuse_missing_numbering_part(
-        document, range_elements + chained_definitions
-    )
+    numbering_plan = _preflight_numbering(document, source, range_elements + chained_definitions)
     _refuse_unloadable_media(source, range_elements)
 
     clones = [copy.deepcopy(element) for element in range_elements]
-    imported_definitions = _reconcile_styles(
-        document, source, clones, styles_mode, report
-    )
+    imported_definitions = _reconcile_styles(document, source, clones, styles_mode, report)
     # numbering references live in imported STYLE definitions too — an
     # unmapped one silently binds to unrelated destination numbering
-    _remap_numbering(document, source, clones + imported_definitions, report)
+    _remap_numbering(
+        document,
+        clones + imported_definitions,
+        numbering_plan,
+        report,
+    )
     _copy_media(document, source, clones, report)
     _recreate_hyperlinks(document, source, clones, report)
     _reconcile_bookmarks(document, clones, report)
@@ -306,43 +349,64 @@ def _story_elements_of(document: "Document"):
     return _story_elements(document)
 
 
-def _refuse_missing_numbering_part(
-    document: "Document", range_elements: "List[_Element]"
-) -> None:
-    """Pre-mutation check for the numbering remap's only failure mode."""
-    needs_numbering = any(
-        int(node.get(_VAL) or 0) > 0
-        for element in range_elements
-        for node in element.iter(qn("w:numId"))
-    )
-    if needs_numbering and _numbering_root_of(document) is None:
-        raise UnsupportedStructureError(
-            "the destination document has no numbering part; create a list"
-            " definition first (ensure_bullet_definition /"
-            " ensure_decimal_definition)"
-        )
-
-
-def _chained_source_definitions(
-    source: "Document", elements: "List[_Element]"
-) -> "List[_Element]":
+def _chained_source_definitions(source: "Document", elements: "List[_Element]") -> "List[_Element]":
     """The source style definitions the copied range pulls in (transitive
     basedOn/link/next chains) — they carry numbering references too."""
     _root, by_id, _by_name = _style_definitions(source)
     return [
-        by_id[style_id]
-        for style_id in _expand_style_chain(by_id, _referenced_style_ids(elements))
+        by_id[style_id] for style_id in _expand_style_chain(by_id, _referenced_style_ids(elements))
     ]
 
 
-def _refuse_unloadable_media(
-    source: "Document", range_elements: "List[_Element]"
-) -> None:
+def _preflight_relationships(source: "Document", range_elements: "List[_Element]") -> None:
+    """Refuse every relationship the composition pipeline cannot remap."""
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    for element in range_elements:
+        for node in element.iter():
+            for attribute, r_id in node.attrib.items():
+                if not (
+                    attribute.startswith(_RELATIONSHIP_ATTRIBUTE_PREFIX)
+                    or attribute == _OFFICE_REL_ID
+                ):
+                    continue
+                rel = source.part.rels.get(r_id)
+                if node.tag == _BLIP and attribute == _R_EMBED:
+                    if rel is not None and rel.reltype == RT.IMAGE and not rel.is_external:
+                        continue
+                    _refuse_relationship(node, attribute, r_id, rel, "embedded image")
+                if node.tag == _IMAGEDATA and attribute == _R_ID:
+                    if rel is not None and rel.reltype == RT.IMAGE and not rel.is_external:
+                        continue
+                    _refuse_relationship(node, attribute, r_id, rel, "embedded image")
+                if node.tag == _HYPERLINK and attribute == _R_ID:
+                    if rel is not None and rel.reltype == RT.HYPERLINK and rel.is_external:
+                        continue
+                    _refuse_relationship(node, attribute, r_id, rel, "external hyperlink")
+                expected = "linked image" if attribute == _R_LINK else None
+                _refuse_relationship(node, attribute, r_id, rel, expected)
+
+
+def _refuse_relationship(node, attribute, r_id, rel, expected=None) -> None:
+    node_name = node.tag.rsplit("}", 1)[-1]
+    attribute_name = attribute.rsplit("}", 1)[-1]
+    if rel is None:
+        kind = expected or "unresolved"
+    else:
+        kind = rel.reltype.rsplit("/", 1)[-1]
+        if expected == "linked image":
+            kind = expected
+    raise UnsupportedStructureError(
+        f"the source range contains an unsupported {kind} relationship"
+        f" ({node_name}@{attribute_name}={r_id!r}); composition cannot remap"
+        " it. Nothing was changed"
+    )
+
+
+def _refuse_unloadable_media(source: "Document", range_elements: "List[_Element]") -> None:
     """Pre-mutation check: every image in the range must be re-embeddable,
     or _copy_media would raise AFTER styles/numbering were already imported
     (refusal atomicity)."""
-    import io as _io
-
     from docx.image.exceptions import UnrecognizedImageError
     from docx.image.image import Image
 
@@ -354,7 +418,10 @@ def _refuse_unloadable_media(
                 continue
             rel = source.part.rels.get(r_id)
             if rel is None or rel.is_external:
-                continue  # dropped later with a finding
+                raise UnsupportedStructureError(
+                    f"image relationship {r_id!r} changed after composition"
+                    " preflight. Nothing was changed"
+                )
             try:
                 Image.from_blob(rel.target_part.blob)
             except UnrecognizedImageError:
@@ -369,6 +436,14 @@ def _refuse_unsupported_content(range_elements: "List[_Element]") -> None:
     from docx.revision import _MARKUP_SCAN_TAGS
 
     for element in range_elements:
+        if element.tag not in _BODY_BLOCK_TAGS:
+            reason = _REFUSED_TAGS.get(element.tag)
+            if reason is None:
+                reason = f"unsupported top-level body content {element.tag.rsplit('}', 1)[-1]!r}"
+            raise UnsupportedStructureError(
+                f"the source range contains {reason}; composition cannot"
+                " carry it (a declared limit)"
+            )
         for node in element.iter():
             if node.tag in _MARKUP_SCAN_TAGS:
                 raise UnsupportedStructureError(
@@ -383,12 +458,46 @@ def _refuse_unsupported_content(range_elements: "List[_Element]") -> None:
                 )
 
 
+def _refuse_malformed_numeric_ids(document: "Document", range_elements: "List[_Element]") -> None:
+    """Parse ids used after imports now, while refusal is still atomic."""
+    roots = [root for _story, root in _story_elements_of(document)]
+    roots.extend(range_elements)
+    for root in roots:
+        for marker in root.iter(_BOOKMARK_START, _BOOKMARK_END):
+            raw = marker.get(_ID)
+            try:
+                value = int(raw) if raw is not None else -1
+            except ValueError:
+                value = -1
+            if value < 0:
+                raise UnsupportedStructureError(
+                    "composition found a bookmark marker with a missing or"
+                    f" non-numeric w:id {raw!r}; nothing was changed"
+                )
+        for sdt_pr in root.iter(qn("w:sdtPr")):
+            id_element = sdt_pr.find(_SDT_ID)
+            raw = id_element.get(_VAL) if id_element is not None else None
+            if raw is None:
+                continue
+            try:
+                value = int(raw)
+            except ValueError:
+                value = -1
+            if value < 0:
+                raise UnsupportedStructureError(
+                    "composition found a content control with a non-numeric"
+                    f" w:id {raw!r}; nothing was changed"
+                )
+
+
 # ---------------------------------------------------------------------------
 # styles
 # ---------------------------------------------------------------------------
 
 
-def _style_definitions(document: "Document") -> "Tuple[_Element, Dict[str, _Element], Dict[str, _Element]]":
+def _style_definitions(
+    document: "Document",
+) -> "Tuple[_Element, Dict[str, _Element], Dict[str, _Element]]":
     root = document.styles.element
     by_id: "Dict[str, _Element]" = {}
     by_name: "Dict[str, _Element]" = {}
@@ -414,20 +523,28 @@ def _referenced_style_ids(clones: "List[_Element]") -> "List[str]":
     return seen
 
 
-def _expand_style_chain(
-    source_by_id: "Dict[str, _Element]", wanted: "List[str]"
-) -> "List[str]":
+def _expand_style_chain(source_by_id: "Dict[str, _Element]", wanted: "List[str]") -> "List[str]":
     ordered: "List[str]" = []
-    queue = list(wanted)
+    queue = [(style_id, None, None) for style_id in wanted]
     while queue:
-        style_id = queue.pop(0)
-        if style_id in ordered or style_id not in source_by_id:
+        style_id, parent_style_id, chain_tag = queue.pop(0)
+        if style_id in ordered:
             continue
+        if style_id not in source_by_id:
+            owner = (
+                "the source content"
+                if parent_style_id is None
+                else f"source style {parent_style_id!r} through w:{chain_tag}"
+            )
+            raise UnsupportedStructureError(
+                f"{owner} references undefined source style {style_id!r}; nothing was changed"
+            )
         ordered.append(style_id)
         for tag in _STYLE_CHAIN_TAGS:
-            chained = source_by_id[style_id].find(tag)
-            if chained is not None and chained.get(_VAL):
-                queue.append(chained.get(_VAL))
+            for chained in source_by_id[style_id].findall(tag):
+                chained_style_id = chained.get(_VAL)
+                if chained_style_id:
+                    queue.append((chained_style_id, style_id, tag.rsplit("}", 1)[-1]))
     return ordered
 
 
@@ -450,9 +567,7 @@ def _reconcile_styles(
 ) -> "List[_Element]":
     """Reconcile and remap; returns the IMPORTED definitions (their
     numbering references still need remapping by the caller)."""
-    destination_root, destination_by_id, destination_by_name = _style_definitions(
-        document
-    )
+    destination_root, destination_by_id, destination_by_name = _style_definitions(document)
     _root, source_by_id, _source_by_name = _style_definitions(source)
     wanted = _expand_style_chain(source_by_id, _referenced_style_ids(clones))
     style_map: "Dict[str, str]" = {}
@@ -467,9 +582,7 @@ def _reconcile_styles(
             if mode == "match_by_name":
                 style_map[style_id] = existing.get(qn("w:styleId"))
                 continue
-            if _normalized_style_bytes(existing) == _normalized_style_bytes(
-                definition
-            ):
+            if _normalized_style_bytes(existing) == _normalized_style_bytes(definition):
                 style_map[style_id] = existing.get(qn("w:styleId"))
                 continue
             # import_renamed: clone under a fresh id AND name
@@ -480,22 +593,18 @@ def _reconcile_styles(
             report.renamed_styles[name] = new_name
             to_import.append((new_id, _renamed_clone(definition, new_id, new_name)))
             continue
-        new_id = (
-            style_id
-            if style_id not in taken_ids
-            else _fresh_style_id(taken_ids, style_id)
-        )
+        new_id = style_id if style_id not in taken_ids else _fresh_style_id(taken_ids, style_id)
         taken_ids.add(new_id)
         style_map[style_id] = new_id
         to_import.append((new_id, _renamed_clone(definition, new_id, None)))
     for new_id, definition in to_import:
         # remap chain references to their final destination ids
         for tag in _STYLE_CHAIN_TAGS:
-            chained = definition.find(tag)
-            if chained is not None and chained.get(_VAL) in style_map:
-                chained.set(_VAL, style_map[chained.get(_VAL)])
-            elif chained is not None:
-                definition.remove(chained)  # dangling chain link
+            for chained in definition.findall(tag):
+                if chained.get(_VAL) in style_map:
+                    chained.set(_VAL, style_map[chained.get(_VAL)])
+                else:
+                    definition.remove(chained)  # empty/malformed chain link
         destination_root.append(definition)
         report.imported_styles.append(new_id)
         destination_by_id[new_id] = definition
@@ -509,9 +618,7 @@ def _reconcile_styles(
     return [definition for _new_id, definition in to_import]
 
 
-def _renamed_clone(
-    definition: "_Element", new_id: str, new_name: Optional[str]
-) -> "_Element":
+def _renamed_clone(definition: "_Element", new_id: str, new_name: Optional[str]) -> "_Element":
     clone = copy.deepcopy(definition)
     clone.set(qn("w:styleId"), new_id)
     if new_name is not None:
@@ -550,13 +657,173 @@ def _numbering_root_of(document: "Document") -> "Optional[_Element]":
     return _numbering_root(document)
 
 
-def _remap_numbering(
+def _preflight_numbering(
     document: "Document",
     source: "Document",
+    elements: "List[_Element]",
+) -> _NumberingPlan:
+    """Validate both numbering graphs and allocate every remap up front."""
+    referenced = _referenced_numbering_ids(elements)
+    if not referenced:
+        return _NumberingPlan()
+
+    source_root = _numbering_root_of(source)
+    if source_root is None:
+        raise UnsupportedStructureError(
+            "the source content references numbering but the source document"
+            " has no numbering part. Nothing was changed"
+        )
+    destination_root = _numbering_root_of(document)
+    if destination_root is None:
+        raise UnsupportedStructureError(
+            "the destination document has no numbering part; create a list"
+            " definition first (ensure_bullet_definition /"
+            " ensure_decimal_definition)"
+        )
+
+    source_nums, source_abstracts, source_abstract_refs = _validated_numbering_graph(
+        source_root, "source numbering"
+    )
+    destination_nums, destination_abstracts, _destination_abstract_refs = (
+        _validated_numbering_graph(destination_root, "destination numbering")
+    )
+
+    next_num_id = max(destination_nums, default=0) + 1
+    next_abstract_id = max(destination_abstracts, default=-1) + 1
+    remaps = []
+    for source_num_id in referenced:
+        source_num = source_nums.get(source_num_id)
+        if source_num is None:
+            raise UnsupportedStructureError(
+                f"source numbering id {source_num_id} has no w:num definition. Nothing was changed"
+            )
+        source_abstract_id = source_abstract_refs[source_num_id]
+        source_abstract = source_abstracts[source_abstract_id]
+        if any(source_abstract.iter(qn("w:lvlPicBulletId"))):
+            raise UnsupportedStructureError(
+                f"source numbering id {source_num_id} uses a picture bullet;"
+                " composition cannot carry its numbering-part relationships."
+                " Nothing was changed"
+            )
+        remaps.append(
+            _NumberingRemap(
+                source_num_id=source_num_id,
+                destination_num_id=next_num_id,
+                destination_abstract_id=next_abstract_id,
+                source_num=source_num,
+                source_abstract=source_abstract,
+            )
+        )
+        next_num_id += 1
+        next_abstract_id += 1
+    return _NumberingPlan(tuple(remaps))
+
+
+def _referenced_numbering_ids(elements: "List[_Element]") -> "List[int]":
+    referenced = []
+    for element in elements:
+        for num_id_element in element.iter(qn("w:numId")):
+            num_id = _parse_numbering_id(
+                num_id_element.get(_VAL),
+                "source content has a w:numId with",
+            )
+            if num_id > 0 and num_id not in referenced:
+                referenced.append(num_id)
+    return referenced
+
+
+def _validated_numbering_graph(
+    root: "_Element", label: str
+) -> "Tuple[Dict[int, _Element], Dict[int, _Element], Dict[int, int]]":
+    picture_ids = _index_numbering_elements(
+        root.findall(qn("w:numPicBullet")),
+        qn("w:numPicBulletId"),
+        label,
+        "w:numPicBullet",
+    )
+    abstracts = _index_numbering_elements(
+        root.findall(qn("w:abstractNum")),
+        qn("w:abstractNumId"),
+        label,
+        "w:abstractNum",
+    )
+    nums = _index_numbering_elements(
+        root.findall(qn("w:num")),
+        qn("w:numId"),
+        label,
+        "w:num",
+    )
+
+    abstract_refs: "Dict[int, int]" = {}
+    for num_id, num in nums.items():
+        refs = num.findall(qn("w:abstractNumId"))
+        if len(refs) != 1:
+            raise UnsupportedStructureError(
+                f"{label} w:num {num_id} must contain exactly one"
+                " w:abstractNumId. Nothing was changed"
+            )
+        abstract_id = _parse_numbering_id(
+            refs[0].get(_VAL),
+            f"{label} w:num {num_id} has a w:abstractNumId with",
+        )
+        if abstract_id not in abstracts:
+            raise UnsupportedStructureError(
+                f"{label} w:num {num_id} references missing abstract"
+                f" numbering definition {abstract_id}. Nothing was changed"
+            )
+        abstract_refs[num_id] = abstract_id
+
+    for abstract_id, abstract in abstracts.items():
+        for picture_ref in abstract.iter(qn("w:lvlPicBulletId")):
+            picture_id = _parse_numbering_id(
+                picture_ref.get(_VAL),
+                f"{label} w:abstractNum {abstract_id} has a w:lvlPicBulletId with",
+            )
+            if picture_id not in picture_ids:
+                raise UnsupportedStructureError(
+                    f"{label} w:abstractNum {abstract_id} references missing"
+                    f" picture-bullet definition {picture_id}. Nothing was"
+                    " changed"
+                )
+    return nums, abstracts, abstract_refs
+
+
+def _index_numbering_elements(
+    elements, attribute, label: str, element_name: str
+) -> "Dict[int, _Element]":
+    indexed = {}
+    for element in elements:
+        value = _parse_numbering_id(
+            element.get(attribute),
+            f"{label} has a {element_name} with",
+        )
+        if value in indexed:
+            raise UnsupportedStructureError(
+                f"{label} contains duplicate {element_name} id {value}. Nothing was changed"
+            )
+        indexed[value] = element
+    return indexed
+
+
+def _parse_numbering_id(raw: Optional[str], prefix: str) -> int:
+    try:
+        value = int(raw) if raw is not None else -1
+    except ValueError:
+        value = -1
+    if value < 0:
+        raise UnsupportedStructureError(
+            f"{prefix} missing or non-numeric id {raw!r}. Nothing was changed"
+        )
+    return value
+
+
+def _remap_numbering(
+    document: "Document",
     clones: "List[_Element]",
+    plan: _NumberingPlan,
     report: CompositionReport,
 ) -> None:
-    referenced: "List[int]" = []
+    referenced = []
     for clone in clones:
         for num_id_element in clone.iter(qn("w:numId")):
             value = num_id_element.get(_VAL)
@@ -564,90 +831,31 @@ def _remap_numbering(
                 referenced.append(int(value))
     if not referenced:
         return
-    source_root = _numbering_root_of(source)
     destination_root = _numbering_root_of(document)
     numbering_map: "Dict[int, int]" = {}
-    for num_id in referenced:
-        source_num = _find_num(source_root, num_id)
-        if source_num is None:
-            for clone in clones:
-                _strip_num_refs(clone, num_id)
-            report.findings.append(
-                CompositionFinding(
-                    kind="numbering_reference_stripped",
-                    detail=(
-                        f"source numbering id {num_id} has no definition;"
-                        " the reference was stripped"
-                    ),
-                )
-            )
+    for remap in plan.remaps:
+        if remap.source_num_id not in referenced:
             continue
-        abstract_ref = source_num.find(qn("w:abstractNumId"))
-        source_abstract = (
-            _find_abstract(source_root, abstract_ref.get(_VAL))
-            if abstract_ref is not None
-            else None
-        )
-        new_num_id = _max_attr(destination_root, qn("w:num"), qn("w:numId")) + 1
-        new_abstract_id = (
-            _max_attr(destination_root, qn("w:abstractNum"), qn("w:abstractNumId")) + 1
-        )
-        if source_abstract is not None:
-            abstract_clone = copy.deepcopy(source_abstract)
-            abstract_clone.set(qn("w:abstractNumId"), str(new_abstract_id))
-            # nsid/tmpl uniqueness is advisory; leaving them is Word-tolerated
-            first_num = destination_root.find(qn("w:num"))
-            if first_num is not None:
-                first_num.addprevious(abstract_clone)
-            else:
-                destination_root.append(abstract_clone)
-        num_clone = copy.deepcopy(source_num)
-        num_clone.set(qn("w:numId"), str(new_num_id))
+        abstract_clone = copy.deepcopy(remap.source_abstract)
+        abstract_clone.set(qn("w:abstractNumId"), str(remap.destination_abstract_id))
+        # nsid/tmpl uniqueness is advisory; leaving them is Word-tolerated
+        first_num = destination_root.find(qn("w:num"))
+        if first_num is not None:
+            first_num.addprevious(abstract_clone)
+        else:
+            destination_root.append(abstract_clone)
+        num_clone = copy.deepcopy(remap.source_num)
+        num_clone.set(qn("w:numId"), str(remap.destination_num_id))
         new_ref = num_clone.find(qn("w:abstractNumId"))
-        if new_ref is not None:
-            new_ref.set(_VAL, str(new_abstract_id))
+        new_ref.set(_VAL, str(remap.destination_abstract_id))
         destination_root.append(num_clone)
-        numbering_map[num_id] = new_num_id
+        numbering_map[remap.source_num_id] = remap.destination_num_id
     for clone in clones:
         for num_id_element in clone.iter(qn("w:numId")):
             value = num_id_element.get(_VAL)
             if value and int(value) in numbering_map:
                 num_id_element.set(_VAL, str(numbering_map[int(value)]))
     report.numbering_map = numbering_map
-
-
-def _find_num(root: "Optional[_Element]", num_id: int) -> "Optional[_Element]":
-    if root is None:
-        return None
-    for num in root.findall(qn("w:num")):
-        if num.get(qn("w:numId")) == str(num_id):
-            return num
-    return None
-
-
-def _find_abstract(root: "_Element", abstract_id: Optional[str]) -> "Optional[_Element]":
-    if abstract_id is None:
-        return None
-    for abstract in root.findall(qn("w:abstractNum")):
-        if abstract.get(qn("w:abstractNumId")) == abstract_id:
-            return abstract
-    return None
-
-
-def _max_attr(root: "_Element", element_tag, attr) -> int:
-    values = [
-        int(element.get(attr))
-        for element in root.findall(element_tag)
-        if element.get(attr) is not None
-    ]
-    return max(values, default=0)
-
-
-def _strip_num_refs(clone: "_Element", num_id: int) -> None:
-    for num_pr in list(clone.iter(qn("w:numPr"))):
-        num_id_element = num_pr.find(qn("w:numId"))
-        if num_id_element is not None and num_id_element.get(_VAL) == str(num_id):
-            num_pr.getparent().remove(num_pr)
 
 
 # ---------------------------------------------------------------------------
@@ -661,28 +869,22 @@ def _copy_media(
     clones: "List[_Element]",
     report: CompositionReport,
 ) -> None:
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
     rel_map: "Dict[str, str]" = {}
     for clone in clones:
-        for node in list(clone.iter(_BLIP, _IMAGEDATA)):
+        for node in clone.iter(_BLIP, _IMAGEDATA):
             attr = _R_EMBED if node.tag == _BLIP else _R_ID
             r_id = node.get(attr)
             if not r_id:
                 continue
             if r_id not in rel_map:
                 rel = source.part.rels.get(r_id)
-                if rel is None or rel.is_external:
-                    _remove_holder_run(node)
-                    report.findings.append(
-                        CompositionFinding(
-                            kind="image_reference_stripped",
-                            detail=(
-                                f"image relationship {r_id} could not be"
-                                " resolved in the source; the image was"
-                                " dropped"
-                            ),
-                        )
+                if rel is None or rel.is_external or rel.reltype != RT.IMAGE:
+                    raise UnsupportedStructureError(
+                        f"image relationship {r_id!r} changed after composition"
+                        " preflight. Nothing was changed"
                     )
-                    continue
                 blob = rel.target_part.blob
                 new_r_id, _image = document.part.get_or_add_image(io.BytesIO(blob))
                 rel_map[r_id] = new_r_id
@@ -690,14 +892,6 @@ def _copy_media(
                     str(document.part.rels[new_r_id].target_part.partname).lstrip("/")
                 )
             node.set(attr, rel_map[r_id])
-
-
-def _remove_holder_run(node: "_Element") -> None:
-    holder = node
-    while holder.getparent() is not None and holder.tag != qn("w:r"):
-        holder = holder.getparent()
-    if holder.getparent() is not None:
-        holder.getparent().remove(holder)
 
 
 def _recreate_hyperlinks(
@@ -714,25 +908,12 @@ def _recreate_hyperlinks(
             if not r_id:
                 continue  # internal anchor link: carried as-is
             rel = source.part.rels.get(r_id)
-            if rel is None or not rel.is_external:
-                # flatten a dangling/internal-target link to its text
-                parent = hyperlink.getparent()
-                for child in list(hyperlink):
-                    hyperlink.addprevious(child)
-                parent.remove(hyperlink)
-                report.findings.append(
-                    CompositionFinding(
-                        kind="hyperlink_flattened",
-                        detail=(
-                            f"hyperlink relationship {r_id} could not be"
-                            " recreated; the link was flattened to text"
-                        ),
-                    )
+            if rel is None or not rel.is_external or rel.reltype != RT.HYPERLINK:
+                raise UnsupportedStructureError(
+                    f"hyperlink relationship {r_id!r} changed after composition"
+                    " preflight. Nothing was changed"
                 )
-                continue
-            new_r_id = document.part.relate_to(
-                rel.target_ref, RT.HYPERLINK, is_external=True
-            )
+            new_r_id = document.part.relate_to(rel.target_ref, RT.HYPERLINK, is_external=True)
             hyperlink.set(_R_ID, new_r_id)
 
 
@@ -792,15 +973,12 @@ def _reconcile_bookmarks(
                     CompositionFinding(
                         kind="bookmark_partially_in_range",
                         detail=(
-                            "a bookmark end whose start lies outside the"
-                            " copied range was dropped"
+                            "a bookmark end whose start lies outside the copied range was dropped"
                         ),
                     )
                 )
     # starts whose end never appeared in the range are half-pairs too
-    ends_present = {
-        end.get(_ID) for clone in clones for end in clone.iter(_BOOKMARK_END)
-    }
+    ends_present = {end.get(_ID) for clone in clones for end in clone.iter(_BOOKMARK_END)}
     for clone in clones:
         for start in list(clone.iter(_BOOKMARK_START)):
             if start.get(_ID) not in ends_present:
@@ -823,12 +1001,18 @@ def _reconcile_bookmarks(
 
 
 def _fresh_bookmark_name(existing: set, base: str) -> str:
-    candidate = f"{base}_imported"
+    # Imported names are authored by this package, so they must obey Word's
+    # public bookmark grammar even when the source name did not.
+    stem = "".join(char if char == "_" or char.isalnum() else "_" for char in base)
+    if not stem or not stem[0].isalpha():
+        stem = f"B_{stem}"
     counter = 1
-    while candidate in existing:
+    while True:
+        suffix = "_imported" if counter == 1 else f"_imported{counter}"
+        candidate = f"{stem[: 40 - len(suffix)]}{suffix}"
+        if candidate not in existing:
+            return candidate
         counter += 1
-        candidate = f"{base}_imported{counter}"
-    return candidate
 
 
 def _remap_field_refs(clones: "List[_Element]", renames: "Dict[str, str]") -> None:
@@ -840,31 +1024,50 @@ def _remap_field_refs(clones: "List[_Element]", renames: "Dict[str, str]") -> No
     matched on their CONCATENATION across split w:instrText runs."""
     from docx.bookmarks import _iter_field_instructions
 
-    alternation = re.compile(
-        "|".join(
-            rf"\b{re.escape(old)}\b"
-            for old in sorted(renames, key=len, reverse=True)
-        )
+    lookup = {old.casefold(): new for old, new in renames.items()}
+    alternatives = "|".join(re.escape(old) for old in sorted(renames, key=len, reverse=True))
+    reference_operand = re.compile(
+        rf"(?P<prefix>\b(?:PAGEREF|NOTEREF|REF)\s+)"
+        rf'(?:"(?P<quoted>{alternatives})"|(?P<bare>{alternatives}))'
+        r"(?=\s|$)",
+        re.IGNORECASE,
     )
 
     def rewrite(text: str) -> str:
-        return alternation.sub(lambda match: renames[match.group(0)], text)
+        def replacement(match) -> str:
+            old = match.group("quoted") or match.group("bare")
+            new = lookup[old.casefold()]
+            operand = f'"{new}"' if match.group("quoted") is not None else new
+            return f"{match.group('prefix')}{operand}"
 
-    ref_family = re.compile(r"\b(?:PAGEREF|NOTEREF|REF)\b")
+        return reference_operand.sub(replacement, text)
+
+    def redistribute(nodes: "List[_Element]", instruction: str) -> None:
+        """Write a rewritten concatenation back across its existing nodes."""
+        offset = 0
+        for position, node in enumerate(nodes):
+            if position == len(nodes) - 1:
+                node.text = instruction[offset:]
+                break
+            width = len(node.text or "")
+            node.text = instruction[offset : offset + width]
+            offset += width
+
     for clone in clones:
         for instruction, nodes in _iter_field_instructions(clone):
-            if ref_family.search(instruction):
-                for node in nodes:
-                    if node.text:
-                        node.text = rewrite(node.text)
+            rewritten = rewrite(instruction)
+            if rewritten != instruction:
+                redistribute(nodes, rewritten)
         for node in clone.iter(_FLD_SIMPLE):
             instr = node.get(_INSTR)
-            if instr and ref_family.search(instr):
-                node.set(_INSTR, rewrite(instr))
+            if instr:
+                rewritten = rewrite(instr)
+                if rewritten != instr:
+                    node.set(_INSTR, rewritten)
         for link in clone.iter(_HYPERLINK):
             anchor = link.get(qn("w:anchor"))
-            if anchor and anchor in renames:
-                link.set(qn("w:anchor"), renames[anchor])
+            if anchor and anchor.casefold() in lookup:
+                link.set(qn("w:anchor"), lookup[anchor.casefold()])
 
 
 def _reallocate_sdt_ids(document: "Document", clones: "List[_Element]") -> None:
@@ -887,6 +1090,10 @@ def _reallocate_sdt_ids(document: "Document", clones: "List[_Element]") -> None:
                 id_element.set(_VAL, str(next_id))
                 existing.add(next_id)
                 next_id += 1
+            elif value:
+                kept_id = int(value)
+                existing.add(kept_id)
+                next_id = max(next_id, kept_id + 1)
 
 
 def _pad_adjacent_tables(anchor_p: "_Element", clones: "List[_Element]") -> None:

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from docx._ownership import require_anchor_owner
+from docx._transaction import rollback_on_error
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
@@ -162,7 +163,8 @@ def insert_blocks_from(
     require_anchor_owner(document, anchor)
     _refuse_if_protected(document, "compose content into the document")
     range_elements = _source_range(source, start_anchor, end_anchor, count)
-    return _compose(document, source, range_elements, anchor, styles)
+    with rollback_on_error(document):
+        return _compose(document, source, range_elements, anchor, styles)
 
 
 def append_document(
@@ -189,23 +191,24 @@ def append_document(
     destination_blocks = [child for child in document.element.body if child.tag in _BODY_BLOCK_TAGS]
     if not destination_blocks:
         raise TargetNotFoundError("the destination document body has no blocks")
-    report = _compose(
-        document,
-        source,
-        range_elements,
-        destination_blocks[-1],
-        styles,
-        anchor_is_element=True,
-    )
-    if section == "new_page":
-        break_paragraph = OxmlElement("w:p")
-        run = OxmlElement("w:r")
-        page_break = OxmlElement("w:br")
-        page_break.set(qn("w:type"), "page")
-        run.append(page_break)
-        break_paragraph.append(run)
-        destination_blocks[-1].addnext(break_paragraph)
-    return report
+    with rollback_on_error(document):
+        report = _compose(
+            document,
+            source,
+            range_elements,
+            destination_blocks[-1],
+            styles,
+            anchor_is_element=True,
+        )
+        if section == "new_page":
+            break_paragraph = OxmlElement("w:p")
+            run = OxmlElement("w:r")
+            page_break = OxmlElement("w:br")
+            page_break.set(qn("w:type"), "page")
+            run.append(page_break)
+            break_paragraph.append(run)
+            destination_blocks[-1].addnext(break_paragraph)
+        return report
 
 
 def _validate_styles_mode(styles: str) -> None:

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import copy
 import io
-import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
@@ -296,6 +295,9 @@ def _compose(
     )
 
     report = CompositionReport()
+    has_fields = any(
+        True for element in range_elements for _node in element.iter(_FLD_SIMPLE, qn("w:fldChar"))
+    )
     # ALL refusal conditions run before any mutation (refusal atomicity):
     # importing styles/numbering/media first would leave orphaned
     # definitions behind when the destination anchor turns out invalid
@@ -312,6 +314,7 @@ def _compose(
         root = next(r for s, r in _story_elements_of(document) if s == story)
         _refuse_paragraph_in_open_field(story, root, anchor_p, for_insertion=True)
     _refuse_malformed_numeric_ids(document, range_elements)
+    _preflight_bookmark_references(source, range_elements)
     _preflight_relationships(source, range_elements)
     chained_definitions = _chained_source_definitions(source, range_elements)
     numbering_plan = _preflight_numbering(document, source, range_elements + chained_definitions)
@@ -334,6 +337,10 @@ def _compose(
 
     _pad_adjacent_tables(anchor_p, clones)
     _insert_after(anchor_p, clones)
+    if has_fields:
+        from docx.fields import _set_update_fields_on_open
+
+        _set_update_fields_on_open(document)
     report.inserted_blocks = len(clones)
     report.declared_parts = [
         "word/document.xml",
@@ -355,9 +362,10 @@ def _story_elements_of(document: "Document"):
 def _chained_source_definitions(source: "Document", elements: "List[_Element]") -> "List[_Element]":
     """The source style definitions the copied range pulls in (transitive
     basedOn/link/next chains) — they carry numbering references too."""
-    _root, by_id, _by_name = _style_definitions(source)
+    _root, by_id, by_name = _style_definitions(source)
+    referenced = _referenced_style_ids(elements) + _styleref_style_ids(elements, by_name)
     return [
-        by_id[style_id] for style_id in _expand_style_chain(by_id, _referenced_style_ids(elements))
+        by_id[style_id] for style_id in _expand_style_chain(by_id, referenced)
     ]
 
 
@@ -388,6 +396,58 @@ def _preflight_relationships(source: "Document", range_elements: "List[_Element]
                     _refuse_relationship(node, attribute, r_id, rel, "external hyperlink")
                 expected = "linked image" if attribute == _R_LINK else None
                 _refuse_relationship(node, attribute, r_id, rel, expected)
+
+
+def _preflight_bookmark_references(
+    source: "Document", range_elements: "List[_Element]"
+) -> None:
+    """Refuse references whose bookmark definition is not copied with them."""
+    from docx._fieldcode import bookmark_operands
+    from docx.bookmarks import _iter_field_instructions, list_bookmarks
+
+    bookmarks = list_bookmarks(source)
+    names_by_fold: "Dict[str, set[str]]" = {}
+    for bookmark in bookmarks:
+        names_by_fold.setdefault(bookmark.name.casefold(), set()).add(bookmark.name)
+    ambiguous = sorted(names for names in names_by_fold.values() if len(names) > 1)
+    if ambiguous:
+        raise UnsupportedStructureError(
+            f"source bookmark names are case-ambiguous: {ambiguous}; nothing was changed"
+        )
+
+    starts = {}
+    ends = set()
+    for element in range_elements:
+        for start in element.iter(_BOOKMARK_START):
+            starts[start.get(_ID)] = start.get(_NAME) or ""
+        ends.update(end.get(_ID) for end in element.iter(_BOOKMARK_END))
+    copied = {
+        name.casefold() for bookmark_id, name in starts.items() if bookmark_id in ends
+    }
+    known_names = tuple(bookmark.name for bookmark in bookmarks)
+
+    def validate_instruction(instruction: str) -> None:
+        for operand in bookmark_operands(instruction, implicit_names=known_names):
+            if operand.value.casefold() not in copied:
+                raise UnsupportedStructureError(
+                    f"the source range references bookmark {operand.value!r}, but its"
+                    " definition is outside the copied range. Nothing was changed"
+                )
+
+    for element in range_elements:
+        for instruction, _nodes in _iter_field_instructions(element):
+            validate_instruction(instruction)
+        for simple_field in element.iter(_FLD_SIMPLE):
+            instruction = simple_field.get(_INSTR)
+            if instruction:
+                validate_instruction(instruction)
+        for hyperlink in element.iter(_HYPERLINK):
+            anchor = hyperlink.get(qn("w:anchor"))
+            if anchor and anchor.casefold() not in copied:
+                raise UnsupportedStructureError(
+                    f"the source range links to bookmark {anchor!r}, but its definition"
+                    " is outside the copied range. Nothing was changed"
+                )
 
 
 def _refuse_relationship(node, attribute, r_id, rel, expected=None) -> None:
@@ -500,10 +560,10 @@ def _refuse_malformed_numeric_ids(document: "Document", range_elements: "List[_E
 
 def _style_definitions(
     document: "Document",
-) -> "Tuple[_Element, Dict[str, _Element], Dict[str, _Element]]":
+) -> "Tuple[_Element, Dict[str, _Element], Dict[tuple, _Element]]":
     root = document.styles.element
     by_id: "Dict[str, _Element]" = {}
-    by_name: "Dict[str, _Element]" = {}
+    by_name: "Dict[tuple, _Element]" = {}
     for style in root.findall(qn("w:style")):
         style_id = style.get(qn("w:styleId"))
         name_element = style.find(qn("w:name"))
@@ -511,7 +571,7 @@ def _style_definitions(
         if style_id:
             by_id[style_id] = style
         if name:
-            by_name[name] = style
+            by_name[(name.casefold(), style.get(qn("w:type")) or "paragraph")] = style
     return root, by_id, by_name
 
 
@@ -524,6 +584,28 @@ def _referenced_style_ids(clones: "List[_Element]") -> "List[str]":
                 if value and value not in seen:
                     seen.append(value)
     return seen
+
+
+def _styleref_style_ids(elements: "List[_Element]", source_by_name) -> "List[str]":
+    from docx._fieldcode import command_operand
+    from docx.bookmarks import _iter_field_instructions
+
+    style_ids = []
+    instructions = []
+    for element in elements:
+        instructions.extend(text for text, _nodes in _iter_field_instructions(element))
+        instructions.extend(
+            field.get(_INSTR) for field in element.iter(_FLD_SIMPLE) if field.get(_INSTR)
+        )
+    for instruction in instructions:
+        operand = command_operand(instruction, "STYLEREF")
+        definition = (
+            source_by_name.get((operand.value.casefold(), "paragraph")) if operand else None
+        )
+        style_id = definition.get(qn("w:styleId")) if definition is not None else None
+        if style_id and style_id not in style_ids:
+            style_ids.append(style_id)
+    return style_ids
 
 
 def _expand_style_chain(source_by_id: "Dict[str, _Element]", wanted: "List[str]") -> "List[str]":
@@ -571,8 +653,9 @@ def _reconcile_styles(
     """Reconcile and remap; returns the IMPORTED definitions (their
     numbering references still need remapping by the caller)."""
     destination_root, destination_by_id, destination_by_name = _style_definitions(document)
-    _root, source_by_id, _source_by_name = _style_definitions(source)
-    wanted = _expand_style_chain(source_by_id, _referenced_style_ids(clones))
+    _root, source_by_id, source_by_name = _style_definitions(source)
+    referenced = _referenced_style_ids(clones) + _styleref_style_ids(clones, source_by_name)
+    wanted = _expand_style_chain(source_by_id, referenced)
     style_map: "Dict[str, str]" = {}
     to_import: "List[Tuple[str, _Element]]" = []
     taken_ids = set(destination_by_id)  # incl. ids allocated THIS batch
@@ -580,7 +663,8 @@ def _reconcile_styles(
         definition = source_by_id[style_id]
         name_element = definition.find(qn("w:name"))
         name = name_element.get(_VAL) if name_element is not None else style_id
-        existing = destination_by_name.get(name)
+        style_type = definition.get(qn("w:type")) or "paragraph"
+        existing = destination_by_name.get((name.casefold(), style_type))
         if existing is not None:
             if mode == "match_by_name":
                 style_map[style_id] = existing.get(qn("w:styleId"))
@@ -591,7 +675,7 @@ def _reconcile_styles(
             # import_renamed: clone under a fresh id AND name
             new_id = _fresh_style_id(taken_ids, style_id)
             taken_ids.add(new_id)
-            new_name = _fresh_style_name(destination_by_name, name)
+            new_name = _fresh_style_name(destination_by_name, name, style_type)
             style_map[style_id] = new_id
             report.renamed_styles[name] = new_name
             to_import.append((new_id, _renamed_clone(definition, new_id, new_name)))
@@ -618,7 +702,35 @@ def _reconcile_styles(
                 if value in style_map and style_map[value] != value:
                     node.set(_VAL, style_map[value])
     report.style_map = style_map
+    if report.renamed_styles:
+        _remap_styleref_fields(clones, report.renamed_styles)
     return [definition for _new_id, definition in to_import]
+
+
+def _remap_styleref_fields(elements: "List[_Element]", renames: "Dict[str, str]") -> None:
+    from docx._fieldcode import rewrite_command_operand
+    from docx.bookmarks import _iter_field_instructions
+
+    for element in elements:
+        for instruction, nodes in _iter_field_instructions(element):
+            rewritten = rewrite_command_operand(instruction, "STYLEREF", renames)
+            if rewritten != instruction:
+                offset = 0
+                for position, node in enumerate(nodes):
+                    width = len(node.text or "")
+                    node.text = (
+                        rewritten[offset:]
+                        if position == len(nodes) - 1
+                        else rewritten[offset : offset + width]
+                    )
+                    offset += width
+        for simple_field in element.iter(_FLD_SIMPLE):
+            instruction = simple_field.get(_INSTR)
+            if instruction:
+                simple_field.set(
+                    _INSTR,
+                    rewrite_command_operand(instruction, "STYLEREF", renames),
+                )
 
 
 def _renamed_clone(definition: "_Element", new_id: str, new_name: Optional[str]) -> "_Element":
@@ -640,10 +752,12 @@ def _fresh_style_id(taken_ids, base: str) -> str:
     return candidate
 
 
-def _fresh_style_name(destination_by_name: "Dict[str, _Element]", base: str) -> str:
+def _fresh_style_name(
+    destination_by_name: "Dict[tuple, _Element]", base: str, style_type: str
+) -> str:
     candidate = f"{base} (imported)"
     counter = 1
-    while candidate in destination_by_name:
+    while (candidate.casefold(), style_type) in destination_by_name:
         counter += 1
         candidate = f"{base} (imported {counter})"
     return candidate
@@ -702,6 +816,17 @@ def _preflight_numbering(
             )
         source_abstract_id = source_abstract_refs[source_num_id]
         source_abstract = source_abstracts[source_abstract_id]
+        if (
+            next(
+                source_abstract.iter(qn("w:numStyleLink"), qn("w:styleLink")),
+                None,
+            )
+            is not None
+        ):
+            raise UnsupportedStructureError(
+                f"source numbering id {source_num_id} depends on a linked numbering"
+                " style that composition cannot reconcile. Nothing was changed"
+            )
         if any(source_abstract.iter(qn("w:lvlPicBulletId"))):
             raise UnsupportedStructureError(
                 f"source numbering id {source_num_id} uses a picture bullet;"
@@ -851,7 +976,11 @@ def _remap_numbering(
         num_clone.set(qn("w:numId"), str(remap.destination_num_id))
         new_ref = num_clone.find(qn("w:abstractNumId"))
         new_ref.set(_VAL, str(remap.destination_abstract_id))
-        destination_root.append(num_clone)
+        cleanup = destination_root.find(qn("w:numIdMacAtCleanup"))
+        if cleanup is not None:
+            cleanup.addprevious(num_clone)
+        else:
+            destination_root.append(num_clone)
         numbering_map[remap.source_num_id] = remap.destination_num_id
     for clone in clones:
         for num_id_element in clone.iter(qn("w:numId")):
@@ -930,12 +1059,12 @@ def _reconcile_bookmarks(
 ) -> None:
     from docx.story import _story_elements
 
-    existing_names = set()
+    existing_names_folded = set()
     max_id = 0
     for _story, root in _story_elements(document):
         for start in root.iter(_BOOKMARK_START):
             if start.get(_NAME):
-                existing_names.add(start.get(_NAME))
+                existing_names_folded.add(start.get(_NAME).casefold())
             max_id = max(max_id, int(start.get(_ID) or 0))
         for end in root.iter(_BOOKMARK_END):
             max_id = max(max_id, int(end.get(_ID) or 0))
@@ -957,13 +1086,13 @@ def _reconcile_bookmarks(
             id_map[old_id] = str(next_id)
             start.set(_ID, str(next_id))
             next_id += 1
-            if name in existing_names:
-                new_name = _fresh_bookmark_name(existing_names, name)
+            if name.casefold() in existing_names_folded:
+                new_name = _fresh_bookmark_name(existing_names_folded, name)
                 renames[name] = new_name
                 start.set(_NAME, new_name)
-                existing_names.add(new_name)
+                existing_names_folded.add(new_name.casefold())
             else:
-                existing_names.add(name)
+                existing_names_folded.add(name.casefold())
         for end in list(clone.iter(_BOOKMARK_END)):
             old_id = end.get(_ID)
             if old_id in id_map:
@@ -1003,7 +1132,7 @@ def _reconcile_bookmarks(
     report.bookmarks_renamed = renames
 
 
-def _fresh_bookmark_name(existing: set, base: str) -> str:
+def _fresh_bookmark_name(existing_folded: set, base: str) -> str:
     # Imported names are authored by this package, so they must obey Word's
     # public bookmark grammar even when the source name did not.
     stem = "".join(char if char == "_" or char.isalnum() else "_" for char in base)
@@ -1013,7 +1142,7 @@ def _fresh_bookmark_name(existing: set, base: str) -> str:
     while True:
         suffix = "_imported" if counter == 1 else f"_imported{counter}"
         candidate = f"{stem[: 40 - len(suffix)]}{suffix}"
-        if candidate not in existing:
+        if candidate.casefold() not in existing_folded:
             return candidate
         counter += 1
 
@@ -1025,25 +1154,13 @@ def _remap_field_refs(clones: "List[_Element]", renames: "Dict[str, str]") -> No
     All renames apply SIMULTANEOUSLY (one alternation pass — sequential
     substitution chains A->B then B->C), and complex-field instructions are
     matched on their CONCATENATION across split w:instrText runs."""
+    from docx._fieldcode import rewrite_bookmark_operands
     from docx.bookmarks import _iter_field_instructions
 
     lookup = {old.casefold(): new for old, new in renames.items()}
-    alternatives = "|".join(re.escape(old) for old in sorted(renames, key=len, reverse=True))
-    reference_operand = re.compile(
-        rf"(?P<prefix>\b(?:PAGEREF|NOTEREF|REF)\s+)"
-        rf'(?:"(?P<quoted>{alternatives})"|(?P<bare>{alternatives}))'
-        r"(?=\s|$)",
-        re.IGNORECASE,
-    )
 
     def rewrite(text: str) -> str:
-        def replacement(match) -> str:
-            old = match.group("quoted") or match.group("bare")
-            new = lookup[old.casefold()]
-            operand = f'"{new}"' if match.group("quoted") is not None else new
-            return f"{match.group('prefix')}{operand}"
-
-        return reference_operand.sub(replacement, text)
+        return rewrite_bookmark_operands(text, renames)
 
     def redistribute(nodes: "List[_Element]", instruction: str) -> None:
         """Write a rewritten concatenation back across its existing nodes."""

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Union
 
 from docx.errors import (
     AmbiguousTargetError,
+    BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
@@ -42,12 +43,28 @@ _T = qn("w:t")
 _R = qn("w:r")
 _P = qn("w:p")
 _RPR = qn("w:rPr")
+_BLOCK_CONTROL_PARENTS = frozenset(
+    qn(tag)
+    for tag in (
+        "w:body",
+        "w:tc",
+        "w:hdr",
+        "w:ftr",
+        "w:footnote",
+        "w:endnote",
+        "w:comment",
+        "w:txbxContent",
+    )
+)
 _SHOWING_PLC_HDR = qn("w:showingPlcHdr")
 _DATA_BINDING = qn("w:dataBinding")
 _DROPDOWN = qn("w:dropDownList")
 _COMBO = qn("w:comboBox")
 _DATE = qn("w:date")
 _FULL_DATE = qn("w:fullDate")
+_DATE_FORMAT = qn("w:dateFormat")
+_LID = qn("w:lid")
+_CALENDAR = qn("w:calendar")
 _LIST_ITEM = qn("w:listItem")
 _DISPLAY_TEXT = qn("w:displayText")
 _LIST_VALUE = qn("w:value")
@@ -57,10 +74,205 @@ _DOC_PART_OBJ = qn("w:docPartObj")
 _GROUP = qn("w:group")
 _CHECKBOX = qn("w14:checkbox")
 _W14_CHECKED = qn("w14:checked")
+_W14_CHECKED_STATE = qn("w14:checkedState")
+_W14_UNCHECKED_STATE = qn("w14:uncheckedState")
 _W14_VAL = qn("w14:val")
+_W14_FONT = qn("w14:font")
+_R_FONTS = qn("w:rFonts")
 
 _CHECKED_GLYPH = "☒"
 _UNCHECKED_GLYPH = "☐"
+
+
+def _control_level(sdt: "_Element", content: "Optional[_Element]") -> str:
+    """Return ``block`` or ``inline`` when the control shape is unambiguous."""
+    parent = sdt.getparent()
+    parent_level = None
+    if parent is not None:
+        if parent.tag == _P:
+            parent_level = "inline"
+        elif parent.tag in _BLOCK_CONTROL_PARENTS:
+            parent_level = "block"
+
+    if content is not None and len(content):
+        has_paragraph = any(child.tag == _P for child in content)
+        has_run = any(child.tag == _R for child in content)
+        if has_paragraph == has_run:
+            raise UnsupportedStructureError(
+                "control content has an ambiguous block/inline shape; nothing was changed"
+            )
+        content_level = "block" if has_paragraph else "inline"
+        if parent_level is not None and content_level != parent_level:
+            raise UnsupportedStructureError(
+                "control content does not match its block/inline parent; nothing was changed"
+            )
+        return content_level
+
+    if parent_level is None:
+        raise UnsupportedStructureError(
+            "empty control has an ambiguous block/inline parent; nothing was changed"
+        )
+    return parent_level
+
+_MONTH_NAMES = (
+    "",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+_WEEKDAY_NAMES = (
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+)
+
+
+def _declared_checkbox_state(
+    checkbox: "_Element", checked: bool
+) -> "Tuple[str, Optional[str]]":
+    """The state glyph/font declared by the control, with Word defaults."""
+    state_tag = _W14_CHECKED_STATE if checked else _W14_UNCHECKED_STATE
+    fallback = _CHECKED_GLYPH if checked else _UNCHECKED_GLYPH
+    state = checkbox.find(state_tag)
+    if state is None:
+        return fallback, None
+    raw = state.get(_W14_VAL)
+    codepoint = -1
+    try:
+        codepoint = int(raw, 16) if raw is not None else -1
+        glyph = chr(codepoint)
+    except (ValueError, OverflowError):
+        glyph = ""
+    if not glyph or 0xD800 <= codepoint <= 0xDFFF:
+        raise UnsupportedStructureError(
+            f"checkbox declares invalid hexadecimal glyph {raw!r}; nothing was changed"
+        )
+    return glyph, state.get(_W14_FONT)
+
+
+def _utc_date_stamp(value: "Union[dt.date, dt.datetime]") -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        stamp = value
+        if stamp.utcoffset() is not None:
+            stamp = stamp.astimezone(dt.timezone.utc)
+    else:
+        stamp = dt.datetime(value.year, value.month, value.day)
+    return stamp.replace(microsecond=0)
+
+
+def _format_declared_date(date_pr: "_Element", stamp: dt.datetime) -> str:
+    """Format ``stamp`` using the supported subset of Word date patterns."""
+    calendar_elm = date_pr.find(_CALENDAR)
+    calendar = calendar_elm.get(_W_VAL) if calendar_elm is not None else None
+    if calendar not in (None, "gregorian"):
+        raise UnsupportedStructureError(
+            f"date control declares unsupported calendar {calendar!r};"
+            " nothing was changed"
+        )
+    format_elm = date_pr.find(_DATE_FORMAT)
+    if format_elm is None:
+        pattern = "yyyy-MM-dd"
+    else:
+        pattern = format_elm.get(_W_VAL) or ""
+        if not pattern:
+            raise UnsupportedStructureError(
+                "date control declares an empty w:dateFormat; nothing was changed"
+            )
+
+    lid_elm = date_pr.find(_LID)
+    language = lid_elm.get(_W_VAL) if lid_elm is not None else None
+    pieces: List[str] = []
+    uses_names = False
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char in ("'", '"'):
+            quote = char
+            index += 1
+            literal: List[str] = []
+            while index < len(pattern) and pattern[index] != quote:
+                literal.append(pattern[index])
+                index += 1
+            if index >= len(pattern):
+                raise UnsupportedStructureError(
+                    f"unsupported date format {pattern!r}: unterminated literal;"
+                    " nothing was changed"
+                )
+            pieces.append("".join(literal))
+            index += 1
+            continue
+        if char == "\\":
+            if index + 1 >= len(pattern):
+                raise UnsupportedStructureError(
+                    f"unsupported date format {pattern!r}: trailing escape;"
+                    " nothing was changed"
+                )
+            pieces.append(pattern[index + 1])
+            index += 2
+            continue
+        if not char.isalpha():
+            pieces.append(char)
+            index += 1
+            continue
+        end = index + 1
+        while end < len(pattern) and pattern[end] == char:
+            end += 1
+        token = pattern[index:end]
+        hour_12 = stamp.hour % 12 or 12
+        replacements = {
+            "d": str(stamp.day),
+            "dd": f"{stamp.day:02d}",
+            "ddd": _WEEKDAY_NAMES[stamp.weekday()][:3],
+            "dddd": _WEEKDAY_NAMES[stamp.weekday()],
+            "M": str(stamp.month),
+            "MM": f"{stamp.month:02d}",
+            "MMM": _MONTH_NAMES[stamp.month][:3],
+            "MMMM": _MONTH_NAMES[stamp.month],
+            "y": str(stamp.year),
+            "yy": f"{stamp.year % 100:02d}",
+            "yyyy": f"{stamp.year:04d}",
+            "H": str(stamp.hour),
+            "HH": f"{stamp.hour:02d}",
+            "h": str(hour_12),
+            "hh": f"{hour_12:02d}",
+            "m": str(stamp.minute),
+            "mm": f"{stamp.minute:02d}",
+            "s": str(stamp.second),
+            "ss": f"{stamp.second:02d}",
+            "t": ("A" if stamp.hour < 12 else "P"),
+            "tt": ("AM" if stamp.hour < 12 else "PM"),
+        }
+        replacement = replacements.get(token)
+        if replacement is None:
+            raise UnsupportedStructureError(
+                f"unsupported date format {pattern!r} (token {token!r});"
+                " nothing was changed"
+            )
+        uses_names = uses_names or token in ("ddd", "dddd", "MMM", "MMMM", "t", "tt")
+        pieces.append(replacement)
+        index = end
+
+    if uses_names and language is not None:
+        normalized_language = language.lower()
+        if normalized_language != "en" and not normalized_language.startswith("en-"):
+            raise UnsupportedStructureError(
+                f"date format {pattern!r} requires locale {language!r}, but only"
+                " English date names are supported; nothing was changed"
+            )
+    return "".join(pieces)
 
 
 @dataclass(frozen=True)
@@ -195,6 +407,33 @@ class Control:
             choices=_choices(self._sdt_pr),
         )
 
+    def _validate_ownership(self) -> None:
+        """Refuse a control no longer active in the document that created it."""
+        story_roots = tuple(root for _story, root in _story_elements(self._document))
+        if any(
+            candidate is self._sdt
+            for root in story_roots
+            for candidate in _iter_sdts(root)
+        ):
+            return
+
+        tree_root = self._sdt
+        while tree_root.getparent() is not None:
+            tree_root = tree_root.getparent()
+        if any(tree_root is root for root in story_roots):
+            raise TargetNotFoundError(
+                "control is stale: it is no longer in the document's active"
+                " content-control traversal"
+            )
+        if tree_root.tag in {root.tag for root in story_roots}:
+            raise BoundaryViolationError(
+                "control belongs to a different document; reacquire it from"
+                " the document that now contains it"
+            )
+        raise TargetNotFoundError(
+            "control is stale: it was removed from its document"
+        )
+
     # -- writing ----------------------------------------------------------
 
     def set_value(self, value: "Union[str, bool, dt.date, dt.datetime]") -> None:
@@ -205,6 +444,7 @@ class Control:
         Dropdown/combo: must match a listItem (dropdown) — combos accept free
         text. Date: date/datetime (stamps `w:fullDate`) or display string.
         """
+        self._validate_ownership()
         _refuse_if_protected(self._document, "set a control value")
         if self.is_data_bound:
             raise UnsupportedStructureError(
@@ -216,7 +456,18 @@ class Control:
         if control_type == "checkbox":
             if not isinstance(value, bool):
                 raise ValueError("checkbox controls take a bool value")
-            self._set_checkbox(value)
+            sdt_pr = self._sdt_pr
+            checkbox = sdt_pr.find(_CHECKBOX) if sdt_pr is not None else None
+            if checkbox is None:
+                raise UnsupportedStructureError(
+                    "checkbox control has no w14:checkbox properties; nothing was changed"
+                )
+            glyph, font = _declared_checkbox_state(checkbox, value)
+            _validate_writable_text(glyph, argument="declared checkbox glyph")
+            # _set_text performs every structure check before mutation. Only
+            # after it succeeds is the machine-readable state changed.
+            self._set_text(glyph, font=font)
+            self._set_checkbox_state(checkbox, value)
             return
         if control_type in ("picture", "group", "building_block"):
             raise UnsupportedStructureError(
@@ -225,17 +476,21 @@ class Control:
         if isinstance(value, bool):
             raise ValueError(f"{control_type} controls take text, not bool")
         if control_type == "date" and isinstance(value, (dt.date, dt.datetime)):
-            display = value.strftime("%Y-%m-%d")
-            self._set_text(display)
-            self._set_full_date(value)
-            return
-        if control_type == "date" and isinstance(value, str):
-            # a plain display string: drop any machine-readable w:fullDate so
-            # the control never shows one date while claiming another
             sdt_pr = self._sdt_pr
             date_pr = sdt_pr.find(_DATE) if sdt_pr is not None else None
-            if date_pr is not None and date_pr.get(_FULL_DATE):
-                del date_pr.attrib[_FULL_DATE]
+            if date_pr is None:
+                raise UnsupportedStructureError(
+                    "date control has no w:date properties; nothing was changed"
+                )
+            stamp = _utc_date_stamp(value)
+            display = _format_declared_date(date_pr, stamp)
+            _validate_writable_text(display, argument="formatted date value")
+            self._set_text(display)
+            date_pr.set(
+                _FULL_DATE,
+                stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+            return
         if not isinstance(value, str):
             raise ValueError(f"{control_type} controls take a string value")
         _validate_writable_text(value, argument="value")
@@ -246,56 +501,52 @@ class Control:
                     f"{value!r} is not one of this dropdown's choices {list(choices)}"
                 )
         self._set_text(value)
+        if control_type == "date":
+            # A plain display string has no trustworthy machine-readable date.
+            # Drop fullDate only after the text replacement has succeeded.
+            sdt_pr = self._sdt_pr
+            date_pr = sdt_pr.find(_DATE) if sdt_pr is not None else None
+            if date_pr is not None and date_pr.get(_FULL_DATE):
+                del date_pr.attrib[_FULL_DATE]
 
-    def _set_checkbox(self, checked: bool) -> None:
-        sdt_pr = self._sdt_pr
-        checkbox = sdt_pr.find(_CHECKBOX)
+    def _set_checkbox_state(self, checkbox: "_Element", checked: bool) -> None:
         state = checkbox.find(_W14_CHECKED)
         if state is None:
             state = OxmlElement("w14:checked")
             checkbox.insert(0, state)
         state.set(_W14_VAL, "1" if checked else "0")
-        self._set_text(_CHECKED_GLYPH if checked else _UNCHECKED_GLYPH)
 
-    def _set_full_date(self, value: "Union[dt.date, dt.datetime]") -> None:
-        sdt_pr = self._sdt_pr
-        date_pr = sdt_pr.find(_DATE)
-        if isinstance(value, dt.datetime):
-            stamp = value.replace(microsecond=0)
-        else:
-            stamp = dt.datetime(value.year, value.month, value.day)
-        date_pr.set(_FULL_DATE, stamp.strftime("%Y-%m-%dT%H:%M:%SZ"))
-
-    def _set_text(self, text: str) -> None:
+    def _set_text(self, text: str, *, font: Optional[str] = None) -> None:
         from docx.search import _clear_placeholder_state
 
         content = self._sdt.find(_SDT_CONTENT)
-        if content is None:
-            content = OxmlElement("w:sdtContent")
-            self._sdt.append(content)
         # structure guards: never destroy nested controls or tables, and never
         # write a bare run into block-level content that has no paragraph
-        if content.find(qn("w:sdt")) is not None or any(
-            node.tag == qn("w:sdt") for node in content.iter(qn("w:sdt"))
-        ):
-            raise UnsupportedStructureError(
-                "control content holds nested content controls; set the inner"
-                " controls individually instead of overwriting the group"
+        if content is not None:
+            if next(iter(content.iter(_SDT)), None) is not None:
+                raise UnsupportedStructureError(
+                    "control content holds nested content controls; set the inner"
+                    " controls individually instead of overwriting the group"
+                )
+            if next(iter(content.iter(qn("w:tbl"))), None) is not None:
+                raise UnsupportedStructureError(
+                    "control content holds a table; refusing to replace structure"
+                    " with plain text"
+                )
+            has_block_content = content.find(_P) is not None
+            has_inline_content = any(child.tag == _R for child in content) or not len(
+                content
             )
-        if content.find(qn("w:tbl")) is not None:
-            raise UnsupportedStructureError(
-                "control content holds a table; refusing to replace structure"
-                " with plain text"
-            )
-        has_block_content = content.find(_P) is not None
-        has_inline_content = any(child.tag == _R for child in content) or not len(content)
-        if not has_block_content and not has_inline_content:
-            raise UnsupportedStructureError(
-                "control content is not simple text (no paragraph or runs to"
-                " replace); refusing to destroy its structure"
-            )
-        # keep the first run's formatting; block controls keep one paragraph
-        first_run = next(iter(content.iter(_R)), None)
+            if not has_block_content and not has_inline_content:
+                raise UnsupportedStructureError(
+                    "control content is not simple text (no paragraph or runs to"
+                    " replace); refusing to destroy its structure"
+                )
+        control_level = _control_level(self._sdt, content)
+
+        # Everything is validated. Keep the first run's formatting; block
+        # controls keep one paragraph.
+        first_run = next(iter(content.iter(_R)), None) if content is not None else None
         template_rpr = None
         if first_run is not None:
             rpr = first_run.find(_RPR)
@@ -303,12 +554,27 @@ class Control:
                 import copy
 
                 template_rpr = copy.deepcopy(rpr)
+        if font:
+            if template_rpr is None:
+                template_rpr = OxmlElement("w:rPr")
+            fonts = template_rpr.find(_R_FONTS)
+            if fonts is None:
+                fonts = OxmlElement("w:rFonts")
+                template_rpr.insert(0, fonts)
+            for attribute in ("w:ascii", "w:hAnsi", "w:eastAsia", "w:cs"):
+                fonts.set(qn(attribute), font)
+        if content is None:
+            content = OxmlElement("w:sdtContent")
+            self._sdt.append(content)
         run = OxmlElement("w:r")
         if template_rpr is not None:
             run.append(template_rpr)
         run.add_t(text)
         first_paragraph = content.find(_P)
-        if first_paragraph is not None:
+        if control_level == "block":
+            if first_paragraph is None:
+                first_paragraph = OxmlElement("w:p")
+                content.append(first_paragraph)
             for child in list(first_paragraph):
                 if child.tag not in (qn("w:pPr"),):
                     first_paragraph.remove(child)

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -184,13 +184,14 @@ def _format_declared_date(date_pr: "_Element", stamp: dt.datetime) -> str:
         )
     format_elm = date_pr.find(_DATE_FORMAT)
     if format_elm is None:
-        pattern = "yyyy-MM-dd"
-    else:
-        pattern = format_elm.get(_W_VAL) or ""
-        if not pattern:
-            raise UnsupportedStructureError(
-                "date control declares an empty w:dateFormat; nothing was changed"
-            )
+        raise UnsupportedStructureError(
+            "date control has no w:dateFormat; nothing was changed"
+        )
+    pattern = format_elm.get(_W_VAL) or ""
+    if not pattern:
+        raise UnsupportedStructureError(
+            "date control declares an empty w:dateFormat; nothing was changed"
+        )
 
     lid_elm = date_pr.find(_LID)
     language = lid_elm.get(_W_VAL) if lid_elm is not None else None
@@ -265,7 +266,12 @@ def _format_declared_date(date_pr: "_Element", stamp: dt.datetime) -> str:
         pieces.append(replacement)
         index = end
 
-    if uses_names and language is not None:
+    if uses_names:
+        if language is None:
+            raise UnsupportedStructureError(
+                f"date format {pattern!r} uses locale-sensitive names, but the"
+                " date control has no w:lid; nothing was changed"
+            )
         normalized_language = language.lower()
         if normalized_language != "en" and not normalized_language.startswith("en-"):
             raise UnsupportedStructureError(

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -58,6 +58,7 @@ _BLOCK_CONTROL_PARENTS = frozenset(
 )
 _SHOWING_PLC_HDR = qn("w:showingPlcHdr")
 _DATA_BINDING = qn("w:dataBinding")
+_LOCK = qn("w:lock")
 _DROPDOWN = qn("w:dropDownList")
 _COMBO = qn("w:comboBox")
 _DATE = qn("w:date")
@@ -458,6 +459,7 @@ class Control:
                 " custom XML part Word re-syncs on open; editing the surface"
                 " text would silently vanish"
             )
+        _refuse_control_write_restrictions(self._sdt)
         control_type = self.control_type
         if control_type == "checkbox":
             if not isinstance(value, bool):
@@ -593,6 +595,42 @@ class Control:
                 content.remove(child)
             content.append(run)
         _clear_placeholder_state(self._sdt)
+
+
+def _validate_span_surface_edit(sdt: "_Element") -> None:
+    """Allow generic edits only on plain or rich-text control surfaces."""
+    sdt_pr = sdt.find(_SDT_PR)
+    if sdt_pr is not None and sdt_pr.find(_DATA_BINDING) is not None:
+        raise UnsupportedStructureError(
+            "span lies in a data-bound control whose surface text Word"
+            " re-syncs from custom XML; use the binding source instead"
+        )
+    control_type = _control_type(sdt_pr)
+    if control_type not in ("text", "rich_text"):
+        raise UnsupportedStructureError(
+            f"span lies in a {control_type} control whose display text is tied"
+            " to machine-readable control state; use Control.set_value()"
+        )
+
+
+def _refuse_control_write_restrictions(sdt: "_Element") -> None:
+    """Honor binding and content locks without rejecting typed controls."""
+    sdt_pr = sdt.find(_SDT_PR)
+    if sdt_pr is None:
+        return
+    if sdt_pr.find(_DATA_BINDING) is not None:
+        raise UnsupportedStructureError(
+            "control is data-bound; edits could be discarded on sync"
+        )
+    locks = sdt_pr.findall(_LOCK)
+    if len(locks) > 1:
+        raise UnsupportedStructureError(
+            "control has multiple w:lock declarations; nothing was changed"
+        )
+    if locks and locks[0].get(_W_VAL) in ("contentLocked", "sdtContentLocked"):
+        raise UnsupportedStructureError(
+            "control content is locked; nothing was changed"
+        )
 
 
 def _iter_sdts(element: "_Element") -> "Iterator[_Element]":

--- a/src/docx/document.py
+++ b/src/docx/document.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from typing import IO, TYPE_CHECKING, Iterator, List, Sequence
 
+from docx._transaction import rollback_on_error
 from docx.blkcntnr import BlockItemContainer
 from docx.enum.section import WD_SECTION
 from docx.enum.text import WD_BREAK
+from docx.errors import UnsupportedStructureError
 from docx.section import Section, Sections
 from docx.shared import ElementProxy, Emu, Inches, Length
 from docx.text.run import Run
@@ -78,14 +80,21 @@ class Document(ElementProxy):
         runs = [runs] if isinstance(runs, Run) else runs
         first_run = runs[0]
         last_run = runs[-1]
+        if first_run.part is not self.part or last_run.part is not self.part:
+            raise UnsupportedStructureError(
+                "comment range runs do not belong to this document; nothing was changed"
+            )
 
-        # -- Note that comments can only appear in the document part --
-        comment = self.comments.add_comment(text=text, author=author, initials=initials)
+        with rollback_on_error(self):
+            # -- Note that comments can only appear in the document part --
+            comment = self.comments.add_comment(
+                text=text, author=author, initials=initials
+            )
 
-        # -- let the first run orchestrate placement of the comment range start and end --
-        first_run.mark_comment_range(last_run, comment.comment_id)
+            # -- let the first run orchestrate placement of the comment range start and end --
+            first_run.mark_comment_range(last_run, comment.comment_id)
 
-        return comment
+            return comment
 
     def add_heading(self, text: str = "", level: int = 1):
         """Return a heading paragraph newly added to the end of the document.

--- a/src/docx/document.py
+++ b/src/docx/document.py
@@ -85,6 +85,11 @@ class Document(ElementProxy):
                 "comment range runs do not belong to this document; nothing was changed"
             )
 
+        from docx.commentops import _preflight_comment_range
+
+        _preflight_comment_range(
+            self, first_run._r, last_run._r, operation="add a comment"
+        )
         with rollback_on_error(self):
             # -- Note that comments can only appear in the document part --
             comment = self.comments.add_comment(

--- a/src/docx/errors.py
+++ b/src/docx/errors.py
@@ -17,6 +17,16 @@ class PaperRefusal(Exception):
     """
 
 
+class PackageLimitError(PaperRefusal):
+    """A package archive is too large, ambiguous, or unsafe to expand.
+
+    Package reads validate ZIP structure and resource bounds before any XML is
+    parsed or output is replaced. This exception therefore represents a safe
+    refusal, including for encrypted entries, duplicate/noncanonical member
+    names, unsupported entry types, and forged ZIP size metadata.
+    """
+
+
 class AmbiguousTargetError(PaperRefusal):
     """The target specification matches more than one location.
 

--- a/src/docx/formatting.py
+++ b/src/docx/formatting.py
@@ -15,9 +15,9 @@ root→leaf, then the character-style chain root→leaf) that specifies TRUE —
 the famous nested-bold-cancels gotcha, pinned by tests. Ordinary
 properties take the nearest specification instead.
 
-Declared out of scope (listed in `unresolved`): table-style
-conditional formatting, numbering-mark properties, and East-Asian/
-complex-script variants beyond the toggle pair (bCs/iCs).
+Declared out of scope (listed in `unresolved`): table-style conditional
+formatting, numbering-mark properties, theme resolution, and every run or
+paragraph property category this focused resolver does not compute.
 """
 
 from __future__ import annotations
@@ -52,12 +52,33 @@ _TOGGLES = {
     "w:vanish": "vanish",
 }
 
-#: declared-unresolvable areas
+#: Declared-unresolvable areas. Keep omitted OOXML property categories
+#: explicit: the finite ``properties`` map is a supported subset, not a claim
+#: that unlisted formatting is absent.
 _UNRESOLVED = (
     "table_style_conditional_formatting",
     "numbering_mark_properties",
     "east_asian_and_complex_script_variants",
     "theme_font_resolution",  # theme-referenced fonts report "theme:<token>"
+    "theme_color_resolution",
+    "run_border",
+    "run_shading",
+    "run_character_spacing",
+    "run_character_scaling",
+    "run_character_position",
+    "run_kerning",
+    "run_language",
+    "run_proofing",
+    "run_additional_text_effects",
+    "paragraph_indentation",
+    "paragraph_spacing",
+    "paragraph_tabs",
+    "paragraph_borders",
+    "paragraph_shading",
+    "paragraph_pagination",
+    "paragraph_text_flow",
+    "paragraph_frame_properties",
+    "section_properties",
 )
 
 
@@ -106,10 +127,11 @@ class EffectiveFormat:
 def format_of(target) -> EffectiveFormat:
     """The effective formatting of a |Run|, |Paragraph| or |Span|.
 
-    Runs resolve the full run-property set; paragraphs resolve their
-    paragraph-level properties (alignment, style) plus the run defaults
-    their style chain implies; spans resolve every run they touch and
-    report disagreeing properties as "mixed".
+    Runs resolve the supported run-property subset in ``properties``;
+    paragraphs resolve alignment and style plus the supported run defaults
+    their style chain implies. Spans resolve every run they touch and report
+    disagreeing properties as "mixed". Omitted categories are named in
+    ``unresolved`` rather than implicitly reported as absent.
     """
     from docx.search import Span
     from docx.text.paragraph import Paragraph

--- a/src/docx/numbering.py
+++ b/src/docx/numbering.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from docx.errors import TargetNotFoundError
+from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
@@ -129,6 +129,74 @@ def _definitions(numbering: "Optional[_Element]") -> Tuple[NumberingDefinition, 
     return tuple(sorted(definitions, key=lambda d: d.num_id))
 
 
+def _styles_index(document: "Document") -> "dict[str, _Element]":
+    return {
+        style_id: style
+        for style in document.styles.element.findall(qn("w:style"))
+        if (style_id := style.get(qn("w:styleId"))) is not None
+    }
+
+
+def _default_paragraph_style_id(document: "Document") -> Optional[str]:
+    default = None
+    for style in document.styles.element.findall(qn("w:style")):
+        if style.get(qn("w:type")) != "paragraph":
+            continue
+        if (style.get(qn("w:default")) or "").lower() in ("1", "true", "on"):
+            default = style.get(qn("w:styleId"))
+    return default
+
+
+def _paragraph_style_chain(
+    styles: "dict[str, _Element]", style_id: Optional[str]
+) -> "list[_Element]":
+    chain = []
+    seen = set()
+    current = style_id
+    while current is not None and current in styles and current not in seen:
+        seen.add(current)
+        style = styles[current]
+        chain.append(style)
+        based_on = style.find(qn("w:basedOn"))
+        current = based_on.get(qn("w:val")) if based_on is not None else None
+    chain.reverse()
+    return chain
+
+
+def _effective_paragraph_numbering(
+    document: "Document", paragraph: "_Element"
+) -> "Optional[Tuple[int, int]]":
+    """Effective ``(numId, ilvl)`` after paragraph-style inheritance."""
+    p_pr = paragraph.find(qn("w:pPr"))
+    style_elm = p_pr.find(qn("w:pStyle")) if p_pr is not None else None
+    style_id = (
+        style_elm.get(qn("w:val"))
+        if style_elm is not None
+        else _default_paragraph_style_id(document)
+    )
+    layers = [
+        style.find(qn("w:pPr"))
+        for style in _paragraph_style_chain(_styles_index(document), style_id)
+    ]
+    layers.append(p_pr)
+    num_id = None
+    level = None
+    for layer in layers:
+        num_pr = layer.find(qn("w:numPr")) if layer is not None else None
+        if num_pr is None:
+            continue
+        num_id_elm = num_pr.find(qn("w:numId"))
+        ilvl_elm = num_pr.find(qn("w:ilvl"))
+        if num_id_elm is not None and num_id_elm.get(qn("w:val")) is not None:
+            num_id = int(num_id_elm.get(qn("w:val")))
+        if ilvl_elm is not None and ilvl_elm.get(qn("w:val")) is not None:
+            level = int(ilvl_elm.get(qn("w:val")))
+    # ECMA-376 reserves numId 0 as an explicit "no numbering" override.
+    if num_id in (None, 0):
+        return None
+    return num_id, level if level is not None else 0
+
+
 def list_numbering(document: "Document") -> NumberingReport:
     """Every numbering definition and every numbered paragraph in `document`."""
     numbered = []
@@ -136,14 +204,10 @@ def list_numbering(document: "Document") -> NumberingReport:
         for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
             if kind != "paragraph":
                 continue
-            num_prs = element.xpath("./w:pPr/w:numPr")
-            if not num_prs:
+            effective = _effective_paragraph_numbering(document, element)
+            if effective is None:
                 continue
-            num_pr = num_prs[0]
-            num_id_elm = num_pr.find(qn("w:numId"))
-            ilvl_elm = num_pr.find(qn("w:ilvl"))
-            if num_id_elm is None:
-                continue
+            num_id, level = effective
             block = _build_block(
                 story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx
             )
@@ -151,8 +215,8 @@ def list_numbering(document: "Document") -> NumberingReport:
                 NumberedParagraph(
                     story=story,
                     index=index,
-                    num_id=int(num_id_elm.get(qn("w:val"))),
-                    level=int(ilvl_elm.get(qn("w:val"))) if ilvl_elm is not None else 0,
+                    num_id=num_id,
+                    level=level,
                     text=block.text,
                 )
             )
@@ -265,11 +329,13 @@ _CANONICAL_ABSTRACT_XML = {
         '<w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="bullet"/>'
         '<w:lvlText w:val="o"/><w:lvlJc w:val="left"/>'
         '<w:pPr><w:ind w:left="1440" w:hanging="360"/></w:pPr>'
-        '<w:rPr><w:rFonts w:ascii="Courier New" w:hAnsi="Courier New" w:hint="default"/></w:rPr></w:lvl>'
+        '<w:rPr><w:rFonts w:ascii="Courier New" w:hAnsi="Courier New"'
+        ' w:hint="default"/></w:rPr></w:lvl>'
         '<w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="bullet"/>'
         '<w:lvlText w:val="▪"/><w:lvlJc w:val="left"/>'
         '<w:pPr><w:ind w:left="2160" w:hanging="360"/></w:pPr>'
-        '<w:rPr><w:rFonts w:ascii="Wingdings" w:hAnsi="Wingdings" w:hint="default"/></w:rPr></w:lvl>'
+        '<w:rPr><w:rFonts w:ascii="Wingdings" w:hAnsi="Wingdings"'
+        ' w:hint="default"/></w:rPr></w:lvl>'
         "</w:abstractNum>"
     ),
     "decimal": (
@@ -338,24 +404,81 @@ def _append_definition(numbering: "_Element", abstract: "_Element", num: "_Eleme
         numbering.append(num)
 
 
+def _structural_signature(
+    element: "_Element", *, ignore_root_abstract_id: bool = False
+) -> tuple:
+    """Prefix/attribute-order-independent exact XML structure signature."""
+    abstract_id_attr = qn("w:abstractNumId")
+    attributes = tuple(
+        sorted(
+            (name, value)
+            for name, value in element.attrib.items()
+            if not (ignore_root_abstract_id and name == abstract_id_attr)
+        )
+    )
+    text = element.text or ""
+    if not text.strip():
+        text = ""
+    return (
+        element.tag,
+        attributes,
+        text,
+        tuple(_structural_signature(child) for child in element),
+    )
+
+
+def _canonical_abstract(kind: str, abstract_id: int) -> "_Element":
+    from docx.oxml.ns import nsdecls
+    from docx.oxml.parser import parse_xml
+
+    _name, template = _CANONICAL_ABSTRACT_XML[kind]
+    ids = f'{nsdecls("w")} w:abstractNumId="{abstract_id}"'
+    return parse_xml(template.format(ids=ids))
+
+
+def _is_canonical_abstract(abstract: "_Element", kind: str) -> bool:
+    expected = _canonical_abstract(kind, 0)
+    return _structural_signature(
+        abstract, ignore_root_abstract_id=True
+    ) == _structural_signature(expected, ignore_root_abstract_id=True)
+
+
+def _is_plain_num_reference(num: "_Element", abstract_id: str) -> bool:
+    """Whether ``num`` is exactly the canonical abstract reference shape."""
+    children = list(num)
+    if len(children) != 1 or children[0].tag != qn("w:abstractNumId"):
+        return False
+    ref = children[0]
+    return (
+        tuple(ref.attrib.items()) == ((qn("w:val"), abstract_id),)
+        and set(num.attrib) == {qn("w:numId")}
+    )
+
+
 def _ensure_definition(document: "Document", kind: str) -> int:
     from docx.oxml.ns import nsdecls
     from docx.oxml.parser import parse_xml
 
-    name, template = _CANONICAL_ABSTRACT_XML[kind]
+    name, _template = _CANONICAL_ABSTRACT_XML[kind]
     numbering = _get_or_create_numbering_root(document)
-    # idempotent: reuse the canonical definition if it is already here
+    # A name is only a marker, not proof. Reuse requires the exact canonical
+    # abstract shape and a plain w:num reference with no hidden overrides.
     for abstract in numbering.findall(qn("w:abstractNum")):
         name_elm = abstract.find(qn("w:name"))
-        if name_elm is not None and name_elm.get(qn("w:val")) == name:
-            abstract_id = abstract.get(qn("w:abstractNumId"))
-            for num in numbering.findall(qn("w:num")):
-                ref = num.find(qn("w:abstractNumId"))
-                if ref is not None and ref.get(qn("w:val")) == abstract_id:
-                    return int(num.get(qn("w:numId")))
+        if (
+            name_elm is None
+            or name_elm.get(qn("w:val")) != name
+            or not _is_canonical_abstract(abstract, kind)
+        ):
+            continue
+        abstract_id = abstract.get(qn("w:abstractNumId"))
+        if abstract_id is None:
+            continue
+        for num in numbering.findall(qn("w:num")):
+            if _is_plain_num_reference(num, abstract_id):
+                return int(num.get(qn("w:numId")))
     abstract_id, num_id = _next_free_ids(numbering)
-    ids = f'{nsdecls("w")} w:abstractNumId="{abstract_id}"'
-    abstract = parse_xml(template.format(ids=ids))
+    abstract = _canonical_abstract(kind, abstract_id)
     num = parse_xml(
         f'<w:num {nsdecls("w")} w:numId="{num_id}">'
         f'<w:abstractNumId w:val="{abstract_id}"/></w:num>'
@@ -392,7 +515,15 @@ def restart_numbering(document: "Document", *, num_id: int) -> int:
     definition = None
     if numbering is not None:
         for num in numbering.findall(qn("w:num")):
-            if int(num.get(qn("w:numId"))) == num_id:
+            raw_num_id = num.get(qn("w:numId"))
+            try:
+                candidate_num_id = int(raw_num_id) if raw_num_id is not None else -1
+            except ValueError:
+                raise UnsupportedStructureError(
+                    f"numbering contains a malformed numId {raw_num_id!r};"
+                    " nothing was changed"
+                ) from None
+            if candidate_num_id == num_id:
                 definition = num
                 break
     if definition is None:
@@ -402,7 +533,28 @@ def restart_numbering(document: "Document", *, num_id: int) -> int:
     from docx.oxml.ns import nsdecls
     from docx.oxml.parser import parse_xml
 
-    abstract_id = definition.find(qn("w:abstractNumId")).get(qn("w:val"))
+    children = list(definition)
+    abstract_ref = definition.find(qn("w:abstractNumId"))
+    abstract_id = abstract_ref.get(qn("w:val")) if abstract_ref is not None else None
+    if abstract_id is None:
+        raise UnsupportedStructureError(
+            f"numbering definition numId={num_id} has no abstractNumId;"
+            " nothing was changed"
+        )
+    if len(children) != 1 or children[0] is not abstract_ref:
+        raise UnsupportedStructureError(
+            f"numbering definition numId={num_id} carries level overrides or"
+            " other customizations that restart_numbering cannot preserve;"
+            " nothing was changed"
+        )
+    if not any(
+        abstract.get(qn("w:abstractNumId")) == abstract_id
+        for abstract in numbering.findall(qn("w:abstractNum"))
+    ):
+        raise UnsupportedStructureError(
+            f"numbering definition numId={num_id} references missing"
+            f" abstractNumId={abstract_id!r}; nothing was changed"
+        )
     _, new_num_id = _next_free_ids(numbering)
     new_num = parse_xml(
         f'<w:num {nsdecls("w")} w:numId="{new_num_id}">'

--- a/src/docx/numbering.py
+++ b/src/docx/numbering.py
@@ -58,6 +58,7 @@ class NumberedParagraph:
     num_id: int
     level: int
     text: str
+    table_cell: "Optional[Tuple[int, int, int]]" = None
 
     def to_dict(self) -> dict:
         return {
@@ -66,6 +67,7 @@ class NumberedParagraph:
             "num_id": self.num_id,
             "level": self.level,
             "text": self.text,
+            "table_cell": self.table_cell,
         }
 
 
@@ -77,7 +79,7 @@ class NumberingReport:
     def to_dict(self) -> dict:
         return {
             "schema": "paper_numbering",
-            "version": 1,
+            "version": 2,
             "definitions": [d.to_dict() for d in self.definitions],
             "numbered_paragraphs": [p.to_dict() for p in self.numbered_paragraphs],
         }
@@ -119,11 +121,24 @@ def _definitions(numbering: "Optional[_Element]") -> Tuple[NumberingDefinition, 
         num_id = int(num.get(qn("w:numId")))
         abstract_ref = num.find(qn("w:abstractNumId"))
         abstract_id = int(abstract_ref.get(qn("w:val"))) if abstract_ref is not None else -1
+        levels = {level.level: level for level in abstract_levels.get(abstract_id, ())}
+        for override in num.findall(qn("w:lvlOverride")):
+            override_level = int(override.get(qn("w:ilvl")))
+            level = override.find(qn("w:lvl"))
+            if level is None:
+                continue
+            num_fmt = level.find(qn("w:numFmt"))
+            lvl_text = level.find(qn("w:lvlText"))
+            levels[override_level] = NumberingLevel(
+                level=override_level,
+                num_fmt=num_fmt.get(qn("w:val")) if num_fmt is not None else None,
+                lvl_text=lvl_text.get(qn("w:val")) if lvl_text is not None else None,
+            )
         definitions.append(
             NumberingDefinition(
                 num_id=num_id,
                 abstract_num_id=abstract_id,
-                levels=abstract_levels.get(abstract_id, ()),
+                levels=tuple(levels[index] for index in sorted(levels)),
             )
         )
     return tuple(sorted(definitions, key=lambda d: d.num_id))
@@ -199,31 +214,83 @@ def _effective_paragraph_numbering(
 
 def list_numbering(document: "Document") -> NumberingReport:
     """Every numbering definition and every numbered paragraph in `document`."""
+    definitions = _definitions(_numbering_root(document))
+    definitions_by_id = {definition.num_id: definition for definition in definitions}
     numbered = []
     for story, root in _story_elements(document):
         for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-            if kind != "paragraph":
-                continue
-            effective = _effective_paragraph_numbering(document, element)
-            if effective is None:
-                continue
-            num_id, level = effective
-            block = _build_block(
-                story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx
+            paragraphs = (
+                (element,)
+                if kind == "paragraph"
+                else tuple(element.iter(qn("w:p")))
+                if kind == "table"
+                else ()
             )
-            numbered.append(
-                NumberedParagraph(
-                    story=story,
-                    index=index,
-                    num_id=num_id,
-                    level=level,
-                    text=block.text,
+            for paragraph in paragraphs:
+                effective = _effective_paragraph_numbering(document, paragraph)
+                if effective is None:
+                    continue
+                num_id, level = effective
+                definition = definitions_by_id.get(num_id)
+                if definition is None:
+                    raise UnsupportedStructureError(
+                        f"paragraph resolves to missing numbering definition numId={num_id};"
+                        " nothing was changed"
+                    )
+                if level not in {item.level for item in definition.levels}:
+                    raise UnsupportedStructureError(
+                        f"paragraph resolves to undefined numbering level {level}"
+                        f" for numId={num_id}; nothing was changed"
+                    )
+                block = _build_block(
+                    story,
+                    "paragraph",
+                    index,
+                    paragraph,
+                    "current",
+                    in_sdt=in_sdt,
+                    in_txbx=in_txbx,
                 )
-            )
+                numbered.append(
+                    NumberedParagraph(
+                        story=story,
+                        index=index,
+                        num_id=num_id,
+                        level=level,
+                        text=block.text,
+                        table_cell=_table_cell_address(paragraph),
+                    )
+                )
     return NumberingReport(
-        definitions=_definitions(_numbering_root(document)),
+        definitions=definitions,
         numbered_paragraphs=tuple(numbered),
     )
+
+
+def _table_cell_address(paragraph: "_Element") -> "Optional[Tuple[int, int, int]]":
+    tc = paragraph.getparent()
+    while tc is not None and tc.tag not in (qn("w:tc"), qn("w:body")):
+        tc = tc.getparent()
+    if tc is None or tc.tag != qn("w:tc"):
+        return None
+    tr = tc.getparent()
+    tbl = tr.getparent() if tr is not None else None
+    if tr is None or tbl is None:
+        return None
+    rows = tbl.findall(qn("w:tr"))
+    cells = tr.findall(qn("w:tc"))
+    column = 0
+    tr_pr = tr.find(qn("w:trPr"))
+    grid_before = tr_pr.find(qn("w:gridBefore")) if tr_pr is not None else None
+    if grid_before is not None:
+        column = int(grid_before.get(qn("w:val")) or 0)
+    for cell in cells:
+        if cell is tc:
+            break
+        tc_pr = cell.find(qn("w:tcPr"))
+        span = tc_pr.find(qn("w:gridSpan")) if tc_pr is not None else None
+        column += int(span.get(qn("w:val")) or 1) if span is not None else 1
+    return rows.index(tr), column, tc.findall(qn("w:p")).index(paragraph)
 
 
 def _document_of_paragraph(paragraph: "Paragraph") -> "Document":
@@ -401,7 +468,11 @@ def _append_definition(numbering: "_Element", abstract: "_Element", num: "_Eleme
     if last:
         last[-1].addnext(num)
     else:
-        numbering.append(num)
+        cleanup = numbering.find(qn("w:numIdMacAtCleanup"))
+        if cleanup is not None:
+            cleanup.addprevious(num)
+        else:
+            numbering.append(num)
 
 
 def _structural_signature(

--- a/src/docx/numbering.py
+++ b/src/docx/numbering.py
@@ -12,13 +12,18 @@ and refuses loudly.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple
 
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
-from docx.story import _build_block, _iter_block_elements, _story_elements
+from docx.story import (
+    _build_block,
+    _first_choice_children,
+    _iter_block_elements,
+    _story_elements,
+)
 
 if TYPE_CHECKING:
     from lxml.etree import _Element
@@ -222,7 +227,7 @@ def list_numbering(document: "Document") -> NumberingReport:
             paragraphs = (
                 (element,)
                 if kind == "paragraph"
-                else tuple(element.iter(qn("w:p")))
+                else tuple(_table_paragraphs(element))
                 if kind == "table"
                 else ()
             )
@@ -267,6 +272,43 @@ def list_numbering(document: "Document") -> NumberingReport:
     )
 
 
+def _selected_descendants(
+    root: "_Element", target_tag: str, *, stop_tags: "Tuple[str, ...]"
+) -> "Iterator[_Element]":
+    """Yield one compatibility-selected subtree, stopping at nested structures."""
+    for child in _first_choice_children(root):
+        if child.tag == target_tag:
+            yield child
+        if child.tag not in stop_tags:
+            yield from _selected_descendants(
+                child, target_tag, stop_tags=stop_tags
+            )
+
+
+def _table_rows(table: "_Element") -> "Tuple[_Element, ...]":
+    return tuple(
+        _selected_descendants(table, qn("w:tr"), stop_tags=(qn("w:tbl"),))
+    )
+
+
+def _row_cells(row: "_Element") -> "Tuple[_Element, ...]":
+    return tuple(
+        _selected_descendants(row, qn("w:tc"), stop_tags=(qn("w:tbl"),))
+    )
+
+
+def _cell_paragraphs(cell: "_Element") -> "Tuple[_Element, ...]":
+    return tuple(
+        _selected_descendants(cell, qn("w:p"), stop_tags=(qn("w:tbl"),))
+    )
+
+
+def _table_paragraphs(table: "_Element") -> "Iterator[_Element]":
+    for row in _table_rows(table):
+        for cell in _row_cells(row):
+            yield from _cell_paragraphs(cell)
+
+
 def _table_cell_address(paragraph: "_Element") -> "Optional[Tuple[int, int, int]]":
     tc = paragraph.getparent()
     while tc is not None and tc.tag not in (qn("w:tc"), qn("w:body")):
@@ -274,11 +316,17 @@ def _table_cell_address(paragraph: "_Element") -> "Optional[Tuple[int, int, int]
     if tc is None or tc.tag != qn("w:tc"):
         return None
     tr = tc.getparent()
-    tbl = tr.getparent() if tr is not None else None
-    if tr is None or tbl is None:
+    while tr is not None and tr.tag not in (qn("w:tr"), qn("w:body")):
+        tr = tr.getparent()
+    if tr is None or tr.tag != qn("w:tr"):
         return None
-    rows = tbl.findall(qn("w:tr"))
-    cells = tr.findall(qn("w:tc"))
+    tbl = tr.getparent()
+    while tbl is not None and tbl.tag not in (qn("w:tbl"), qn("w:body")):
+        tbl = tbl.getparent()
+    if tbl is None or tbl.tag != qn("w:tbl"):
+        return None
+    rows = _table_rows(tbl)
+    cells = _row_cells(tr)
     column = 0
     tr_pr = tr.find(qn("w:trPr"))
     grid_before = tr_pr.find(qn("w:gridBefore")) if tr_pr is not None else None
@@ -290,7 +338,7 @@ def _table_cell_address(paragraph: "_Element") -> "Optional[Tuple[int, int, int]
         tc_pr = cell.find(qn("w:tcPr"))
         span = tc_pr.find(qn("w:gridSpan")) if tc_pr is not None else None
         column += int(span.get(qn("w:val")) or 1) if span is not None else 1
-    return rows.index(tr), column, tc.findall(qn("w:p")).index(paragraph)
+    return rows.index(tr), column, _cell_paragraphs(tc).index(paragraph)
 
 
 def _document_of_paragraph(paragraph: "Paragraph") -> "Document":

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING, Iterator, cast
+import os
+import secrets
+import stat
+import tempfile
+from contextlib import suppress
+from typing import IO, TYPE_CHECKING, BinaryIO, Iterator, Optional, cast
 
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.packuri import PACKAGE_URI, PackURI
@@ -161,9 +166,14 @@ class OpcPackage:
 
         `pkg_file` can be either a file-path or a file-like object.
         """
-        for part in self.parts:
+        parts = self.parts
+        for part in parts:
             part.before_marshal()
-        PackageWriter.write(pkg_file, self.rels, self.parts)
+        parts = self.parts
+        if isinstance(pkg_file, (str, os.PathLike)):
+            _atomic_package_write(os.fspath(pkg_file), self.rels, parts)
+        else:
+            _atomic_stream_write(pkg_file, self.rels, parts)
 
     @property
     def _core_properties_part(self) -> CorePropertiesPart:
@@ -217,3 +227,216 @@ class Unmarshaller:
             source = package if source_uri == "/" else parts[source_uri]
             target = srel.target_ref if srel.is_external else parts[srel.target_partname]
             source.load_rel(srel.reltype, target, srel.rId, srel.is_external)
+
+
+def _validate_serialized_output(source) -> None:
+    """Reopen a staged package so malformed output never reaches its destination."""
+    reader = PackageReader.from_file(source)
+    # Force traversal of the complete serialized relationship graph.
+    tuple(reader.iter_sparts())
+    tuple(reader.iter_srels())
+
+
+def _atomic_package_write(path: str, relationships, parts) -> None:
+    """Serialize beside ``path``, validate, and atomically replace it."""
+    link_state = None
+    if os.path.islink(path):
+        link_stat = os.lstat(path)
+        destination = os.path.realpath(path)
+        link_state = (link_stat.st_dev, link_stat.st_ino, destination)
+    else:
+        destination = path
+    directory = os.path.dirname(os.path.abspath(destination)) or os.curdir
+    descriptor, temporary = _new_atomic_temp(directory, f".{os.path.basename(destination)}.")
+    try:
+        if os.path.exists(destination):
+            os.fchmod(descriptor, stat.S_IMODE(os.stat(destination).st_mode))
+        os.close(descriptor)
+        descriptor = -1
+        PackageWriter.write(temporary, relationships, parts)
+        _validate_serialized_output(temporary)
+        with open(temporary, "rb") as staged:
+            os.fsync(staged.fileno())
+        if link_state is not None:
+            try:
+                current = os.lstat(path)
+            except OSError as exc:
+                raise OSError(
+                    "destination symlink changed during save; nothing was replaced"
+                ) from exc
+            if (
+                not stat.S_ISLNK(current.st_mode)
+                or (current.st_dev, current.st_ino) != link_state[:2]
+                or os.path.realpath(path) != link_state[2]
+            ):
+                raise OSError(
+                    "destination symlink changed during save; nothing was replaced"
+                )
+        os.replace(temporary, destination)
+        with suppress(OSError):
+            directory_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        with suppress(OSError):
+            os.unlink(temporary)
+
+
+def _new_atomic_temp(directory: str, prefix: str) -> "tuple[int, str]":
+    """Create a sibling temporary file using normal umask semantics."""
+    for _ in range(100):
+        path = os.path.join(directory, f"{prefix}{secrets.token_hex(8)}.partial")
+        try:
+            return os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o666), path
+        except FileExistsError:
+            continue
+    raise FileExistsError("could not allocate a unique atomic-save temp file")
+
+
+_STREAM_COPY_BYTES = 1024 * 1024
+_STREAM_SPOOL_BYTES = 8 * 1024 * 1024
+
+
+def _atomic_stream_write(stream: IO[bytes], relationships, parts) -> None:
+    """Stage output and roll back a readable, seekable destination on failure."""
+    start = _stream_position(stream)
+    snapshot_record = _snapshot_stream_tail(stream, start)
+    if snapshot_record is None:
+        if _has_stream_rollback_surface(stream, start):
+            raise OSError(
+                "destination stream exposes rollback operations but its existing"
+                " content could not be snapshotted; nothing was written"
+            )
+        _write_staged_to_unrestorable_stream(
+            stream, relationships, parts, start=start
+        )
+        return
+    snapshot, original_end = snapshot_record
+    try:
+        with tempfile.SpooledTemporaryFile(max_size=_STREAM_SPOOL_BYTES, mode="w+b") as staged:
+            assert start is not None
+            _copy_stream_prefix(stream, staged, start)
+            PackageWriter.write(staged, relationships, parts)
+            _validate_serialized_output(staged)
+            staged.seek(start)
+            try:
+                stream.seek(start)
+                _copy_stream(staged, cast(BinaryIO, stream))
+                stream.truncate()
+                flush = getattr(stream, "flush", None)
+                if callable(flush):
+                    flush()
+            except BaseException:
+                try:
+                    _restore_stream_tail(stream, start, original_end, snapshot)
+                except BaseException as rollback_error:
+                    raise RuntimeError(
+                        "stream save failed and the destination stream could not be restored"
+                    ) from rollback_error
+                raise
+    finally:
+        snapshot.close()
+
+
+def _has_stream_rollback_surface(stream, start: "Optional[int]") -> bool:
+    return start is not None and all(
+        callable(getattr(stream, name, None)) for name in ("read", "seek", "tell", "truncate")
+    )
+
+
+def _write_staged_to_unrestorable_stream(
+    stream, relationships, parts, *, start: "Optional[int]"
+) -> None:
+    """Validate first; after commit starts, write-only stream errors are final."""
+    if start not in (None, 0):
+        raise OSError(
+            "cannot validate a write-only stream with an existing prefix;"
+            " nothing was written"
+        )
+    with tempfile.SpooledTemporaryFile(max_size=_STREAM_SPOOL_BYTES, mode="w+b") as staged:
+        PackageWriter.write(staged, relationships, parts)
+        staged.seek(0)
+        _validate_serialized_output(staged)
+        staged.seek(0)
+        _copy_stream(staged, cast(BinaryIO, stream))
+        flush = getattr(stream, "flush", None)
+        if callable(flush):
+            flush()
+
+
+def _copy_stream_prefix(stream, destination: BinaryIO, length: int) -> None:
+    """Copy the exact preserved prefix into the staged validation stream."""
+    stream.seek(0)
+    remaining = length
+    while remaining:
+        chunk = stream.read(min(_STREAM_COPY_BYTES, remaining))
+        if not isinstance(chunk, bytes) or not chunk:
+            raise OSError(
+                "destination stream prefix could not be read; nothing was written"
+            )
+        destination.write(chunk)
+        remaining -= len(chunk)
+    stream.seek(length)
+
+
+def _stream_position(stream) -> "Optional[int]":
+    try:
+        position = stream.tell()
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+    return (
+        position
+        if isinstance(position, int) and not isinstance(position, bool) and position >= 0
+        else None
+    )
+
+
+def _snapshot_stream_tail(stream, start) -> "Optional[tuple[BinaryIO, int]]":
+    if not _has_stream_rollback_surface(stream, start):
+        return None
+    snapshot = tempfile.SpooledTemporaryFile(  # noqa: SIM115 - returned to caller
+        max_size=_STREAM_SPOOL_BYTES, mode="w+b"
+    )
+    try:
+        stream.seek(0, os.SEEK_END)
+        original_end = stream.tell()
+        stream.seek(start)
+        remaining = original_end - start
+        while remaining:
+            chunk = stream.read(min(_STREAM_COPY_BYTES, remaining))
+            if not isinstance(chunk, bytes) or not chunk:
+                raise OSError("destination stream suffix could not be read")
+            snapshot.write(chunk)
+            remaining -= len(chunk)
+        snapshot.seek(0)
+        stream.seek(start)
+        return snapshot, original_end
+    except (AttributeError, OSError, TypeError, ValueError):
+        snapshot.close()
+        with suppress(Exception):
+            stream.seek(start)
+        return None
+
+
+def _restore_stream_tail(stream, start: int, original_end: int, snapshot: BinaryIO) -> None:
+    stream.seek(start)
+    snapshot.seek(0)
+    _copy_stream(snapshot, cast(BinaryIO, stream))
+    stream.truncate(original_end)
+    stream.seek(start)
+
+
+def _copy_stream(source: BinaryIO, destination: BinaryIO) -> None:
+    while chunk := source.read(_STREAM_COPY_BYTES):
+        offset = 0
+        while offset < len(chunk):
+            written = destination.write(chunk[offset:])
+            if not isinstance(written, int) or isinstance(written, bool) or written <= 0:
+                raise OSError("destination stream returned an invalid write count")
+            if written > len(chunk) - offset:
+                raise OSError("destination stream returned an invalid write count")
+            offset += written

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -250,7 +250,11 @@ def _atomic_package_write(path: str, relationships, parts) -> None:
     descriptor, temporary = _new_atomic_temp(directory, f".{os.path.basename(destination)}.")
     try:
         if os.path.exists(destination):
-            os.fchmod(descriptor, stat.S_IMODE(os.stat(destination).st_mode))
+            mode = stat.S_IMODE(os.stat(destination).st_mode)
+            if hasattr(os, "fchmod"):
+                os.fchmod(descriptor, mode)
+            else:
+                os.chmod(temporary, mode)
         os.close(descriptor)
         descriptor = -1
         PackageWriter.write(temporary, relationships, parts)

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -307,6 +307,12 @@ _STREAM_SPOOL_BYTES = 8 * 1024 * 1024
 
 def _atomic_stream_write(stream: IO[bytes], relationships, parts) -> None:
     """Stage output and roll back a readable, seekable destination on failure."""
+    mode = getattr(stream, "mode", None)
+    if isinstance(mode, str) and "a" in mode:
+        raise OSError(
+            "append-mode destination streams do not support positional writes;"
+            " nothing was written"
+        )
     start = _stream_position(stream)
     snapshot_record = _snapshot_stream_tail(stream, start)
     if snapshot_record is None:

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -4,6 +4,7 @@ import os
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo, is_zipfile
 
 from docx._zipguard import GuardedZipReader, enforce_compressed_size, preflight_zip
+from docx.errors import PackageLimitError
 from docx.opc.exceptions import PackageNotFoundError
 from docx.opc.packuri import CONTENT_TYPES_URI
 
@@ -15,13 +16,14 @@ class PhysPkgReader:
 
     def __new__(cls, pkg_file):
         # if `pkg_file` is a string, treat it as a path
-        if isinstance(pkg_file, str):
-            if os.path.isdir(pkg_file):
+        if isinstance(pkg_file, (str, os.PathLike)):
+            path = os.fspath(pkg_file)
+            if os.path.isdir(path):
                 reader_cls = _DirPkgReader
-            elif is_zipfile(pkg_file):
+            elif is_zipfile(path):
                 reader_cls = _ZipPkgReader
             else:
-                raise PackageNotFoundError("Package not found at '%s'" % pkg_file)
+                raise PackageNotFoundError("Package not found at '%s'" % path)
         else:  # assume it's a stream and pass it to Zip reader to sort out
             reader_cls = _ZipPkgReader
 
@@ -42,14 +44,49 @@ class _DirPkgReader(PhysPkgReader):
     def __init__(self, path):
         """`path` is the path to a directory containing an expanded package."""
         super(_DirPkgReader, self).__init__()
-        self._path = os.path.abspath(path)
+        self._path = os.path.abspath(os.fspath(path))
+        if os.path.islink(self._path):
+            raise PackageLimitError("expanded package root is a symbolic link")
+        names = []
+        for root, directories, files in os.walk(self._path, followlinks=False):
+            directories.sort()
+            files.sort()
+            for directory in directories:
+                if os.path.islink(os.path.join(root, directory)):
+                    raise PackageLimitError("expanded package contains a symbolic link")
+            for filename in files:
+                file_path = os.path.join(root, filename)
+                if os.path.islink(file_path):
+                    raise PackageLimitError("expanded package contains a symbolic link")
+                member = os.path.relpath(file_path, self._path).replace(
+                    os.sep, "/"
+                )
+                names.append(member)
+        self._member_name_by_fold = {}
+        for name in names:
+            folded = name.casefold()
+            if folded in self._member_name_by_fold:
+                raise PackageLimitError(
+                    f"expanded package contains case-ambiguous member name {name!r}"
+                )
+            self._member_name_by_fold[folded] = name
+        self._member_names = tuple(names)
 
     def blob_for(self, pack_uri):
         """Return contents of file corresponding to `pack_uri` in package directory."""
-        path = os.path.join(self._path, pack_uri.membername)
+        actual_name = self._member_name_by_fold[pack_uri.membername.casefold()]
+        path = os.path.join(self._path, *actual_name.split("/"))
         with open(path, "rb") as f:
             blob = f.read()
         return blob
+
+    def partname_for(self, pack_uri):
+        actual_name = self._member_name_by_fold[pack_uri.membername.casefold()]
+        return type(pack_uri)(f"/{actual_name}")
+
+    @property
+    def member_names(self):
+        return self._member_names
 
     def close(self):
         """Provides interface consistency with |ZipFileSystem|, but does nothing, a
@@ -66,7 +103,7 @@ class _DirPkgReader(PhysPkgReader):
         rels item."""
         try:
             rels_xml = self.blob_for(source_uri.rels_uri)
-        except IOError:
+        except (IOError, KeyError):
             rels_xml = None
         return rels_xml
 
@@ -91,6 +128,9 @@ class _ZipPkgReader(PhysPkgReader):
             preflight_zip(source)
             self._zipf = ZipFile(source, "r")
             self._guarded_reader = GuardedZipReader(self._zipf)
+            self._member_name_by_fold = {
+                name.casefold(): name for name in self._guarded_reader.order
+            }
         except Exception:
             zip_file = getattr(self, "_zipf", None)
             if zip_file is not None:
@@ -102,7 +142,16 @@ class _ZipPkgReader(PhysPkgReader):
 
         Raises |ValueError| if no matching member is present in zip archive.
         """
-        return self._guarded_reader.read(pack_uri.membername)
+        actual_name = self._member_name_by_fold[pack_uri.membername.casefold()]
+        return self._guarded_reader.read(actual_name)
+
+    def partname_for(self, pack_uri):
+        actual_name = self._member_name_by_fold[pack_uri.membername.casefold()]
+        return type(pack_uri)(f"/{actual_name}")
+
+    @property
+    def member_names(self):
+        return self._guarded_reader.order
 
     def close(self):
         """Close the zip archive, releasing any resources it is using."""

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -76,13 +76,25 @@ class _ZipPkgReader(PhysPkgReader):
 
     def __init__(self, pkg_file):
         super(_ZipPkgReader, self).__init__()
-        enforce_compressed_size(pkg_file)
-        preflight_zip(pkg_file)
-        self._zipf = ZipFile(pkg_file, "r")
+        if isinstance(pkg_file, (str, os.PathLike)):
+            with open(pkg_file, "rb") as stream:
+                self._load(stream)
+                # GuardedZipReader caches every member during construction.
+                self._zipf.close()
+            return
+        self._load(pkg_file)
+
+    def _load(self, source):
+        """Preflight and cache one already-open package source."""
         try:
+            enforce_compressed_size(source)
+            preflight_zip(source)
+            self._zipf = ZipFile(source, "r")
             self._guarded_reader = GuardedZipReader(self._zipf)
         except Exception:
-            self._zipf.close()
+            zip_file = getattr(self, "_zipf", None)
+            if zip_file is not None:
+                zip_file.close()
             raise
 
     def blob_for(self, pack_uri):

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -1,10 +1,13 @@
 """Provides a general interface to a `physical` OPC package, such as a zip file."""
 
 import os
-from zipfile import ZIP_DEFLATED, ZipFile, is_zipfile
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo, is_zipfile
 
+from docx._zipguard import GuardedZipReader, enforce_compressed_size, preflight_zip
 from docx.opc.exceptions import PackageNotFoundError
 from docx.opc.packuri import CONTENT_TYPES_URI
+
+_FIXED_ZIP_DATE = (1980, 1, 1, 0, 0, 0)
 
 
 class PhysPkgReader:
@@ -73,14 +76,21 @@ class _ZipPkgReader(PhysPkgReader):
 
     def __init__(self, pkg_file):
         super(_ZipPkgReader, self).__init__()
+        enforce_compressed_size(pkg_file)
+        preflight_zip(pkg_file)
         self._zipf = ZipFile(pkg_file, "r")
+        try:
+            self._guarded_reader = GuardedZipReader(self._zipf)
+        except Exception:
+            self._zipf.close()
+            raise
 
     def blob_for(self, pack_uri):
         """Return blob corresponding to `pack_uri`.
 
         Raises |ValueError| if no matching member is present in zip archive.
         """
-        return self._zipf.read(pack_uri.membername)
+        return self._guarded_reader.read(pack_uri.membername)
 
     def close(self):
         """Close the zip archive, releasing any resources it is using."""
@@ -116,4 +126,8 @@ class _ZipPkgWriter(PhysPkgWriter):
     def write(self, pack_uri, blob):
         """Write `blob` to this zip package with the membername corresponding to
         `pack_uri`."""
-        self._zipf.writestr(pack_uri.membername, blob)
+        info = ZipInfo(pack_uri.membername, date_time=_FIXED_ZIP_DATE)
+        info.compress_type = ZIP_DEFLATED
+        info.create_system = 3
+        info.external_attr = 0o600 << 16
+        self._zipf.writestr(info, blob)

--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -318,10 +318,20 @@ class _SerializedRelationships:
 
 def _validate_relationship_records(blob, base_uri) -> None:
     """Check relationship fields before the object model can normalize them."""
+    parser = etree.XMLParser(
+        load_dtd=False,
+        no_network=True,
+        resolve_entities=False,
+    )
     try:
-        root = etree.fromstring(blob)
+        root = etree.fromstring(blob, parser)
     except etree.XMLSyntaxError as exc:
         raise PackageLimitError(f"relationships for {base_uri!r} are malformed") from exc
+    docinfo = root.getroottree().docinfo
+    if docinfo.doctype or docinfo.internalDTD is not None:
+        raise PackageLimitError(
+            f"relationships for {base_uri!r} contain a prohibited DTD"
+        )
     relationships_tag = (
         "{http://schemas.openxmlformats.org/package/2006/relationships}Relationships"
     )

--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -1,6 +1,14 @@
 """Low-level, read-only API to a serialized Open Packaging Convention (OPC) package."""
 
+from lxml import etree
+
+from docx._contenttypes import content_type_matches
+from docx._rels import is_relationship_type, is_xml_id
+from docx._zipguard import _parse_content_types
+from docx.errors import PackageLimitError
+from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TARGET_MODE as RTM
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.oxml import parse_xml
 from docx.opc.packuri import PACKAGE_URI, PackURI
 from docx.opc.phys_pkg import PhysPkgReader
@@ -20,11 +28,14 @@ class PackageReader:
     def from_file(pkg_file):
         """Return a |PackageReader| instance loaded with contents of `pkg_file`."""
         phys_reader = PhysPkgReader(pkg_file)
-        content_types = _ContentTypeMap.from_xml(phys_reader.content_types_xml)
-        pkg_srels = PackageReader._srels_for(phys_reader, PACKAGE_URI)
-        sparts = PackageReader._load_serialized_parts(phys_reader, pkg_srels, content_types)
-        phys_reader.close()
-        return PackageReader(content_types, pkg_srels, sparts)
+        try:
+            content_types = _ContentTypeMap.from_xml(phys_reader.content_types_xml)
+            pkg_srels = PackageReader._srels_for(phys_reader, PACKAGE_URI)
+            _validate_package_relationships(pkg_srels)
+            sparts = PackageReader._load_serialized_parts(phys_reader, pkg_srels, content_types)
+            return PackageReader(content_types, pkg_srels, sparts)
+        finally:
+            phys_reader.close()
 
     def iter_sparts(self):
         """Generate a 4-tuple `(partname, content_type, reltype, blob)` for each of the
@@ -47,7 +58,9 @@ class PackageReader:
         `phys_reader` accessible by walking the relationship graph starting with
         `pkg_srels`."""
         sparts = []
-        part_walker = PackageReader._walk_phys_parts(phys_reader, pkg_srels)
+        part_walker = PackageReader._walk_phys_parts(
+            phys_reader, pkg_srels, content_types=content_types
+        )
         for partname, blob, reltype, srels in part_walker:
             content_type = content_types[partname]
             spart = _SerializedPart(partname, content_type, reltype, blob, srels)
@@ -62,7 +75,7 @@ class PackageReader:
         return _SerializedRelationships.load_from_xml(source_uri.baseURI, rels_xml)
 
     @staticmethod
-    def _walk_phys_parts(phys_reader, srels, visited_partnames=None):
+    def _walk_phys_parts(phys_reader, srels, visited_partnames=None, content_types=None):
         """Generate a 4-tuple `(partname, blob, reltype, srels)` for each of the parts
         in `phys_reader` by walking the relationship graph rooted at srels."""
         if visited_partnames is None:
@@ -71,14 +84,34 @@ class PackageReader:
             if srel.is_external:
                 continue
             partname = srel.target_partname
-            if partname in visited_partnames:
+            if content_types is not None:
+                try:
+                    phys_reader.partname_for(partname)
+                except KeyError as exc:
+                    raise PackageLimitError(
+                        f"relationship {srel.rId!r} targets missing package part"
+                        f" {partname!s}"
+                    ) from exc
+                try:
+                    content_type = content_types[partname]
+                except KeyError as exc:
+                    raise PackageLimitError(
+                        f"relationship {srel.rId!r} targets {partname!s}, which has no"
+                        " declared content type"
+                    ) from exc
+                _validate_relationship_target_content_type(
+                    srel.reltype, content_type, partname
+                )
+            if str(partname).casefold() in {str(item).casefold() for item in visited_partnames}:
                 continue
             visited_partnames.append(partname)
             reltype = srel.reltype
             part_srels = PackageReader._srels_for(phys_reader, partname)
             blob = phys_reader.blob_for(partname)
             yield (partname, blob, reltype, part_srels)
-            next_walker = PackageReader._walk_phys_parts(phys_reader, part_srels, visited_partnames)
+            next_walker = PackageReader._walk_phys_parts(
+                phys_reader, part_srels, visited_partnames, content_types
+            )
             for partname, blob, reltype, srels in next_walker:
                 yield (partname, blob, reltype, srels)
 
@@ -108,6 +141,7 @@ class _ContentTypeMap:
     def from_xml(content_types_xml):
         """Return a new |_ContentTypeMap| instance populated with the contents of
         `content_types_xml`."""
+        _parse_content_types(content_types_xml)
         types_elm = parse_xml(content_types_xml)
         ct_map = _ContentTypeMap()
         for o in types_elm.overrides:
@@ -248,7 +282,139 @@ class _SerializedRelationships:
         """
         srels = _SerializedRelationships()
         if rels_item_xml is not None:
+            if isinstance(rels_item_xml, (bytes, str)):
+                _validate_relationship_records(rels_item_xml, baseURI)
             rels_elm = parse_xml(rels_item_xml)
+            seen_ids = set()
             for rel_elm in rels_elm.Relationship_lst:
-                srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
+                serialized = _SerializedRelationship(baseURI, rel_elm)
+                if isinstance(serialized.rId, str) and not is_xml_id(serialized.rId):
+                    raise PackageLimitError(
+                        f"relationship Id {serialized.rId!r} is not a valid XML ID"
+                    )
+                if isinstance(serialized.rId, str) and serialized.rId in seen_ids:
+                    raise PackageLimitError(
+                        f"relationships for {baseURI!r} contain duplicate Id {serialized.rId!r}"
+                    )
+                if isinstance(serialized.rId, str):
+                    seen_ids.add(serialized.rId)
+                if isinstance(serialized.target_mode, str) and serialized.target_mode not in (
+                    RTM.INTERNAL,
+                    RTM.EXTERNAL,
+                ):
+                    raise PackageLimitError(
+                        f"relationship {serialized.rId!r} has invalid TargetMode"
+                    )
+                if not serialized.is_external:
+                    try:
+                        serialized.target_partname
+                    except (IndexError, TypeError, ValueError) as exc:
+                        raise PackageLimitError(
+                            f"relationship {serialized.rId!r} has an invalid target"
+                        ) from exc
+                srels._srels.append(serialized)
         return srels
+
+
+def _validate_relationship_records(blob, base_uri) -> None:
+    """Check relationship fields before the object model can normalize them."""
+    try:
+        root = etree.fromstring(blob)
+    except etree.XMLSyntaxError as exc:
+        raise PackageLimitError(f"relationships for {base_uri!r} are malformed") from exc
+    relationships_tag = (
+        "{http://schemas.openxmlformats.org/package/2006/relationships}Relationships"
+    )
+    relationship_tag = (
+        "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
+    )
+    if root.tag != relationships_tag:
+        raise PackageLimitError(
+            f"relationships for {base_uri!r} have an unexpected root element"
+        )
+    seen = set()
+    for child in root:
+        if not isinstance(child.tag, str):
+            continue
+        if child.tag != relationship_tag:
+            raise PackageLimitError(
+                f"relationships for {base_uri!r} contain an unexpected element"
+            )
+        relationship_id = child.get("Id")
+        if not is_xml_id(relationship_id):
+            raise PackageLimitError(f"relationship Id {relationship_id!r} is not a valid XML ID")
+        if relationship_id in seen:
+            raise PackageLimitError(
+                f"relationships for {base_uri!r} contain duplicate Id {relationship_id!r}"
+            )
+        seen.add(relationship_id)
+        if not child.get("Type") or not child.get("Target"):
+            raise PackageLimitError(f"relationship {relationship_id!r} is missing Type or Target")
+        if child.get("TargetMode", RTM.INTERNAL) not in (RTM.INTERNAL, RTM.EXTERNAL):
+            raise PackageLimitError(f"relationship {relationship_id!r} has invalid TargetMode")
+
+
+def _validate_package_relationships(relationships) -> None:
+    """Reject ambiguous main-part declarations before object construction."""
+    office_documents = [
+        relationship
+        for relationship in relationships
+        if is_relationship_type(relationship.reltype, RT.OFFICE_DOCUMENT)
+    ]
+    if len(office_documents) > 1:
+        raise PackageLimitError(
+            "package contains multiple officeDocument relationships"
+        )
+    if office_documents and office_documents[0].is_external:
+        raise PackageLimitError("package officeDocument relationship is external")
+
+
+_OFFICE_DOCUMENT_CONTENT_TYPES = (
+    CT.WML_DOCUMENT_MAIN,
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml",
+    "application/vnd.ms-word.document.macroEnabled.main+xml",
+    "application/vnd.ms-word.template.macroEnabledTemplate.main+xml",
+    CT.PML_PRESENTATION_MAIN,
+    CT.PML_SLIDESHOW_MAIN,
+    CT.PML_TEMPLATE_MAIN,
+    "application/vnd.ms-powerpoint.presentation.macroEnabled.main+xml",
+    "application/vnd.ms-powerpoint.slideshow.macroEnabled.main+xml",
+    "application/vnd.ms-powerpoint.template.macroEnabled.main+xml",
+    CT.SML_SHEET_MAIN,
+    CT.SML_TEMPLATE_MAIN,
+    "application/vnd.ms-excel.sheet.macroEnabled.main+xml",
+    "application/vnd.ms-excel.template.macroEnabled.main+xml",
+)
+_KNOWN_RELATIONSHIP_CONTENT_TYPES = (
+    (RT.CORE_PROPERTIES, (CT.OPC_CORE_PROPERTIES,)),
+    (RT.OFFICE_DOCUMENT, _OFFICE_DOCUMENT_CONTENT_TYPES),
+    (RT.STYLES, (CT.WML_STYLES, CT.SML_STYLES)),
+    (RT.SETTINGS, (CT.WML_SETTINGS,)),
+    (RT.NUMBERING, (CT.WML_NUMBERING,)),
+    (RT.FONT_TABLE, (CT.WML_FONT_TABLE,)),
+    (RT.HEADER, (CT.WML_HEADER,)),
+    (RT.FOOTER, (CT.WML_FOOTER,)),
+    (RT.FOOTNOTES, (CT.WML_FOOTNOTES,)),
+    (RT.ENDNOTES, (CT.WML_ENDNOTES,)),
+    (RT.COMMENTS, (CT.WML_COMMENTS, CT.PML_COMMENTS, CT.SML_COMMENTS)),
+    (RT.THEME, (CT.OFC_THEME,)),
+)
+
+
+def _validate_relationship_target_content_type(reltype, content_type, partname) -> None:
+    """Reject a known role pointing at a part with an incompatible media type."""
+    if is_relationship_type(reltype, RT.IMAGE):
+        if content_type.partition(";")[0].strip().casefold().startswith("image/"):
+            return
+        raise PackageLimitError(
+            f"image relationship targets {partname!s} with invalid content type {content_type!r}"
+        )
+    for expected_reltype, expected_types in _KNOWN_RELATIONSHIP_CONTENT_TYPES:
+        if not is_relationship_type(reltype, expected_reltype):
+            continue
+        if any(content_type_matches(content_type, item) for item in expected_types):
+            return
+        raise PackageLimitError(
+            f"relationship type {reltype!r} targets {partname!s} with invalid content type"
+            f" {content_type!r}"
+        )

--- a/src/docx/opc/pkgwriter.py
+++ b/src/docx/opc/pkgwriter.py
@@ -32,10 +32,12 @@ class PackageWriter:
         """Write a physical package (.pptx file) to `pkg_file` containing `pkg_rels` and
         `parts` and a content types stream based on the content types of the parts."""
         phys_writer = PhysPkgWriter(pkg_file)
-        PackageWriter._write_content_types_stream(phys_writer, parts)
-        PackageWriter._write_pkg_rels(phys_writer, pkg_rels)
-        PackageWriter._write_parts(phys_writer, parts)
-        phys_writer.close()
+        try:
+            PackageWriter._write_content_types_stream(phys_writer, parts)
+            PackageWriter._write_pkg_rels(phys_writer, pkg_rels)
+            PackageWriter._write_parts(phys_writer, parts)
+        finally:
+            phys_writer.close()
 
     @staticmethod
     def _write_content_types_stream(phys_writer, parts):

--- a/src/docx/opc/rel.py
+++ b/src/docx/opc/rel.py
@@ -18,6 +18,11 @@ class Relationships(Dict[str, "_Relationship"]):
         self._baseURI = baseURI
         self._target_parts_by_rId: dict[str, Any] = {}
 
+    def __delitem__(self, rId: str) -> None:
+        """Remove `rId` from both relationship indexes."""
+        super().__delitem__(rId)
+        self._target_parts_by_rId.pop(rId, None)
+
     def add_relationship(
         self, reltype: str, target: Part | str, rId: str, is_external: bool = False
     ) -> "_Relationship":

--- a/src/docx/protection.py
+++ b/src/docx/protection.py
@@ -39,7 +39,7 @@ class ProtectionStatus:
     """What `w:documentProtection` declares, read-only.
 
     `edit` is the raw `w:edit` token ("readOnly", "forms", "comments",
-    "trackedChanges") or None when no edit restriction is declared;
+    "trackedChanges", or unrestricted "none") or None when no edit restriction is declared;
     `formatting` reflects the independent format restriction. `enforced`
     reports active enforcement of either kind; `acknowledged` is this
     package's in-memory override flag (never persisted).
@@ -95,7 +95,7 @@ def protection_status(document: "Document") -> ProtectionStatus:
     enforcement = _is_on(element.get(qn("w:enforcement")))
     return ProtectionStatus(
         edit=edit,
-        enforced=(edit is not None or formatting) and enforcement,
+        enforced=(edit not in (None, "none") or formatting) and enforcement,
         acknowledged=bool(getattr(package, _ACK_ATTR, False)),
         formatting=formatting,
     )
@@ -131,9 +131,13 @@ def _refuse_if_protected(obj, operation: str) -> None:
     edit = element.get(qn("w:edit"))
     formatting = _is_on(element.get(qn("w:formatting")))
     enforcement = _is_on(element.get(qn("w:enforcement")))
-    if (edit is None and not formatting) or not enforcement:
+    if (edit in (None, "none") and not formatting) or not enforcement:
         return
-    restriction = f"{edit!r} editing" if edit is not None else "formatting-only"
+    restriction = (
+        f"{edit!r} editing"
+        if edit not in (None, "none")
+        else "formatting-only"
+    )
     raise DocumentProtectedError(
         f"cannot {operation}: this document enforces {restriction}"
         " protection (w:documentProtection). Protection is advisory, not"

--- a/src/docx/protection.py
+++ b/src/docx/protection.py
@@ -30,19 +30,25 @@ _ACK_ATTR = "_paper_protection_acknowledged"
 _TRUTHY = ("1", "true", "on")
 
 
+def _is_on(value: Optional[str]) -> bool:
+    return (value or "").lower() in _TRUTHY
+
+
 @dataclass(frozen=True)
 class ProtectionStatus:
     """What `w:documentProtection` declares, read-only.
 
     `edit` is the raw `w:edit` token ("readOnly", "forms", "comments",
-    "trackedChanges") or None when no protection element exists; `enforced`
-    reflects `w:enforcement`; `acknowledged` is this package's in-memory
-    override flag (never persisted).
+    "trackedChanges") or None when no edit restriction is declared;
+    `formatting` reflects the independent format restriction. `enforced`
+    reports active enforcement of either kind; `acknowledged` is this
+    package's in-memory override flag (never persisted).
     """
 
     edit: Optional[str]
     enforced: bool
     acknowledged: bool
+    formatting: bool = False
 
     @property
     def blocks_paper_edits(self) -> bool:
@@ -51,6 +57,7 @@ class ProtectionStatus:
     def to_dict(self) -> dict:
         return {
             "edit": self.edit,
+            "formatting": self.formatting,
             "enforced": self.enforced,
             "acknowledged": self.acknowledged,
         }
@@ -80,13 +87,17 @@ def protection_status(document: "Document") -> ProtectionStatus:
     package = _package_of(document)
     element = _protection_element(package)
     if element is None:
-        return ProtectionStatus(edit=None, enforced=False, acknowledged=False)
+        return ProtectionStatus(
+            edit=None, enforced=False, acknowledged=False, formatting=False
+        )
     edit = element.get(qn("w:edit"))
-    enforcement = (element.get(qn("w:enforcement")) or "").lower()
+    formatting = _is_on(element.get(qn("w:formatting")))
+    enforcement = _is_on(element.get(qn("w:enforcement")))
     return ProtectionStatus(
         edit=edit,
-        enforced=edit is not None and enforcement in _TRUTHY,
+        enforced=(edit is not None or formatting) and enforcement,
         acknowledged=bool(getattr(package, _ACK_ATTR, False)),
+        formatting=formatting,
     )
 
 
@@ -105,7 +116,7 @@ def acknowledge_protection(document: "Document") -> ProtectionStatus:
 
 
 def _refuse_if_protected(obj, operation: str) -> None:
-    """Typed refusal when `obj`'s document enforces editing protection.
+    """Typed refusal when `obj`'s document enforces edit/format protection.
 
     `obj` is whatever the mutating API has in hand: a |Document|, or any
     proxy/part with a `.part` (Table, Paragraph, ...). Called BEFORE any
@@ -118,11 +129,13 @@ def _refuse_if_protected(obj, operation: str) -> None:
     if element is None:
         return
     edit = element.get(qn("w:edit"))
-    enforcement = (element.get(qn("w:enforcement")) or "").lower()
-    if edit is None or enforcement not in _TRUTHY:
+    formatting = _is_on(element.get(qn("w:formatting")))
+    enforcement = _is_on(element.get(qn("w:enforcement")))
+    if (edit is None and not formatting) or not enforcement:
         return
+    restriction = f"{edit!r} editing" if edit is not None else "formatting-only"
     raise DocumentProtectedError(
-        f"cannot {operation}: this document enforces {edit!r} editing"
+        f"cannot {operation}: this document enforces {restriction}"
         " protection (w:documentProtection). Protection is advisory, not"
         " security — if editing is intended, call"
         " docx.protection.acknowledge_protection(document) first; paper-docx"

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -235,6 +235,7 @@ class Revision:
                 accept=True,
                 author=None,
                 require_clean=False,
+                individual=True,
             )
             with rollback_on_error(self._document):
                 _resolve_one(self._element, accept=True, document=self._document)
@@ -254,6 +255,7 @@ class Revision:
                 accept=False,
                 author=None,
                 require_clean=False,
+                individual=True,
             )
             with rollback_on_error(self._document):
                 _resolve_one(self._element, accept=False, document=self._document)
@@ -353,6 +355,7 @@ class Revisions(Sequence[Revision]):
             accept=accept,
             author=author,
             require_clean=author is None,
+            individual=False,
         )
         if not _transactional:
             return self._apply_all(selected, accept=accept)
@@ -664,6 +667,7 @@ def _preflight_resolution(
     accept: bool,
     author: "Optional[str]",
     require_clean: bool,
+    individual: bool,
 ) -> None:
     """Validate every dependency a resolution can touch before mutation."""
     _validate_comment_marker_ids(document)
@@ -674,8 +678,13 @@ def _preflight_resolution(
         _refuse_unaccounted_markup(document)
     _validate_paragraph_mark_joins(selected, document, accept=accept)
     discard_roots = _resolution_discard_roots(selected, document, accept=accept)
-    _validate_filtered_destructive_closure(
-        discard_roots, selected, document, author=author
+    _validate_destructive_closure(
+        discard_roots,
+        selected,
+        document,
+        accept=accept,
+        author=author,
+        individual=individual,
     )
     _validate_cleanup_dependencies(document, discard_roots)
 
@@ -750,18 +759,40 @@ def _resolution_discard_roots(
     return roots
 
 
-def _validate_filtered_destructive_closure(
+def _validate_destructive_closure(
     discard_roots: "List[_Element]",
     selected: "List[Revision]",
     document: "Document",
     *,
+    accept: bool,
     author: "Optional[str]",
+    individual: bool,
 ) -> None:
-    """Refuse a filter that would erase unselected revision markup."""
-    if author is None:
+    """Refuse selected destructive changes that erase unselected markup."""
+    if author is None and not individual:
         return
     selected_ids = {id(revision._element) for revision in selected}  # noqa: SLF001
     accounted_ids = set(selected_ids)
+    for revision in selected:
+        if revision.revision_type not in ("row_insertion", "row_deletion"):
+            continue
+        marker = revision._element  # noqa: SLF001
+        marker_author = marker.get(_AUTHOR)
+        marker_date = marker.get(_DATE)
+        if not marker_author or not marker_date:
+            continue
+        tr_pr = marker.getparent()
+        row = tr_pr.getparent() if tr_pr is not None else None
+        if row is None or row.tag != _TR:
+            continue  # `_resolution_discard_roots()` reports the malformed row.
+        for node in row.iter(marker.tag):
+            if (
+                node.get(_AUTHOR) == marker_author
+                and node.get(_DATE) == marker_date
+            ):
+                # Word records one row change as a row marker plus matching
+                # content and paragraph-mark revisions in each cell.
+                accounted_ids.add(id(node))
     selected_move_ids = {
         id(revision._element)  # noqa: SLF001
         for revision in selected
@@ -773,18 +804,35 @@ def _validate_filtered_destructive_closure(
             if any(id(element) in selected_move_ids for element in unit.elements):
                 accounted_ids.update(id(element) for element in unit.elements)
 
-    conflicts: "set[str]" = set()
+    conflict_authors: "set[str]" = set()
+    conflict_types: "set[str]" = set()
     for root in discard_roots:
         for node in root.iter():
             if node.tag not in _MARKUP_SCAN_TAGS or id(node) in accounted_ids:
                 continue
             node_author = node.get(_AUTHOR) or ""
-            conflicts.add(node_author or "<missing author>")
-    if conflicts:
+            conflict_authors.add(node_author or "<missing author>")
+            conflict_types.add(
+                _revision_type_of(node)
+                if node.tag in _REVISION_TYPES
+                else node.tag.rsplit("}", 1)[-1]
+            )
+    if not conflict_types:
+        return
+    if individual:
+        verb = "accept" if accept else "reject"
+        revision_type = selected[0].revision_type
+        raise UnsupportedStructureError(
+            f"cannot {verb} a {revision_type!r} revision individually: its"
+            " destructive resolution would also consume nested unselected"
+            f" revision markup (types {sorted(conflict_types)!r}, authors"
+            f" {sorted(conflict_authors)!r}); nothing was changed"
+        )
+    if author is not None:
         raise UnsupportedStructureError(
             f"cannot resolve revisions with author={author!r}: a selected"
             " destructive revision would also consume unselected revision"
-            f" markup (authors {sorted(conflicts)!r}); nothing was changed"
+            f" markup (authors {sorted(conflict_authors)!r}); nothing was changed"
         )
 
 

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -773,26 +773,6 @@ def _validate_destructive_closure(
         return
     selected_ids = {id(revision._element) for revision in selected}  # noqa: SLF001
     accounted_ids = set(selected_ids)
-    for revision in selected:
-        if revision.revision_type not in ("row_insertion", "row_deletion"):
-            continue
-        marker = revision._element  # noqa: SLF001
-        marker_author = marker.get(_AUTHOR)
-        marker_date = marker.get(_DATE)
-        if not marker_author or not marker_date:
-            continue
-        tr_pr = marker.getparent()
-        row = tr_pr.getparent() if tr_pr is not None else None
-        if row is None or row.tag != _TR:
-            continue  # `_resolution_discard_roots()` reports the malformed row.
-        for node in row.iter(marker.tag):
-            if (
-                node.get(_AUTHOR) == marker_author
-                and node.get(_DATE) == marker_date
-            ):
-                # Word records one row change as a row marker plus matching
-                # content and paragraph-mark revisions in each cell.
-                accounted_ids.add(id(node))
     selected_move_ids = {
         id(revision._element)  # noqa: SLF001
         for revision in selected

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -20,6 +20,7 @@ import datetime as dt
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
+from docx._transaction import rollback_on_error
 from docx.errors import UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
@@ -235,7 +236,10 @@ class Revision:
                 author=None,
                 require_clean=False,
             )
-        _resolve_one(self._element, accept=True, document=self._document)
+            with rollback_on_error(self._document):
+                _resolve_one(self._element, accept=True, document=self._document)
+            return
+        _resolve_one(self._element, accept=True, document=None)
 
     def reject(self) -> None:
         """Undo this change, restoring the pre-change content. Tracked moves
@@ -251,7 +255,10 @@ class Revision:
                 author=None,
                 require_clean=False,
             )
-        _resolve_one(self._element, accept=False, document=self._document)
+            with rollback_on_error(self._document):
+                _resolve_one(self._element, accept=False, document=self._document)
+            return
+        _resolve_one(self._element, accept=False, document=None)
 
     def to_dict(self) -> dict:
         return {
@@ -312,7 +319,13 @@ class Revisions(Sequence[Revision]):
                 census[revision.revision_type] = census.get(revision.revision_type, 0) + 1
         return dict(sorted(census.items()))
 
-    def _resolve_all(self, *, accept: bool, author: Optional[str]) -> int:
+    def _resolve_all(
+        self,
+        *,
+        accept: bool,
+        author: Optional[str],
+        _transactional: bool = True,
+    ) -> int:
         if self._snapshot_signature != _revision_signature(self._document):
             raise UnsupportedStructureError(
                 "cannot resolve a stale Revisions snapshot; reacquire"
@@ -341,6 +354,12 @@ class Revisions(Sequence[Revision]):
             author=author,
             require_clean=author is None,
         )
+        if not _transactional:
+            return self._apply_all(selected, accept=accept)
+        with rollback_on_error(self._document):
+            return self._apply_all(selected, accept=accept)
+
+    def _apply_all(self, selected: "List[Revision]", *, accept: bool) -> int:
         # moves first (their range brackets must still be intact — a row
         # removal in the same batch could take a move site with it), then
         # other content, then paragraph marks (mark resolution can remove

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
 from docx.errors import UnsupportedStructureError
@@ -56,6 +56,23 @@ _RPR_CHANGE = qn("w:rPrChange")
 _PPR_CHANGE = qn("w:pPrChange")
 _AUTHOR = qn("w:author")
 _DATE = qn("w:date")
+_COMMENT = qn("w:comment")
+_COMMENT_RANGE_START = qn("w:commentRangeStart")
+_COMMENT_RANGE_END = qn("w:commentRangeEnd")
+_COMMENT_REFERENCE = qn("w:commentReference")
+_FOOTNOTE = qn("w:footnote")
+_ENDNOTE = qn("w:endnote")
+_FOOTNOTE_REFERENCE = qn("w:footnoteReference")
+_ENDNOTE_REFERENCE = qn("w:endnoteReference")
+_NOTE_TYPE = qn("w:type")
+_W14_PARA_ID = qn("w14:paraId")
+_W15_NS = "http://schemas.microsoft.com/office/word/2012/wordml"
+_W15_COMMENT_EX = f"{{{_W15_NS}}}commentEx"
+_W15_PARA_ID = f"{{{_W15_NS}}}paraId"
+_REL_NS_PREFIX = (
+    "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+)
+_OFFICE_REL_ID = "{urn:schemas-microsoft-com:office:office}relid"
 
 #: tag -> revision_type for everything Document.revisions enumerates.
 #: `w:ins`/`w:del` refine to "row_insertion"/"row_deletion" when the node is
@@ -170,6 +187,9 @@ class Revision:
     is_paragraph_mark: bool
     _element: "_Element"
     _document: "Optional[Document]" = None
+    _snapshot_signature: "Tuple[_Element, ...]" = field(
+        default=(), repr=False, compare=False
+    )
 
     @property
     def is_resolvable(self) -> bool:
@@ -184,20 +204,53 @@ class Revision:
                 " version)"
             )
 
+    def _refuse_if_stale(self, verb: str) -> None:
+        if self._document is None:
+            if self._element.getparent() is None:
+                raise UnsupportedStructureError(
+                    f"cannot {verb} a stale Revision; reacquire it from"
+                    " document.revisions. Nothing was changed"
+                )
+            return
+        if (
+            self._snapshot_signature != _revision_signature(self._document)
+            or not _is_in_story(self._element, self._document)
+        ):
+            raise UnsupportedStructureError(
+                f"cannot {verb} a stale Revision; reacquire it from"
+                " document.revisions. Nothing was changed"
+            )
+
     def accept(self) -> None:
         """Apply this change to the document. Tracked moves resolve as a
         PAIR: accepting either site accepts both."""
         self._refuse_unresolvable("accept")
+        self._refuse_if_stale("accept")
         if self._document is not None:
             _refuse_if_protected(self._document, "resolve a revision")
+            _preflight_resolution(
+                self._document,
+                [self],
+                accept=True,
+                author=None,
+                require_clean=False,
+            )
         _resolve_one(self._element, accept=True, document=self._document)
 
     def reject(self) -> None:
         """Undo this change, restoring the pre-change content. Tracked moves
         resolve as a PAIR: rejecting either site rejects both."""
         self._refuse_unresolvable("reject")
+        self._refuse_if_stale("reject")
         if self._document is not None:
             _refuse_if_protected(self._document, "resolve a revision")
+            _preflight_resolution(
+                self._document,
+                [self],
+                accept=False,
+                author=None,
+                require_clean=False,
+            )
         _resolve_one(self._element, accept=False, document=self._document)
 
     def to_dict(self) -> dict:
@@ -216,12 +269,13 @@ class Revisions(Sequence[Revision]):
     """All tracked changes in a document, across every story part.
 
     A fresh snapshot is enumerated on each `Document.revisions` access;
-    resolving revisions invalidates previously-held |Revision| objects.
+    mutation through another snapshot invalidates this snapshot and its
+    previously-held |Revision| objects. Stale resolution attempts refuse.
     """
 
     def __init__(self, document: "Document") -> None:
         self._document = document
-        self._items = tuple(_enumerate_revisions(document))
+        self._items, self._snapshot_signature = _revision_snapshot(document)
 
     def __len__(self) -> int:
         return len(self._items)
@@ -236,8 +290,8 @@ class Revisions(Sequence[Revision]):
         """Apply every selected revision (optionally only `author`'s).
 
         Validates the WHOLE selected set first: if it contains revision types
-        this package cannot resolve (moves, formatting changes), the call
-        refuses atomically — it never half-resolves and reports success while
+        this package cannot resolve, the call refuses atomically — it never
+        half-resolves and reports success while
         Word still shows pending changes. Returns the resolved count; check
         `remaining_unsupported()` before inferring "the document is clean".
         """
@@ -259,6 +313,11 @@ class Revisions(Sequence[Revision]):
         return dict(sorted(census.items()))
 
     def _resolve_all(self, *, accept: bool, author: Optional[str]) -> int:
+        if self._snapshot_signature != _revision_signature(self._document):
+            raise UnsupportedStructureError(
+                "cannot resolve a stale Revisions snapshot; reacquire"
+                " document.revisions. Nothing was changed"
+            )
         _refuse_if_protected(self._document, "resolve revisions")
         selected = [
             revision
@@ -275,12 +334,13 @@ class Revisions(Sequence[Revision]):
                 " by author, resolve individual insertions/deletions, or"
                 " resolve the rest in Word"
             )
-        _validate_moves(selected, self._document)
-        if author is None:
-            # an UNFILTERED resolution certifies "clean afterwards" — refuse
-            # upfront anything that would falsify that
-            _refuse_unaccounted_markup(self._document)
-        resolved = 0
+        _preflight_resolution(
+            self._document,
+            selected,
+            accept=accept,
+            author=author,
+            require_clean=author is None,
+        )
         # moves first (their range brackets must still be intact — a row
         # removal in the same batch could take a move site with it), then
         # other content, then paragraph marks (mark resolution can remove
@@ -290,13 +350,23 @@ class Revisions(Sequence[Revision]):
                 return 0
             return 2 if item.is_paragraph_mark else 1
 
-        for revision in sorted(selected, key=_order):
+        ordered = sorted(selected, key=_order)
+        handled: set[int] = set()
+        for revision in ordered:
+            element_id = id(revision._element)  # noqa: SLF001
+            if element_id in handled:
+                continue
+            if not _is_in_story(revision._element, self._document):  # noqa: SLF001
+                # An earlier move/row/enclosing-wrapper operation resolved
+                # this selected node as part of its compound unit.
+                handled.add(element_id)
+                continue
             _resolve_one(  # noqa: SLF001
                 revision._element, accept=accept, document=self._document
             )
-            resolved += 1
-        self._items = tuple(_enumerate_revisions(self._document))
-        return resolved
+            handled.add(element_id)
+        self._items, self._snapshot_signature = _revision_snapshot(self._document)
+        return len(selected)
 
     def to_dict(self) -> dict:
         return {
@@ -492,11 +562,9 @@ def _resolve_move_unit(
     for wrapper in keep_site.wrappers:
         if wrapper.getparent() is not None:
             _unwrap(wrapper)
-    orphaned_comments: "List[int]" = []
     for wrapper in drop_site.wrappers:
         if wrapper.getparent() is not None:
-            orphaned_comments.extend(_comment_ids_inside(wrapper))
-            wrapper.getparent().remove(wrapper)
+            _discard_element(wrapper, document)
     for site in (unit.from_site, unit.to_site):
         for marker in (site.start, site.end):
             if marker is not None and marker.getparent() is not None:
@@ -505,12 +573,17 @@ def _resolve_move_unit(
         for stamp in site.mark_stamps:
             if stamp.getparent() is not None:
                 _resolve_paragraph_mark(stamp, accept=accept)
-    _cleanup_comment_anchors(document, orphaned_comments)
 
 
-def _validate_moves(selected: "List[Revision]", document: "Document") -> None:
+def _validate_moves(
+    selected: "List[Revision]",
+    document: "Document",
+    *,
+    author: "Optional[str]",
+) -> None:
     """Refuse BEFORE mutating when any selected move is orphaned, duplicated
-    or cross-story (refusal atomicity for the batch)."""
+    or cross-story, or an author filter would resolve another author's side
+    of the same compound move (refusal atomicity for the batch)."""
     move_nodes = [
         revision._element  # noqa: SLF001
         for revision in selected
@@ -519,10 +592,15 @@ def _validate_moves(selected: "List[Revision]", document: "Document") -> None:
     if not move_nodes:
         return
     units, orphans = _move_units(document)
-    unit_elements = {id(e) for unit in units for e in unit.elements}
+    units_by_element = {
+        id(element): unit for unit in units for element in unit.elements
+    }
     orphan_reasons = {id(element): reason for element, reason in orphans}
+    touched_units: dict[int, _MoveUnit] = {}
     for node in move_nodes:
-        if id(node) in unit_elements:
+        unit = units_by_element.get(id(node))
+        if unit is not None:
+            touched_units[id(unit)] = unit
             continue
         reason = orphan_reasons.get(
             id(node), "its range markers were not found"
@@ -530,6 +608,164 @@ def _validate_moves(selected: "List[Revision]", document: "Document") -> None:
         raise UnsupportedStructureError(
             f"selected revisions include an unresolvable tracked move:"
             f" {reason}; nothing was changed. Resolve it in Word instead"
+        )
+    if author is None:
+        return
+    for unit in touched_units.values():
+        revision_elements = (
+            unit.from_site.wrappers
+            + unit.from_site.mark_stamps
+            + unit.to_site.wrappers
+            + unit.to_site.mark_stamps
+        )
+        unit_authors = {element.get(_AUTHOR) or "" for element in revision_elements}
+        unit_authors.update(
+            value
+            for element in (
+                unit.from_site.start,
+                unit.from_site.end,
+                unit.to_site.start,
+                unit.to_site.end,
+            )
+            if element is not None
+            if (value := element.get(_AUTHOR)) is not None
+        )
+        if unit_authors != {author}:
+            raise UnsupportedStructureError(
+                f"cannot resolve move {unit.name!r} with author={author!r}:"
+                f" its compound move unit's authors differ"
+                f" ({sorted(unit_authors)!r}); nothing was changed"
+            )
+
+
+def _preflight_resolution(
+    document: "Document",
+    selected: "List[Revision]",
+    *,
+    accept: bool,
+    author: "Optional[str]",
+    require_clean: bool,
+) -> None:
+    """Validate every dependency a resolution can touch before mutation."""
+    _validate_comment_marker_ids(document)
+    _validate_moves(selected, document, author=author)
+    if require_clean:
+        # An unfiltered resolution certifies "clean afterwards". Refuse
+        # upfront anything that would falsify that claim.
+        _refuse_unaccounted_markup(document)
+    _validate_paragraph_mark_joins(selected, document, accept=accept)
+    discard_roots = _resolution_discard_roots(selected, document, accept=accept)
+    _validate_filtered_destructive_closure(
+        discard_roots, selected, document, author=author
+    )
+    _validate_cleanup_dependencies(document, discard_roots)
+
+
+def _resolution_discard_roots(
+    selected: "List[Revision]",
+    document: "Document",
+    *,
+    accept: bool,
+) -> "List[_Element]":
+    """Subtrees that `_resolve_one()` can detach for this selected set."""
+    units, _orphans = _move_units(document)
+    units_by_element = {
+        id(element): unit for unit in units for element in unit.elements
+    }
+    roots: "List[_Element]" = []
+    seen: "set[int]" = set()
+
+    def add(root: "Optional[_Element]") -> None:
+        if root is not None and id(root) not in seen:
+            roots.append(root)
+            seen.add(id(root))
+
+    for revision in selected:
+        node = revision._element  # noqa: SLF001
+        if revision.is_paragraph_mark and _paragraph_mark_applies(
+            node, accept=accept
+        ):
+            paragraph = _paragraph_of_mark(node)
+            if paragraph is not None and _paragraph_has_content(paragraph):
+                if _next_paragraph_sibling(paragraph) is not None:
+                    add(paragraph.find(_PPR))
+            elif (
+                paragraph is not None
+                and not _is_last_block_in_container(paragraph)
+            ):
+                add(paragraph)
+
+        if revision.revision_type in ("move_from", "move_to"):
+            unit = units_by_element.get(id(node))
+            if unit is None:
+                continue  # `_validate_moves()` already raised for this case.
+            drop_site = unit.from_site if accept else unit.to_site
+            for wrapper in drop_site.wrappers:
+                add(wrapper)
+            continue
+
+        if revision.revision_type in ("row_insertion", "row_deletion"):
+            keeps_row = (
+                node.tag == _INS and accept
+            ) or (node.tag == _DEL and not accept)
+            if keeps_row:
+                continue
+            tr_pr = node.getparent()
+            row = tr_pr.getparent() if tr_pr is not None else None
+            table = row.getparent() if row is not None else None
+            if row is None or row.tag != _TR or table is None or table.tag != _TBL:
+                raise UnsupportedStructureError(
+                    "malformed tracked-row revision cannot be resolved;"
+                    " nothing was changed"
+                )
+            row_count = sum(1 for child in table if child.tag == _TR)
+            add(table if row_count == 1 else row)
+            continue
+
+        removes_content = (node.tag == _INS and not accept) or (
+            node.tag == _DEL and accept
+        )
+        if removes_content and not revision.is_paragraph_mark:
+            add(node)
+
+    return roots
+
+
+def _validate_filtered_destructive_closure(
+    discard_roots: "List[_Element]",
+    selected: "List[Revision]",
+    document: "Document",
+    *,
+    author: "Optional[str]",
+) -> None:
+    """Refuse a filter that would erase unselected revision markup."""
+    if author is None:
+        return
+    selected_ids = {id(revision._element) for revision in selected}  # noqa: SLF001
+    accounted_ids = set(selected_ids)
+    selected_move_ids = {
+        id(revision._element)  # noqa: SLF001
+        for revision in selected
+        if revision.revision_type in ("move_from", "move_to")
+    }
+    if selected_move_ids:
+        units, _orphans = _move_units(document)
+        for unit in units:
+            if any(id(element) in selected_move_ids for element in unit.elements):
+                accounted_ids.update(id(element) for element in unit.elements)
+
+    conflicts: "set[str]" = set()
+    for root in discard_roots:
+        for node in root.iter():
+            if node.tag not in _MARKUP_SCAN_TAGS or id(node) in accounted_ids:
+                continue
+            node_author = node.get(_AUTHOR) or ""
+            conflicts.add(node_author or "<missing author>")
+    if conflicts:
+        raise UnsupportedStructureError(
+            f"cannot resolve revisions with author={author!r}: a selected"
+            " destructive revision would also consume unselected revision"
+            f" markup (authors {sorted(conflicts)!r}); nothing was changed"
         )
 
 
@@ -600,6 +836,25 @@ def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
                 )
 
 
+def _revision_signature(document: "Document") -> "Tuple[_Element, ...]":
+    """Identity signature for the document's currently enumerable revisions."""
+    return tuple(revision._element for revision in _enumerate_revisions(document))
+
+
+def _revision_snapshot(
+    document: "Document",
+) -> "Tuple[Tuple[Revision, ...], Tuple[_Element, ...]]":
+    revisions = tuple(_enumerate_revisions(document))
+    signature = tuple(revision._element for revision in revisions)
+    return (
+        tuple(
+            replace(revision, _snapshot_signature=signature)
+            for revision in revisions
+        ),
+        signature,
+    )
+
+
 #: every tag that constitutes revision markup, for the post-resolution rescan
 #: (enumerated types plus the range brackets that resolution must sweep up)
 _MARKUP_SCAN_TAGS = tuple(_REVISION_TYPES) + tuple(
@@ -664,6 +919,22 @@ def _refuse_unaccounted_markup(document: "Document") -> None:
             f" ({'; '.join(reasons)}); nothing was changed. Resolve it in"
             " Word instead"
         )
+    marker_only = sorted(
+        unit.name
+        for unit in units
+        if not (
+            unit.from_site.wrappers
+            or unit.from_site.mark_stamps
+            or unit.to_site.wrappers
+            or unit.to_site.mark_stamps
+        )
+    )
+    if marker_only:
+        raise UnsupportedStructureError(
+            "the document carries complete marker-only move units with no"
+            f" resolvable move content ({marker_only!r}); nothing was"
+            " changed. Resolve it in Word instead"
+        )
     accounted = {id(r._element) for r in _enumerate_revisions(document)}  # noqa: SLF001
     for unit in units:
         accounted.update(id(element) for element in unit.elements)
@@ -689,12 +960,360 @@ def _is_in_story(node: "_Element", document: "Document") -> bool:
     return id(top) in root_ids
 
 
-def _comment_ids_inside(node: "_Element"):
-    return [
-        int(ref.get(qn("w:id")))
-        for ref in node.iter(qn("w:commentReference"))
-        if ref.get(qn("w:id"))
-    ]
+def _comment_id(node: "_Element") -> int:
+    raw = node.get(_ID)
+    try:
+        if raw is None:
+            raise ValueError
+        return int(raw)
+    except (TypeError, ValueError):
+        name = node.tag.rsplit("}", 1)[-1]
+        raise UnsupportedStructureError(
+            f"malformed {name} comment marker w:id={raw!r}; nothing was"
+            " changed"
+        ) from None
+
+
+def _related_xml_root(
+    document: "Document", reltype: str, label: str
+) -> "Optional[_Element]":
+    """Return one related live-XML root or refuse an ambiguous/opaque part."""
+    try:
+        part = document.part.part_related_by(reltype)
+    except KeyError:
+        return None
+    except ValueError:
+        raise UnsupportedStructureError(
+            f"multiple {label} relationships make revision cleanup"
+            " ambiguous; nothing was changed"
+        ) from None
+    root = getattr(part, "_element", None)
+    if root is None:
+        raise UnsupportedStructureError(
+            f"{label} part is not loaded as live XML; nothing was changed"
+        )
+    return root
+
+
+def _validate_comment_marker_ids(document: "Document") -> None:
+    """Validate comment identifiers and cleanup parts before mutation."""
+    for _story, root in _story_elements(document):
+        for marker in root.iter(
+            _COMMENT_RANGE_START, _COMMENT_RANGE_END, _COMMENT_REFERENCE
+        ):
+            _comment_id(marker)
+        for comment in root.iter(_COMMENT):
+            _comment_id(comment)
+
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    comments_root = _related_xml_root(document, RT.COMMENTS, "comments")
+    if comments_root is not None:
+        for comment in comments_root.iter(_COMMENT):
+            _comment_id(comment)
+
+    # Cleanup also edits commentsExtended. Ensure it is live XML before a
+    # destructive operation can discover that too late for atomic refusal.
+    from docx.commentops import COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+
+    _related_xml_root(
+        document,
+        COMMENTS_EXTENDED_RELATIONSHIP_TYPE,
+        "commentsExtended",
+    )
+
+
+def _comment_ids_inside(node: "_Element") -> "List[int]":
+    return [_comment_id(ref) for ref in node.iter(_COMMENT_REFERENCE)]
+
+
+def _comment_range_ids_inside(node: "_Element") -> "set[int]":
+    return {
+        _comment_id(marker)
+        for marker in node.iter(_COMMENT_RANGE_START, _COMMENT_RANGE_END)
+    }
+
+
+def _part_containing(node: "_Element", document: "Document"):
+    top = node
+    while top.getparent() is not None:
+        top = top.getparent()
+    package = document.part.package
+    assert package is not None
+    for part in package.iter_parts():
+        if getattr(part, "_element", None) is top:
+            return part
+    return None
+
+
+def _is_relationship_attribute(name: str) -> bool:
+    return name.startswith(_REL_NS_PREFIX) or name == _OFFICE_REL_ID
+
+
+def _relationship_ids_inside(node: "_Element", part) -> "set[str]":
+    available = set(part.rels)
+    return {
+        value
+        for descendant in node.iter()
+        for name, value in descendant.attrib.items()
+        if _is_relationship_attribute(name) and value in available
+    }
+
+
+def _drop_unreferenced_relationships(part, candidates: "set[str]") -> None:
+    if not candidates:
+        return
+    root = getattr(part, "_element", None)
+    if root is None:
+        return
+    referenced = {
+        value
+        for descendant in root.iter()
+        for name, value in descendant.attrib.items()
+        if _is_relationship_attribute(name) and value in candidates
+    }
+    for r_id in sorted(candidates - referenced):
+        if r_id in part.rels:
+            part.drop_rel(r_id)
+
+
+def _note_id(node: "_Element") -> int:
+    raw = node.get(_ID)
+    try:
+        if raw is None:
+            raise ValueError
+        return int(raw)
+    except (TypeError, ValueError):
+        name = node.tag.rsplit("}", 1)[-1]
+        raise UnsupportedStructureError(
+            f"malformed {name} w:id={raw!r}; nothing was changed"
+        ) from None
+
+
+def _note_ids_inside(node: "_Element", reference_tag: str) -> "set[int]":
+    return {_note_id(reference) for reference in node.iter(reference_tag)}
+
+
+def _note_reference_remains(
+    document: "Document", reference_tag: str, note_id: int
+) -> bool:
+    return any(
+        _note_id(reference) == note_id
+        for _story, root in _story_elements(document)
+        for reference in root.iter(reference_tag)
+    )
+
+
+def _validate_note_cleanup_graph(document: "Document") -> None:
+    """Validate both note relationship graphs and all decimal identifiers."""
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    note_kinds = (
+        (_FOOTNOTE_REFERENCE, _FOOTNOTE, RT.FOOTNOTES, "footnotes"),
+        (_ENDNOTE_REFERENCE, _ENDNOTE, RT.ENDNOTES, "endnotes"),
+    )
+    roots = [root for _story, root in _story_elements(document)]
+    comments_root = _related_xml_root(document, RT.COMMENTS, "comments")
+    if comments_root is not None and all(
+        comments_root is not existing for existing in roots
+    ):
+        roots.append(comments_root)
+    for _reference_tag, body_tag, reltype, label in note_kinds:
+        root = _related_xml_root(document, reltype, label)
+        if root is None:
+            continue
+        if all(root is not existing for existing in roots):
+            roots.append(root)
+        for note in root.iter(body_tag):
+            _note_id(note)
+    for root in roots:
+        for marker in root.iter(
+            _COMMENT_RANGE_START, _COMMENT_RANGE_END, _COMMENT_REFERENCE
+        ):
+            _comment_id(marker)
+        for comment in root.iter(_COMMENT):
+            _comment_id(comment)
+        for reference_tag, _body_tag, _reltype, _label in note_kinds:
+            for reference in root.iter(reference_tag):
+                _note_id(reference)
+
+
+def _validate_cleanup_dependencies(
+    document: "Document", discard_roots: "List[_Element]"
+) -> None:
+    """Preflight every side-part/resource cleanup a discard can trigger."""
+    has_note_references = False
+    comment_ids: "set[int]" = set()
+    comment_range_ids: "set[int]" = set()
+    for root in discard_roots:
+        comment_ids.update(_comment_ids_inside(root))
+        comment_range_ids.update(_comment_range_ids_inside(root))
+        for reference_tag in (_FOOTNOTE_REFERENCE, _ENDNOTE_REFERENCE):
+            if _note_ids_inside(root, reference_tag):
+                has_note_references = True
+        part = _part_containing(root, document)
+        has_relationships = any(
+            _is_relationship_attribute(name)
+            for descendant in root.iter()
+            for name in descendant.attrib
+        )
+        if has_relationships and part is None:
+            raise UnsupportedStructureError(
+                "cannot identify the package part containing relationship-"
+                "bearing revision content; nothing was changed"
+            )
+    partial_comment_ids = sorted(comment_range_ids - comment_ids)
+    if partial_comment_ids:
+        raise UnsupportedStructureError(
+            "revision cleanup would remove comment range markers while"
+            f" leaving their reference marks live (comment ids"
+            f" {partial_comment_ids}); nothing was changed"
+        )
+    if comment_ids:
+        from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+        comments_root = _related_xml_root(document, RT.COMMENTS, "comments")
+        _validate_comment_cleanup_graph(
+            document,
+            comment_ids,
+            discard_roots,
+            comments_root,
+        )
+        if comments_root is not None and any(
+            True
+            for reference_tag in (_FOOTNOTE_REFERENCE, _ENDNOTE_REFERENCE)
+            for _reference in comments_root.iter(reference_tag)
+        ):
+            has_note_references = True
+    if has_note_references:
+        _validate_note_cleanup_graph(document)
+
+
+def _validate_comment_cleanup_graph(
+    document: "Document",
+    comment_ids: "set[int]",
+    discard_roots: "List[_Element]",
+    comments_root: "Optional[_Element]",
+) -> None:
+    """Require one unambiguous reference and body for each removed comment."""
+    def is_discarded(node: "_Element") -> bool:
+        while node is not None:
+            if any(node is root for root in discard_roots):
+                return True
+            node = node.getparent()
+        return False
+
+    story_roots = [root for _story, root in _story_elements(document)]
+    for comment_id in sorted(comment_ids):
+        references = [
+            reference
+            for root in story_roots
+            for reference in root.iter(_COMMENT_REFERENCE)
+            if _comment_id(reference) == comment_id
+        ]
+        if len(references) != 1 or not is_discarded(references[0]):
+            raise UnsupportedStructureError(
+                f"comment {comment_id} has {len(references)} reference marks;"
+                " revision cleanup requires exactly one reference inside the"
+                " discarded content. Nothing was changed"
+            )
+
+        bodies = (
+            []
+            if comments_root is None
+            else [
+                comment
+                for comment in comments_root.iter(_COMMENT)
+                if _comment_id(comment) == comment_id
+            ]
+        )
+        if len(bodies) != 1:
+            raise UnsupportedStructureError(
+                f"comment {comment_id} has {len(bodies)} comment bodies;"
+                " revision cleanup requires exactly one. Nothing was changed"
+            )
+
+        starts = [
+            marker
+            for root in story_roots
+            for marker in root.iter(_COMMENT_RANGE_START)
+            if _comment_id(marker) == comment_id
+        ]
+        ends = [
+            marker
+            for root in story_roots
+            for marker in root.iter(_COMMENT_RANGE_END)
+            if _comment_id(marker) == comment_id
+        ]
+        if len(starts) != len(ends) or len(starts) > 1:
+            raise UnsupportedStructureError(
+                f"comment {comment_id} has an ambiguous range-marker graph;"
+                " nothing was changed"
+            )
+
+
+def _cleanup_note_bodies(
+    document: "Document",
+    footnote_ids: "set[int]",
+    endnote_ids: "set[int]",
+) -> None:
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+    note_kinds = (
+        (_FOOTNOTE_REFERENCE, _FOOTNOTE, RT.FOOTNOTES, footnote_ids),
+        (_ENDNOTE_REFERENCE, _ENDNOTE, RT.ENDNOTES, endnote_ids),
+    )
+    for reference_tag, body_tag, reltype, note_ids in note_kinds:
+        removable = {
+            note_id
+            for note_id in note_ids
+            if not _note_reference_remains(document, reference_tag, note_id)
+        }
+        if not removable:
+            continue
+        try:
+            notes_part = document.part.part_related_by(reltype)
+        except KeyError:
+            continue
+        notes_root = getattr(notes_part, "_element", None)
+        if notes_root is None:
+            raise UnsupportedStructureError(
+                "note part is not loaded as live XML; cleanup cannot"
+                " continue without leaving orphaned note bodies"
+            )
+        for note in list(notes_root):
+            if (
+                note.tag == body_tag
+                and note.get(_NOTE_TYPE) is None
+                and _note_id(note) in removable
+            ):
+                _discard_element(note, document)
+
+
+def _cleanup_comments_extended(
+    document: "Document", paragraph_ids: "set[str]"
+) -> None:
+    if not paragraph_ids:
+        return
+    from docx.commentops import COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+
+    try:
+        extended = document.part.part_related_by(
+            COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+        )
+    except KeyError:
+        return
+    root = getattr(extended, "_element", None)
+    if root is None:  # prevalidated for public resolution paths
+        raise UnsupportedStructureError(
+            "commentsExtended is not loaded as live XML"
+        )
+    for entry in list(root):
+        if (
+            entry.tag == _W15_COMMENT_EX
+            and entry.get(_W15_PARA_ID) in paragraph_ids
+        ):
+            root.remove(entry)
 
 
 def _cleanup_comment_anchors(document: "Optional[Document]", comment_ids) -> None:
@@ -705,11 +1324,8 @@ def _cleanup_comment_anchors(document: "Optional[Document]", comment_ids) -> Non
         return
     wanted = set(comment_ids)
     for _story, root in _story_elements(document):
-        for marker in list(
-            root.iter(qn("w:commentRangeStart"), qn("w:commentRangeEnd"))
-        ):
-            raw = marker.get(qn("w:id"))
-            if raw and int(raw) in wanted:
+        for marker in list(root.iter(_COMMENT_RANGE_START, _COMMENT_RANGE_END)):
+            if _comment_id(marker) in wanted:
                 marker.getparent().remove(marker)
     from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
@@ -718,19 +1334,58 @@ def _cleanup_comment_anchors(document: "Optional[Document]", comment_ids) -> Non
     except KeyError:
         return
     comments_root = comments_part._element  # noqa: SLF001
+    paragraph_ids: "set[str]" = set()
     for comment in list(comments_root):
-        raw = comment.get(qn("w:id"))
-        if raw and int(raw) in wanted:
-            comments_root.remove(comment)
+        if _comment_id(comment) not in wanted:
+            continue
+        paragraphs = comment.findall(_P)
+        if paragraphs:
+            para_id = paragraphs[-1].get(_W14_PARA_ID)
+            if para_id is not None:
+                paragraph_ids.add(para_id)
+        _discard_element(comment, document)
+    _cleanup_comments_extended(document, paragraph_ids)
+
+
+def _discard_element(
+    node: "_Element", document: "Optional[Document]"
+) -> None:
+    """Detach a subtree and prune resources that only that subtree used."""
+    parent = node.getparent()
+    if parent is None:
+        raise UnsupportedStructureError(
+            "cannot discard a detached revision subtree; nothing was changed"
+        )
+    comment_ids = _comment_ids_inside(node)
+    footnote_ids = _note_ids_inside(node, _FOOTNOTE_REFERENCE)
+    endnote_ids = _note_ids_inside(node, _ENDNOTE_REFERENCE)
+    part = _part_containing(node, document) if document is not None else None
+    relationship_ids = (
+        _relationship_ids_inside(node, part) if part is not None else set()
+    )
+
+    parent.remove(node)
+
+    if part is not None:
+        _drop_unreferenced_relationships(part, relationship_ids)
+    if document is not None:
+        _cleanup_note_bodies(document, footnote_ids, endnote_ids)
+        _cleanup_comment_anchors(document, comment_ids)
 
 
 def _resolve_one(
     node: "_Element", *, accept: bool, document: "Optional[Document]" = None
 ) -> None:
     if node.getparent() is None:
-        return  # already resolved via an enclosing operation
+        raise UnsupportedStructureError(
+            "cannot resolve a stale Revision; reacquire it from"
+            " document.revisions. Nothing was changed"
+        )
     if document is not None and not _is_in_story(node, document):
-        return  # its subtree was detached by an enclosing resolution
+        raise UnsupportedStructureError(
+            "cannot resolve a stale Revision; reacquire it from"
+            " document.revisions. Nothing was changed"
+        )
     revision_type = _revision_type_of(node)
     if revision_type in ("move_from", "move_to"):
         _resolve_move(node, accept=accept, document=document)
@@ -747,12 +1402,13 @@ def _resolve_one(
     removes_content = (node.tag == _INS and not accept) or (
         node.tag == _DEL and accept
     )
-    orphaned = _comment_ids_inside(node) if removes_content else []
+    if removes_content:
+        _discard_element(node, document)
+        return
     if node.tag == _INS:
         _resolve_insertion(node, accept=accept)
     else:
         _resolve_deletion(node, accept=accept)
-    _cleanup_comment_anchors(document, orphaned)
 
 
 def _unwrap(node: "_Element") -> None:
@@ -841,7 +1497,6 @@ def _resolve_row_revision(
         return
     table = row.getparent()
     if sum(1 for child in table if child.tag == _TR) == 1:
-        orphaned = _comment_ids_inside(table)
         parent = table.getparent()
         siblings = [
             child for child in parent if child.tag in (_P, _TBL) and child is not table
@@ -850,12 +1505,9 @@ def _resolve_row_revision(
             from docx.oxml.parser import OxmlElement
 
             table.addprevious(OxmlElement("w:p"))
-        parent.remove(table)
-        _cleanup_comment_anchors(document, orphaned)
+        _discard_element(table, document)
         return
-    orphaned = _comment_ids_inside(row)
-    table.remove(row)
-    _cleanup_comment_anchors(document, orphaned)
+    _discard_element(row, document)
 
 
 def _paragraph_of_mark(node: "_Element") -> "Optional[_Element]":
@@ -877,18 +1529,95 @@ def _is_last_block_in_container(paragraph: "_Element") -> bool:
     return not blocks
 
 
+_TRANSPARENT_BLOCK_MARKERS = frozenset(
+    qn(tag)
+    for tag in (
+        "w:bookmarkStart",
+        "w:bookmarkEnd",
+        "w:commentRangeStart",
+        "w:commentRangeEnd",
+        "w:permStart",
+        "w:permEnd",
+        "w:proofErr",
+        "w:moveFromRangeStart",
+        "w:moveFromRangeEnd",
+        "w:moveToRangeStart",
+        "w:moveToRangeEnd",
+        "w:customXmlInsRangeStart",
+        "w:customXmlInsRangeEnd",
+        "w:customXmlDelRangeStart",
+        "w:customXmlDelRangeEnd",
+        "w:customXmlMoveFromRangeStart",
+        "w:customXmlMoveFromRangeEnd",
+        "w:customXmlMoveToRangeStart",
+        "w:customXmlMoveToRangeEnd",
+    )
+)
+
+
 def _next_paragraph_sibling(paragraph: "_Element") -> "Optional[_Element]":
     node = paragraph.getnext()
     while node is not None:
         if node.tag == _P:
             return node
-        if node.tag in (qn("w:tbl"), qn("w:sdt")):
+        if node.tag in (_TBL, qn("w:sdt"), _SECT_PR):
             # merging across a table or INTO a block-level content control
             # is not a paragraph join — hopping content past it would
             # silently reorder document text
             return None
-        node = node.getnext()
+        if node.tag in _TRANSPARENT_BLOCK_MARKERS:
+            node = node.getnext()
+            continue
+        name = node.tag.rsplit("}", 1)[-1]
+        raise UnsupportedStructureError(
+            f"cannot resolve a paragraph-mark revision across the {name!r}"
+            " block; its content boundary is not a safe paragraph join."
+            " Nothing was changed"
+        )
     return None
+
+
+def _paragraph_mark_applies(node: "_Element", *, accept: bool) -> bool:
+    is_deletion = node.tag in (_DEL, _MOVE_FROM)
+    return (accept and is_deletion) or (not accept and not is_deletion)
+
+
+def _preflight_paragraph_mark(node: "_Element", *, accept: bool) -> None:
+    paragraph = _paragraph_of_mark(node)
+    if (
+        paragraph is not None
+        and _paragraph_mark_applies(node, accept=accept)
+        and _paragraph_has_content(paragraph)
+    ):
+        _next_paragraph_sibling(paragraph)
+
+
+def _validate_paragraph_mark_joins(
+    selected: "List[Revision]", document: "Document", *, accept: bool
+) -> None:
+    """Preflight every paragraph join, including compound move stamps."""
+    marks = [
+        revision._element  # noqa: SLF001
+        for revision in selected
+        if revision.is_paragraph_mark
+    ]
+    move_nodes = {
+        id(revision._element)  # noqa: SLF001
+        for revision in selected
+        if revision.revision_type in ("move_from", "move_to")
+    }
+    if move_nodes:
+        units, _orphans = _move_units(document)
+        for unit in units:
+            if any(id(element) in move_nodes for element in unit.elements):
+                marks.extend(unit.from_site.mark_stamps)
+                marks.extend(unit.to_site.mark_stamps)
+    seen: "set[int]" = set()
+    for mark in marks:
+        if id(mark) in seen:
+            continue
+        seen.add(id(mark))
+        _preflight_paragraph_mark(mark, accept=accept)
 
 
 def _resolve_paragraph_mark(node: "_Element", *, accept: bool) -> None:
@@ -905,10 +1634,16 @@ def _resolve_paragraph_mark(node: "_Element", *, accept: bool) -> None:
       a mark-INSERTED split merges the same way.
     """
     paragraph = _paragraph_of_mark(node)
-    # w:moveFrom stamps are del-like (the mark moved AWAY from here),
-    # w:moveTo stamps ins-like — same break-change algebra
-    is_deletion = node.tag in (_DEL, _MOVE_FROM)
-    applying_break_change = (accept and is_deletion) or (not accept and not is_deletion)
+    applying_break_change = _paragraph_mark_applies(node, accept=accept)
+    following = None
+    if (
+        paragraph is not None
+        and applying_break_change
+        and _paragraph_has_content(paragraph)
+    ):
+        # Resolve the join target before touching the revision stamp. This is
+        # the last-line atomicity guard for direct/internal callers.
+        following = _next_paragraph_sibling(paragraph)
 
     r_pr = node.getparent()
     r_pr.remove(node)
@@ -917,7 +1652,6 @@ def _resolve_paragraph_mark(node: "_Element", *, accept: bool) -> None:
     if paragraph is None or not applying_break_change:
         return
     if _paragraph_has_content(paragraph):
-        following = _next_paragraph_sibling(paragraph)
         if following is None:
             return  # nothing to join with; the content stays as a paragraph
         insert_at = 1 if following.find(_PPR) is not None else 0

--- a/src/docx/scrubbing.py
+++ b/src/docx/scrubbing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
+from docx._transaction import rollback_on_error
 from docx.errors import UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected, protection_status
@@ -125,17 +126,20 @@ def finalize(document: "Document", *, revisions: str = "accept") -> int:
         )
     _refuse_if_protected(document, "finalize the document")
     snapshot = document.revisions
-    resolved = (
-        snapshot.accept_all() if revisions == "accept" else snapshot.reject_all()
-    )
-    leftover = _remaining_markup(document)
-    if leftover:
-        raise UnsupportedStructureError(
-            "finalize resolved the enumerated revisions but revision markup"
-            f" remains: {leftover}; the document is NOT final. Resolve the"
-            " remainder in Word"
+    with rollback_on_error(document):
+        resolved = snapshot._resolve_all(  # noqa: SLF001 - shared transaction
+            accept=revisions == "accept",
+            author=None,
+            _transactional=False,
         )
-    return resolved
+        leftover = _remaining_markup(document)
+        if leftover:
+            raise UnsupportedStructureError(
+                "finalize resolved the enumerated revisions but revision markup"
+                f" remains: {leftover}; the document is NOT final. Resolve the"
+                " remainder in Word"
+            )
+        return resolved
 
 
 def scrub(
@@ -181,18 +185,19 @@ def scrub(
         }
         if status.formatting:
             report.document_protection["formatting"] = True
-    if comments:
-        _scrub_comment_parts(document, report)
-        _scrub_comment_anchors(document, report)
-    if metadata:
-        _scrub_metadata(document, report)
-    if track_changes_setting:
-        _scrub_track_changes_setting(document, report)
-    if rsids:
-        _scrub_rsids(document, report)
-    if hidden_text:
-        _scrub_hidden_text(hidden_runs, report)
-    return report
+    with rollback_on_error(document):
+        if comments:
+            _scrub_comment_parts(document, report)
+            _scrub_comment_anchors(document, report)
+        if metadata:
+            _scrub_metadata(document, report)
+        if track_changes_setting:
+            _scrub_track_changes_setting(document, report)
+        if rsids:
+            _scrub_rsids(document, report)
+        if hidden_text:
+            _scrub_hidden_text(hidden_runs, report)
+        return report
 
 
 def _scrub_comment_parts(document: "Document", report: ScrubReport) -> None:

--- a/src/docx/scrubbing.py
+++ b/src/docx/scrubbing.py
@@ -30,18 +30,32 @@ if TYPE_CHECKING:
 
 #: relationship-type suffixes of the comment part family (base comments part
 #: plus Word's extended/threading/people side-parts)
-_COMMENT_RELTYPE_SUFFIXES = (
-    "/comments",
-    "/commentsExtended",
-    "/commentsIds",
-    "/commentsExtensible",
-    "/people",
+_COMMENT_RELATIONSHIP_TYPES = frozenset(
+    (
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments",
+        "http://purl.oclc.org/ooxml/officeDocument/relationships/comments",
+        "http://schemas.microsoft.com/office/2011/relationships/commentsExtended",
+        "http://schemas.microsoft.com/office/2016/09/relationships/commentsIds",
+        "http://schemas.microsoft.com/office/2018/08/relationships/commentsExtensible",
+        "http://schemas.microsoft.com/office/2011/relationships/people",
+    )
+)
+_COMMENT_CONTENT_TYPE_FRAGMENTS = (
+    ".comments+xml",
+    ".commentsExtended+xml",
+    ".commentsIds+xml",
+    ".commentsExtensible+xml",
+    ".people+xml",
 )
 
 _COMMENT_ANCHOR_TAGS = (
     qn("w:commentRangeStart"),
     qn("w:commentRangeEnd"),
     qn("w:commentReference"),
+)
+
+_MC_ALTERNATE_CONTENT = (
+    "{http://schemas.openxmlformats.org/markup-compatibility/2006}AlternateContent"
 )
 
 _RSID_ATTRS = tuple(
@@ -121,9 +135,7 @@ def finalize(document: "Document", *, revisions: str = "accept") -> int:
     rescan of every story finds zero revision markup of any kind.
     """
     if revisions not in ("accept", "reject"):
-        raise ValueError(
-            f"revisions must be 'accept' or 'reject', got {revisions!r}"
-        )
+        raise ValueError(f"revisions must be 'accept' or 'reject', got {revisions!r}")
     _refuse_if_protected(document, "finalize the document")
     snapshot = document.revisions
     with rollback_on_error(document):
@@ -172,9 +184,9 @@ def scrub(
         )
     if metadata:
         _validate_metadata_parts(document)
-    hidden_runs = (
-        _hidden_runs(document, include_comments=not comments) if hidden_text else []
-    )
+    hidden_runs = _hidden_runs(document, include_comments=not comments) if hidden_text else []
+    if hidden_text:
+        _validate_hidden_run_deletions(document, hidden_runs)
     report = ScrubReport()
     status = protection_status(document)
     if status.edit is not None or status.formatting:
@@ -197,6 +209,20 @@ def scrub(
             _scrub_rsids(document, report)
         if hidden_text:
             _scrub_hidden_text(hidden_runs, report)
+        if comments and (
+            any(
+                rel.reltype in _COMMENT_RELATIONSHIP_TYPES
+                for part in document.part.package.iter_parts()
+                for rel in part.rels.values()
+            )
+            or any(
+                next(root.iter(*_COMMENT_ANCHOR_TAGS), None) is not None
+                for _story, root in _story_elements(document)
+            )
+        ):
+            raise UnsupportedStructureError(
+                "comment scrub postcondition failed; operation was rolled back"
+            )
         return report
 
 
@@ -209,11 +235,20 @@ def _scrub_comment_parts(document: "Document", report: ScrubReport) -> None:
     package = document_part.package
     parts_before = {part.partname: part for part in package.iter_parts()}
     dropped_any = False
-    for r_id, rel in list(document_part.rels.items()):
-        if rel.is_external:
-            continue
-        if any(rel.reltype.endswith(sfx) for sfx in _COMMENT_RELTYPE_SUFFIXES):
-            document_part.drop_rel(r_id)
+    owners = (document_part,) + tuple(package.iter_parts())
+    for owner in owners:
+        for r_id, rel in list(owner.rels.items()):
+            if rel.is_external or rel.reltype not in _COMMENT_RELATIONSHIP_TYPES:
+                continue
+            if not any(
+                rel.target_part.content_type.endswith(fragment)
+                for fragment in _COMMENT_CONTENT_TYPE_FRAGMENTS
+            ):
+                raise UnsupportedStructureError(
+                    "cannot scrub comments: a comment relationship has an"
+                    " unexpected target content type; nothing was changed"
+                )
+            owner.drop_rel(r_id)
             dropped_any = True
     if not dropped_any:
         return
@@ -235,9 +270,7 @@ def _scrub_comment_anchors(document: "Document", report: ScrubReport) -> None:
             parent.remove(node)
             report.comment_anchors_removed += 1
             # a run that held only the commentReference is Word residue too
-            if parent.tag == qn("w:r") and not any(
-                child.tag != qn("w:rPr") for child in parent
-            ):
+            if parent.tag == qn("w:r") and not any(child.tag != qn("w:rPr") for child in parent):
                 parent.getparent().remove(parent)
 
 
@@ -262,9 +295,7 @@ def _scrub_metadata(document: "Document", report: ScrubReport) -> None:
     for r_id, rel in list(package.rels.items()):
         if rel.is_external:
             continue
-        if rel.reltype.endswith("/custom-properties") or rel.reltype.endswith(
-            "/thumbnail"
-        ):
+        if rel.reltype.endswith("/custom-properties") or rel.reltype.endswith("/thumbnail"):
             report.removed_parts.append(str(rel.target_part.partname).lstrip("/"))
             del package.rels[r_id]
         elif rel.reltype.endswith("/extended-properties"):
@@ -305,14 +336,12 @@ def _parse_app_properties(app_part):
         root = etree.fromstring(app_part.blob, parser)
     except etree.XMLSyntaxError as exc:
         raise UnsupportedStructureError(
-            "cannot scrub metadata: docProps/app.xml is malformed;"
-            " nothing was changed"
+            "cannot scrub metadata: docProps/app.xml is malformed; nothing was changed"
         ) from exc
     docinfo = root.getroottree().docinfo
     if docinfo.internalDTD is not None or docinfo.doctype:
         raise UnsupportedStructureError(
-            "cannot scrub metadata: docProps/app.xml contains a DTD;"
-            " nothing was changed"
+            "cannot scrub metadata: docProps/app.xml contains a DTD; nothing was changed"
         )
     return root
 
@@ -354,15 +383,18 @@ def _scrub_rsids(document: "Document", report: ScrubReport) -> None:
                     report.rsid_attributes_removed += 1
 
 
-def _hidden_runs(
-    document: "Document", *, include_comments: bool
-) -> "List[_Element]":
+def _hidden_runs(document: "Document", *, include_comments: bool) -> "List[_Element]":
     """Resolve every hidden-text target before scrub mutates any package part."""
     from docx.formatting import _enclosing_paragraph, _resolve_run
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
+    try:
+        comments_root = document.part.part_related_by(RT.COMMENTS)._element
+    except KeyError:
+        comments_root = None
     hidden = []
     for story, root in _story_elements(document):
-        if not include_comments and story == "word/comments.xml":
+        if not include_comments and root is comments_root:
             continue
         for run in root.iter(qn("w:r")):
             resolved = _resolve_run(document, run, _enclosing_paragraph(run))
@@ -383,3 +415,67 @@ def _scrub_hidden_text(hidden_runs: "List[_Element]", report: ScrubReport) -> No
         if parent is not None:
             parent.remove(run)
             report.hidden_runs_removed += 1
+
+
+def _validate_hidden_run_deletions(document: "Document", hidden_runs: "List[_Element]") -> None:
+    """Refuse only hidden targets whose deletion breaks local structure."""
+    hidden_ids = {id(run) for run in hidden_runs}
+    structural = {
+        qn("w:fldChar"),
+        qn("w:instrText"),
+        qn("w:commentReference"),
+        qn("w:footnoteReference"),
+        qn("w:endnoteReference"),
+    }
+    from docx.controls import (
+        _refuse_control_write_restrictions,
+        _validate_span_surface_edit,
+    )
+
+    for run in hidden_runs:
+        if any(node.tag in structural for node in run.iter()):
+            raise UnsupportedStructureError(
+                "cannot scrub hidden text because a target run carries"
+                " structural review or field markup; nothing was changed"
+            )
+        current = run.getparent()
+        while current is not None:
+            if current.tag == _MC_ALTERNATE_CONTENT:
+                raise UnsupportedStructureError(
+                    "cannot scrub hidden text inside mc:AlternateContent because"
+                    " different consumers may select different branches; nothing was changed"
+                )
+            if current.tag == qn("w:fldSimple"):
+                raise UnsupportedStructureError(
+                    "cannot scrub hidden text inside a field; nothing was changed"
+                )
+            if current.tag == qn("w:sdt"):
+                _validate_span_surface_edit(current)
+                _refuse_control_write_restrictions(current)
+            current = current.getparent()
+
+    start_tag, end_tag, run_tag = (qn("w:bookmarkStart"), qn("w:bookmarkEnd"), qn("w:r"))
+    id_attr = qn("w:id")
+    for _story, root in _story_elements(document):
+        ordered = list(root.iter())
+        positions = {id(node): index for index, node in enumerate(ordered)}
+        ends = {node.get(id_attr): node for node in ordered if node.tag == end_tag}
+        for start in (node for node in ordered if node.tag == start_tag):
+            end = ends.get(start.get(id_attr))
+            if end is None:
+                continue
+            runs = [
+                node
+                for node in ordered[positions[id(start)] + 1 : positions[id(end)]]
+                if node.tag == run_tag
+                and any(
+                    child.tag != qn("w:rPr")
+                    and (child.tag != qn("w:t") or bool(child.text))
+                    for child in node
+                )
+            ]
+            if runs and all(id(run) in hidden_ids for run in runs):
+                raise UnsupportedStructureError(
+                    "cannot scrub hidden text because it would hollow out"
+                    " a bookmark; nothing was changed"
+                )

--- a/src/docx/scrubbing.py
+++ b/src/docx/scrubbing.py
@@ -23,6 +23,8 @@ from docx.revision import _remaining_markup
 from docx.story import _story_elements
 
 if TYPE_CHECKING:
+    from lxml.etree import _Element
+
     from docx.document import Document
 
 #: relationship-type suffixes of the comment part family (base comments part
@@ -67,6 +69,13 @@ _CORE_STRING_FIELDS = (
     "subject",
     "title",
     "version",
+)
+
+_CORE_PRIVATE_TAGS = (
+    ("dcterms:created", "created"),
+    ("dcterms:modified", "modified"),
+    ("cp:lastPrinted", "last_printed"),
+    ("cp:revision", "revision"),
 )
 
 
@@ -157,14 +166,21 @@ def scrub(
             " document; finalize(revisions=...) first, or pass"
             " metadata=False. Nothing was changed"
         )
+    if metadata:
+        _validate_metadata_parts(document)
+    hidden_runs = (
+        _hidden_runs(document, include_comments=not comments) if hidden_text else []
+    )
     report = ScrubReport()
     status = protection_status(document)
-    if status.edit is not None:
+    if status.edit is not None or status.formatting:
         report.document_protection = {
             "edit": status.edit,
             "enforced": status.enforced,
             "note": "reported, never removed (docx.protection)",
         }
+        if status.formatting:
+            report.document_protection["formatting"] = True
     if comments:
         _scrub_comment_parts(document, report)
         _scrub_comment_anchors(document, report)
@@ -175,7 +191,7 @@ def scrub(
     if rsids:
         _scrub_rsids(document, report)
     if hidden_text:
-        _scrub_hidden_text(document, report)
+        _scrub_hidden_text(hidden_runs, report)
     return report
 
 
@@ -232,6 +248,12 @@ def _scrub_metadata(document: "Document", report: ScrubReport) -> None:
             if getattr(core, name):
                 setattr(core, name, "")
                 report.metadata_fields_cleared.append(f"core:{name}")
+        core_element = core._element  # noqa: SLF001 - remove optional metadata nodes
+        for tag, name in _CORE_PRIVATE_TAGS:
+            node = core_element.find(qn(tag))
+            if node is not None:
+                core_element.remove(node)
+                report.metadata_fields_cleared.append(f"core:{name}")
     for r_id, rel in list(package.rels.items()):
         if rel.is_external:
             continue
@@ -248,10 +270,7 @@ def _clear_app_properties(app_part, report: ScrubReport) -> None:
     """Blank Company/Manager in docProps/app.xml (kept as a generic part)."""
     from lxml import etree
 
-    try:
-        root = etree.fromstring(app_part.blob)
-    except etree.XMLSyntaxError:
-        return
+    root = _parse_app_properties(app_part)
     changed = False
     for local in ("Company", "Manager"):
         for element in root.iter(f"{{*}}{local}"):
@@ -263,6 +282,34 @@ def _clear_app_properties(app_part, report: ScrubReport) -> None:
         app_part._blob = etree.tostring(  # noqa: SLF001 - generic Part storage
             root, xml_declaration=True, encoding="UTF-8", standalone=True
         )
+
+
+def _validate_metadata_parts(document: "Document") -> None:
+    """Parse every app-properties part before scrub mutates any package part."""
+    package = document.part.package
+    for rel in package.rels.values():
+        if not rel.is_external and rel.reltype.endswith("/extended-properties"):
+            _parse_app_properties(rel.target_part)
+
+
+def _parse_app_properties(app_part):
+    from lxml import etree
+
+    parser = etree.XMLParser(resolve_entities=False, no_network=True)
+    try:
+        root = etree.fromstring(app_part.blob, parser)
+    except etree.XMLSyntaxError as exc:
+        raise UnsupportedStructureError(
+            "cannot scrub metadata: docProps/app.xml is malformed;"
+            " nothing was changed"
+        ) from exc
+    docinfo = root.getroottree().docinfo
+    if docinfo.internalDTD is not None or docinfo.doctype:
+        raise UnsupportedStructureError(
+            "cannot scrub metadata: docProps/app.xml contains a DTD;"
+            " nothing was changed"
+        )
+    return root
 
 
 def _settings_element(document: "Document"):
@@ -302,22 +349,32 @@ def _scrub_rsids(document: "Document", report: ScrubReport) -> None:
                     report.rsid_attributes_removed += 1
 
 
-def _scrub_hidden_text(document: "Document", report: ScrubReport) -> None:
-    """Remove runs carrying `w:vanish` (explicit opt-in — this DELETES
-    content Word merely hides)."""
-    vanish = qn("w:vanish")
-    val = qn("w:val")
-    for _story, root in _story_elements(document):
-        for run in list(root.iter(qn("w:r"))):
-            r_pr = run.find(qn("w:rPr"))
-            if r_pr is None:
-                continue
-            node = r_pr.find(vanish)
-            if node is None:
-                continue
-            if (node.get(val) or "true").lower() in ("0", "false", "off"):
-                continue
-            parent = run.getparent()
-            if parent is not None:
-                parent.remove(run)
-                report.hidden_runs_removed += 1
+def _hidden_runs(
+    document: "Document", *, include_comments: bool
+) -> "List[_Element]":
+    """Resolve every hidden-text target before scrub mutates any package part."""
+    from docx.formatting import _enclosing_paragraph, _resolve_run
+
+    hidden = []
+    for story, root in _story_elements(document):
+        if not include_comments and story == "word/comments.xml":
+            continue
+        for run in root.iter(qn("w:r")):
+            resolved = _resolve_run(document, run, _enclosing_paragraph(run))
+            if resolved["vanish"].value is True:
+                hidden.append(run)
+    return hidden
+
+
+def _scrub_hidden_text(hidden_runs: "List[_Element]", report: ScrubReport) -> None:
+    """Remove effectively vanished runs (explicit opt-in; this deletes text).
+
+    ``w:vanish`` is inheritable and a direct ``w:vanish w:val="false"``
+    overrides a hidden style. Resolve the full style chain rather than merely
+    looking for a direct element on the run.
+    """
+    for run in hidden_runs:
+        parent = run.getparent()
+        if parent is not None:
+            parent.remove(run)
+            report.hidden_runs_removed += 1

--- a/src/docx/scrubbing.py
+++ b/src/docx/scrubbing.py
@@ -184,7 +184,7 @@ def scrub(
         )
     if metadata:
         _validate_metadata_parts(document)
-    hidden_runs = _hidden_runs(document, include_comments=not comments) if hidden_text else []
+    hidden_runs = _hidden_runs(document, include_comments=comments) if hidden_text else []
     if hidden_text:
         _validate_hidden_run_deletions(document, hidden_runs)
     report = ScrubReport()
@@ -392,15 +392,22 @@ def _scrub_rsids(document: "Document", report: ScrubReport) -> None:
 def _hidden_runs(document: "Document", *, include_comments: bool) -> "List[_Element]":
     """Resolve every hidden-text target before scrub mutates any package part."""
     from docx.formatting import _enclosing_paragraph, _resolve_run
-    from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
-    try:
-        comments_root = document.part.part_related_by(RT.COMMENTS)._element
-    except KeyError:
-        comments_root = None
+    package = document.part.package
+    owners = (package,) + tuple(package.iter_parts())
+    comment_roots = tuple(
+        root
+        for owner in owners
+        for rel in owner.rels.values()
+        if not rel.is_external and rel.reltype in _COMMENT_RELATIONSHIP_TYPES
+        if (root := getattr(rel.target_part, "_element", None)) is not None
+    )
     hidden = []
     for story, root in _story_elements(document):
-        if not include_comments and root is comments_root:
+        if not include_comments and any(
+            root is comment_root or root == comment_root
+            for comment_root in comment_roots
+        ):
             continue
         for run in root.iter(qn("w:r")):
             resolved = _resolve_run(document, run, _enclosing_paragraph(run))

--- a/src/docx/scrubbing.py
+++ b/src/docx/scrubbing.py
@@ -209,11 +209,14 @@ def scrub(
             _scrub_rsids(document, report)
         if hidden_text:
             _scrub_hidden_text(hidden_runs, report)
+        relationship_owners = (document.part.package,) + tuple(
+            document.part.package.iter_parts()
+        )
         if comments and (
             any(
                 rel.reltype in _COMMENT_RELATIONSHIP_TYPES
-                for part in document.part.package.iter_parts()
-                for rel in part.rels.values()
+                for owner in relationship_owners
+                for rel in owner.rels.values()
             )
             or any(
                 next(root.iter(*_COMMENT_ANCHOR_TAGS), None) is not None
@@ -235,7 +238,7 @@ def _scrub_comment_parts(document: "Document", report: ScrubReport) -> None:
     package = document_part.package
     parts_before = {part.partname: part for part in package.iter_parts()}
     dropped_any = False
-    owners = (document_part,) + tuple(package.iter_parts())
+    owners = (package, document_part) + tuple(package.iter_parts())
     for owner in owners:
         for r_id, rel in list(owner.rels.items()):
             if rel.is_external or rel.reltype not in _COMMENT_RELATIONSHIP_TYPES:
@@ -248,7 +251,10 @@ def _scrub_comment_parts(document: "Document", report: ScrubReport) -> None:
                     "cannot scrub comments: a comment relationship has an"
                     " unexpected target content type; nothing was changed"
                 )
-            owner.drop_rel(r_id)
+            if owner is package:
+                del package.rels[r_id]
+            else:
+                owner.drop_rel(r_id)
             dropped_any = True
     if not dropped_any:
         return

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -18,7 +18,7 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
-from docx import _clock
+from docx import _clock, _textatoms
 from docx._normalize import normalize_text  # noqa: F401 - public re-export
 from docx.errors import (
     AmbiguousTargetError,
@@ -43,14 +43,11 @@ if TYPE_CHECKING:
 
     from docx.document import Document
 
-_T = qn("w:t")
-_DEL_TEXT = qn("w:delText")
-_INSTR_TEXT = qn("w:instrText")
-_TEXT_TAGS = (_T, _DEL_TEXT, _INSTR_TEXT)
-#: tab/break elements contribute fixed characters to the search text so
-#: needles can match across them; spans containing them refuse to replace
-_SYNTHETIC_TAGS = {qn("w:tab"): "\t", qn("w:br"): "\n", qn("w:cr"): "\n"}
-_R = qn("w:r")
+_T = _textatoms.T
+_DEL_TEXT = _textatoms.DEL_TEXT
+_INSTR_TEXT = _textatoms.INSTR_TEXT
+_TEXT_TAGS = _textatoms.TEXT_TAGS
+_R = _textatoms.R
 _INS = qn("w:ins")
 _DEL = qn("w:del")
 _MOVE_FROM = qn("w:moveFrom")
@@ -69,9 +66,10 @@ _FLD_CHAR_TYPE = qn("w:fldCharType")
 class _Atom:
     """One text node in search space, with its structural context.
 
-    `fixed_text` marks a synthetic atom: a `w:tab`/`w:br`/`w:cr` that
-    contributes a fixed character to the search text so needles can match
-    across it, but that can never be edited through a span (replace refuses).
+    `fixed_text` marks a synthetic atom such as a tab, break, or no-break
+    hyphen. ``barrier`` marks visible run XML with no safe text model; it
+    contributes an object-replacement sentinel solely to split search text.
+    Neither kind can be edited directly through a span.
     """
 
     element: "_Element"
@@ -87,6 +85,7 @@ class _Atom:
     hyperlink: "Optional[_Element]" = None  # innermost w:hyperlink, if any
     in_field: bool = False
     fixed_text: Optional[str] = None
+    barrier: bool = False
 
     @property
     def in_hyperlink(self) -> bool:
@@ -101,6 +100,57 @@ class _Atom:
     @property
     def is_synthetic(self) -> bool:
         return self.fixed_text is not None
+
+
+_CONTEXT_SCOPE_TAGS = frozenset(
+    (_INS, _DEL, _MOVE_FROM, _MOVE_TO, _SDT, _HYPERLINK, _FLD_SIMPLE, _TXBX)
+)
+
+
+def _atom_context_signature(atom: _Atom) -> tuple:
+    """Snapshot the edit-sensitive structural context of one atom.
+
+    Element identity catches reparenting into a different run, paragraph, or
+    edit-sensitive scope without coupling freshness to absolute sibling
+    indexes. Attributes catch retargeted hyperlinks and re-authored revisions;
+    SDT properties catch lock/placeholder/type changes. Complex-field
+    membership is carried separately because its begin/end markers are
+    siblings rather than ancestors of the result text.
+    """
+    from lxml import etree
+
+    scopes = []
+    current = atom.element.getparent()
+    while current is not None:
+        if current.tag in _CONTEXT_SCOPE_TAGS:
+            extra = b""
+            if current.tag == _SDT:
+                sdt_pr = current.find(qn("w:sdtPr"))
+                if sdt_pr is not None:
+                    extra = etree.tostring(sdt_pr, with_tail=False)
+            scopes.append(
+                (
+                    current,
+                    current.tag,
+                    tuple(sorted(current.attrib.items())),
+                    extra,
+                )
+            )
+        current = current.getparent()
+    scopes.reverse()
+    return (
+        atom.story,
+        atom.tag,
+        atom.paragraph,
+        atom.run,
+        atom.in_insert,
+        atom.in_delete,
+        atom.in_text_box,
+        atom.in_field,
+        atom.fixed_text,
+        atom.barrier,
+        tuple(scopes),
+    )
 
 
 def _collect_block_atoms(
@@ -138,7 +188,10 @@ def _collect_block_atoms(
                 elif fld_type == "end" and field_depth[0] > 0:
                     field_depth[0] -= 1
                 continue
-            if tag in _TEXT_TAGS or tag in _SYNTHETIC_TAGS:
+            if _textatoms.is_direct_run_child(child):
+                projection = _textatoms.project_run_child(child)
+                if not projection.text and not projection.barrier:
+                    continue
                 yield _Atom(
                     element=child,
                     tag=tag,
@@ -152,7 +205,10 @@ def _collect_block_atoms(
                     in_text_box=in_box,
                     hyperlink=hlink,
                     in_field=in_fld or field_depth[0] > 0,
-                    fixed_text=_SYNTHETIC_TAGS.get(tag),
+                    fixed_text=(
+                        None if tag in _TEXT_TAGS else projection.text
+                    ),
+                    barrier=projection.barrier,
                 )
                 continue
             yield from walk(
@@ -306,6 +362,21 @@ class Span:
     _end_offset: int = field(repr=False)  # exclusive, into last atom's text
     _norm_start: int = field(repr=False)  # position in the story's normalized text
     _consumed: bool = field(default=False, repr=False)  # set by tracked replace
+    _context_signatures: "Tuple[tuple, ...]" = field(init=False, repr=False)
+    _atom_sequence: "Tuple[_Element, ...]" = field(init=False, repr=False)
+    _sequence_view: "Optional[str]" = field(init=False, repr=False)
+    _view: str = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._context_signatures = tuple(
+            _atom_context_signature(atom) for atom in self._atoms
+        )
+        # Constructors outside search build current-view spans. Search replaces
+        # this fallback with the full captured interval, including atoms hidden
+        # by the selected view.
+        self._atom_sequence = tuple(atom.element for atom in self._atoms)
+        self._sequence_view = "current"
+        self._view = "current"
 
     # -- comments ---------------------------------------------------------
 
@@ -325,6 +396,12 @@ class Span:
         """
         if not author:
             raise ValueError("author is required")
+        _validate_xml_characters(text, argument="text")
+        _validate_xml_characters(author, argument="author")
+        if initials is not None:
+            _validate_xml_characters(initials, argument="initials")
+        if date is not None and not isinstance(date, dt.datetime):
+            raise TypeError("date must be a datetime or None")
         _refuse_if_protected(self._document, "anchor a comment")
         if self.story != "word/document.xml":
             raise UnsupportedStructureError(
@@ -337,6 +414,9 @@ class Span:
                 raise UnsupportedStructureError(
                     "span text is not inside runs; cannot anchor a comment"
                 )
+        from docx.commentops import _preflight_comment_add
+
+        _preflight_comment_add(self._document)
         self._isolate_edge_runs()
         runs = []
         for atom in self._atoms:
@@ -517,6 +597,21 @@ class Span:
             _end_offset=end_off,
             _norm_start=self._norm_start,
         )
+        sub_span._view = self._view
+        sub_span._sequence_view = self._sequence_view
+        sequence_positions = {
+            id(element): index for index, element in enumerate(self._atom_sequence)
+        }
+        sequence_start = sequence_positions.get(id(sub_atoms[0].element))
+        sequence_end = sequence_positions.get(id(sub_atoms[-1].element))
+        if (
+            sequence_start is not None
+            and sequence_end is not None
+            and sequence_start <= sequence_end
+        ):
+            sub_span._atom_sequence = self._atom_sequence[
+                sequence_start : sequence_end + 1
+            ]
         return sub_span, changed_new
 
     # -- validation -------------------------------------------------------
@@ -555,24 +650,78 @@ class Span:
                 f"span is stale: expected {self.text!r} at its anchor"
                 f" ({self.anchor.to_dict()}) but the document has changed"
             )
-        # detached atoms still hold their text; an edit landing in an orphaned
-        # subtree would report success and reach nothing
-        story_roots = {id(root) for _, root in _story_elements(self._document)}
-        for atom in self._atoms:
-            top = atom.element
-            while top.getparent() is not None:
-                top = top.getparent()
-            if id(top) not in story_roots:
+        # Text equality is insufficient: moving the same w:t into a field,
+        # hyperlink, content control, or revision changes whether/how it may be
+        # edited. Rebuild the story atom census and compare the captured scope
+        # of each live element. Detached and alternate-branch-switched atoms
+        # naturally disappear from this census.
+        story_root = next(
+            (
+                root
+                for story_name, root in _story_elements(self._document)
+                if story_name == self.story
+            ),
+            None,
+        )
+        if story_root is None:
+            raise TargetNotFoundError(
+                "span is stale: its story part was removed from the document"
+            )
+        current_atoms = _story_atoms(self._document, self.story, story_root)
+        current_by_element = {id(atom.element): atom for atom in current_atoms}
+        for captured, expected in zip(self._atoms, self._context_signatures):
+            current = current_by_element.get(id(captured.element))
+            if current is None or _atom_context_signature(current) != expected:
                 raise TargetNotFoundError(
-                    "span is stale: its containing structure was removed from"
-                    " the document"
+                    "span is stale: its field, hyperlink, content-control,"
+                    " revision, or containing structure has changed or was"
+                    " removed"
                 )
+        sequence_atoms = (
+            current_atoms
+            if self._sequence_view is None
+            else [
+                atom
+                for atom in current_atoms
+                if _include_atom(atom, self._sequence_view)
+            ]
+        )
+        sequence_positions = {
+            id(atom.element): index for index, atom in enumerate(sequence_atoms)
+        }
+        expected_first = self._atom_sequence[0]
+        expected_last = self._atom_sequence[-1]
+        sequence_start = sequence_positions.get(id(expected_first))
+        sequence_end = sequence_positions.get(id(expected_last))
+        current_sequence = (
+            ()
+            if sequence_start is None
+            or sequence_end is None
+            or sequence_start > sequence_end
+            else tuple(
+                atom.element
+                for atom in sequence_atoms[sequence_start : sequence_end + 1]
+            )
+        )
+        if len(current_sequence) != len(self._atom_sequence) or any(
+            current is not expected
+            for current, expected in zip(current_sequence, self._atom_sequence)
+        ):
+            raise TargetNotFoundError(
+                "span is stale: the text-atom sequence inside its captured"
+                " interval has changed"
+            )
 
     def _validate_replaceable(self) -> None:
         for atom in self._atoms:
             if atom.is_synthetic:
+                detail = (
+                    "unmodeled visible run content"
+                    if atom.barrier
+                    else "a tab or line break, or a no-break hyphen"
+                )
                 raise UnsupportedStructureError(
-                    "span crosses a tab or line break; replace the text"
+                    f"span crosses {detail}; replace the text"
                     " segments on either side individually"
                 )
             if atom.tag == _DEL_TEXT or atom.in_delete:
@@ -723,13 +872,17 @@ class Span:
         self.text = new_text
         self._end_offset = self._start_offset + len(new_text)
         del self._atoms[1:]
+        self._context_signatures = tuple(
+            _atom_context_signature(atom) for atom in self._atoms
+        )
+        self._atom_sequence = (first.element,)
+        self._sequence_view = "current"
+        self._view = "current"
         return result
 
     def _tracked_replace(
         self, new_text: str, *, author: str, date: Optional[dt.datetime]
     ) -> ReplaceResult:
-        import copy
-
         from docx.oxml.revision import CT_RunTrackChange
 
         if self.story == "word/comments.xml":
@@ -981,6 +1134,27 @@ _W_ID = qn("w:id")
 _W_NAME = qn("w:name")
 
 
+def _validate_xml_characters(value: str, *, argument: str) -> None:
+    """Reject characters XML 1.0 cannot represent before any mutation."""
+    invalid = sorted(
+        {
+            f"U+{ord(char):04X}"
+            for char in value
+            if not (
+                ord(char) in (0x09, 0x0A, 0x0D)
+                or 0x20 <= ord(char) <= 0xD7FF
+                or 0xE000 <= ord(char) <= 0xFFFD
+                or 0x10000 <= ord(char) <= 0x10FFFF
+            )
+        }
+    )
+    if invalid:
+        raise ValueError(
+            f"{argument} contains character(s) XML 1.0 cannot represent:"
+            f" {invalid!r}"
+        )
+
+
 def _validate_writable_text(value: str, *, argument: str) -> None:
     """Refuse control characters in text written into `w:t` (programmer error).
 
@@ -989,6 +1163,7 @@ def _validate_writable_text(value: str, *, argument: str) -> None:
     structure. The search side refuses spans crossing `w:br`/`w:tab` for the
     mirror reason: replacing across one would silently drop it.
     """
+    _validate_xml_characters(value, argument=argument)
     found = sorted({c for c in value if c in _CONTROL_CHARS})
     if found:
         raise ValueError(
@@ -1116,9 +1291,15 @@ def _spans_for_story(
     story_name: str,
     atoms: "List[_Atom]",
     needle_norm: str,
+    *,
+    all_atoms: "Sequence[_Atom]",
+    view: str,
 ) -> "List[Span]":
     raw_text, char_map = _assemble(atoms)
     normalized, norm_map = _normalized_with_map(raw_text)
+    all_atom_positions = {
+        id(atom.element): index for index, atom in enumerate(all_atoms)
+    }
     spans: "List[Span]" = []
     search_from = 0
     while True:
@@ -1144,28 +1325,34 @@ def _spans_for_story(
         )
         span_atoms = atoms[start_atom_idx : end_atom_idx + 1]
         start_block = atoms[start_atom_idx].block_index
-        spans.append(
-            Span(
-                text=raw_text[raw_start:raw_end],
+        span = Span(
+            text=raw_text[raw_start:raw_end],
+            story=story_name,
+            anchor=Anchor(
                 story=story_name,
-                anchor=Anchor(
-                    story=story_name,
-                    index=start_block,
-                    content_hash=content_hash(raw_text[raw_start:raw_end]),
-                ),
-                in_insert=any(a.in_insert for a in span_atoms),
-                in_delete=any(a.in_delete or a.tag == _DEL_TEXT for a in span_atoms),
-                in_content_control=any(a.sdt is not None for a in span_atoms),
-                in_text_box=any(a.in_text_box for a in span_atoms),
-                in_field=any(a.in_field for a in span_atoms),
-                crosses_paragraphs=crosses,
-                _document=document,
-                _atoms=list(span_atoms),
-                _start_offset=start_offset,
-                _end_offset=end_offset + 1,
-                _norm_start=found_at,
-            )
+                index=start_block,
+                content_hash=content_hash(raw_text[raw_start:raw_end]),
+            ),
+            in_insert=any(a.in_insert for a in span_atoms),
+            in_delete=any(a.in_delete or a.tag == _DEL_TEXT for a in span_atoms),
+            in_content_control=any(a.sdt is not None for a in span_atoms),
+            in_text_box=any(a.in_text_box for a in span_atoms),
+            in_field=any(a.in_field for a in span_atoms),
+            crosses_paragraphs=crosses,
+            _document=document,
+            _atoms=list(span_atoms),
+            _start_offset=start_offset,
+            _end_offset=end_offset + 1,
+            _norm_start=found_at,
         )
+        sequence_start = all_atom_positions[id(span_atoms[0].element)]
+        sequence_end = all_atom_positions[id(span_atoms[-1].element)]
+        span._atom_sequence = tuple(
+            atom.element for atom in all_atoms[sequence_start : sequence_end + 1]
+        )
+        span._sequence_view = None
+        span._view = view
+        spans.append(span)
     return spans
 
 
@@ -1204,14 +1391,18 @@ def find_text(
     for story_name, root in _story_elements(document):
         if story is not None and story_name != story:
             continue
-        atoms = [
-            atom
-            for atom in _story_atoms(document, story_name, root)
-            if _include_atom(atom, view)
-        ]
+        all_atoms = _story_atoms(document, story_name, root)
+        atoms = [atom for atom in all_atoms if _include_atom(atom, view)]
         if not atoms:
             continue
-        spans = _spans_for_story(document, story_name, atoms, needle_norm)
+        spans = _spans_for_story(
+            document,
+            story_name,
+            atoms,
+            needle_norm,
+            all_atoms=all_atoms,
+            view=view,
+        )
         if not spans:
             continue
         near_positions: "List[int]" = []

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -103,6 +103,15 @@ class _Atom:
         return self.fixed_text is not None
 
 
+@dataclass(frozen=True)
+class _FreshnessCensus:
+    """One story census shared by a synchronous replacement batch."""
+
+    atoms: "Tuple[_Atom, ...]"
+    by_element: "dict[int, _Atom]"
+    positions: "dict[int, int]"
+
+
 _CONTEXT_SCOPE_TAGS = frozenset(
     (_INS, _DEL, _MOVE_FROM, _MOVE_TO, _SDT, _HYPERLINK, _FLD_SIMPLE, _TXBX)
 )
@@ -367,6 +376,9 @@ class Span:
     _atom_sequence: "Tuple[_Element, ...]" = field(init=False, repr=False)
     _sequence_view: "Optional[str]" = field(init=False, repr=False)
     _view: str = field(init=False, repr=False)
+    _freshness_census: "Optional[_FreshnessCensus]" = field(
+        default=None, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self._context_signatures = tuple(
@@ -620,6 +632,7 @@ class Span:
         )
         sub_span._view = self._view
         sub_span._sequence_view = self._sequence_view
+        sub_span._freshness_census = self._freshness_census
         sequence_positions = {
             id(element): index for index, element in enumerate(self._atom_sequence)
         }
@@ -673,9 +686,9 @@ class Span:
             )
         # Text equality is insufficient: moving the same w:t into a field,
         # hyperlink, content control, or revision changes whether/how it may be
-        # edited. Rebuild the story atom census and compare the captured scope
-        # of each live element. Detached and alternate-branch-switched atoms
-        # naturally disappear from this census.
+        # edited. Compare against one shared census for a synchronous batch,
+        # or rebuild the story census for an independently used span. Detached
+        # and alternate-branch-switched atoms naturally disappear from it.
         story_root = next(
             (
                 root
@@ -688,8 +701,17 @@ class Span:
             raise TargetNotFoundError(
                 "span is stale: its story part was removed from the document"
             )
-        current_atoms = _story_atoms(self._document, self.story, story_root)
-        current_by_element = {id(atom.element): atom for atom in current_atoms}
+        census = self._freshness_census
+        if census is None:
+            current_atoms = tuple(
+                _story_atoms(self._document, self.story, story_root)
+            )
+            current_by_element = {
+                id(atom.element): atom for atom in current_atoms
+            }
+        else:
+            current_atoms = census.atoms
+            current_by_element = census.by_element
         for captured, expected in zip(self._atoms, self._context_signatures):
             current = current_by_element.get(id(captured.element))
             if current is None or _atom_context_signature(current) != expected:
@@ -707,9 +729,14 @@ class Span:
                 if _include_atom(atom, self._sequence_view)
             ]
         )
-        sequence_positions = {
-            id(atom.element): index for index, atom in enumerate(sequence_atoms)
-        }
+        sequence_positions = (
+            census.positions
+            if census is not None and self._sequence_view is None
+            else {
+                id(atom.element): index
+                for index, atom in enumerate(sequence_atoms)
+            }
+        )
         expected_first = self._atom_sequence[0]
         expected_last = self._atom_sequence[-1]
         sequence_start = sequence_positions.get(id(expected_first))
@@ -1524,29 +1551,56 @@ def replace_all(
         by_story.setdefault(span.story, []).append(span)
     results: "List[ReplaceResult]" = []
     refused: "List[dict]" = []
-    with rollback_on_error(document):
-        for story_name in sorted(by_story):
-            ordered = sorted(
-                by_story[story_name], key=lambda s: s._norm_start, reverse=True
+    story_roots = dict(_story_elements(document))
+    for story_name, story_spans in by_story.items():
+        root = story_roots.get(story_name)
+        if root is None:
+            raise TargetNotFoundError(
+                f"story {story_name!r} was removed before replacement"
             )
-            for span in ordered:
-                try:
-                    results.append(
-                        span.replace(new_text, tracked=tracked, author=author, date=date)
-                    )
-                except TargetNotFoundError:
-                    # A stale target invalidates the captured batch. The outer
-                    # transaction restores replacements already applied.
-                    raise
-                except PaperRefusal as exc:
-                    refused.append(
-                        {
-                            "story": span.story,
-                            "anchor": span.anchor.to_dict(),
-                            "error": type(exc).__name__,
-                            "message": str(exc),
-                        }
-                    )
+        atoms = tuple(_story_atoms(document, story_name, root))
+        census = _FreshnessCensus(
+            atoms=atoms,
+            by_element={id(atom.element): atom for atom in atoms},
+            positions={
+                id(atom.element): index for index, atom in enumerate(atoms)
+            },
+        )
+        for span in story_spans:
+            span._freshness_census = census
+    try:
+        with rollback_on_error(document):
+            for story_name in sorted(by_story):
+                ordered = sorted(
+                    by_story[story_name], key=lambda s: s._norm_start, reverse=True
+                )
+                for span in ordered:
+                    try:
+                        results.append(
+                            span.replace(
+                                new_text,
+                                tracked=tracked,
+                                author=author,
+                                date=date,
+                            )
+                        )
+                    except TargetNotFoundError:
+                        # A stale target invalidates the captured batch. The outer
+                        # transaction restores replacements already applied.
+                        raise
+                    except PaperRefusal as exc:
+                        refused.append(
+                            {
+                                "story": span.story,
+                                "anchor": span.anchor.to_dict(),
+                                "error": type(exc).__name__,
+                                "message": str(exc),
+                            }
+                        )
+    finally:
+        for story_spans in by_story.values():
+            for span in story_spans:
+                span._freshness_census = None
     return ReplaceAllResult(
         replaced_count=len(results), results=tuple(results), refused=tuple(refused)
     )

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
 from docx import _clock, _textatoms
 from docx._normalize import normalize_text  # noqa: F401 - public re-export
+from docx._transaction import rollback_on_error
 from docx.errors import (
     AmbiguousTargetError,
     BoundaryViolationError,
@@ -417,17 +418,24 @@ class Span:
         from docx.commentops import _preflight_comment_add
 
         _preflight_comment_add(self._document)
-        self._isolate_edge_runs()
-        runs = []
-        for atom in self._atoms:
-            if not any(existing is atom.run for existing in runs):
-                runs.append(atom.run)
-        comments = self._document.comments
-        comment = comments.add_comment(text=text, author=author, initials=initials or "")
-        comment._comment_elm.date = date if date is not None else _clock.now()  # noqa: SLF001
-        runs[0].insert_comment_range_start_above(comment.comment_id)
-        runs[-1].insert_comment_range_end_and_reference_below(comment.comment_id)
-        return comment
+        with rollback_on_error(self._document, self):
+            self._isolate_edge_runs()
+            runs = []
+            for atom in self._atoms:
+                if not any(existing is atom.run for existing in runs):
+                    runs.append(atom.run)
+            comments = self._document.comments
+            comment = comments.add_comment(
+                text=text, author=author, initials=initials or ""
+            )
+            comment._comment_elm.date = (  # noqa: SLF001
+                date if date is not None else _clock.now()
+            )
+            runs[0].insert_comment_range_start_above(comment.comment_id)
+            runs[-1].insert_comment_range_end_and_reference_below(
+                comment.comment_id
+            )
+            return comment
 
     def _isolate_edge_runs(self) -> None:
         """Split boundary runs so this span's runs hold EXACTLY its text.

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -805,6 +805,12 @@ class Span:
         """
         if tracked and not author:
             raise ValueError("author is required when tracked=True")
+        if tracked:
+            # the w:ins/w:del identity attributes are stamped AFTER mutation
+            # begins; malformed values must refuse before anything changes
+            _validate_xml_characters(author, argument="author")
+            if date is not None and not isinstance(date, dt.datetime):
+                raise TypeError("date must be a datetime or None")
         _validate_writable_text(new_text, argument="new_text")
         _refuse_if_protected(self._document, "replace text")
         self._validate_fresh()

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -404,7 +404,12 @@ class Span:
         if date is not None and not isinstance(date, dt.datetime):
             raise TypeError("date must be a datetime or None")
         _refuse_if_protected(self._document, "anchor a comment")
-        if self.story != "word/document.xml":
+        main_story = next(
+            story
+            for story, root in _story_elements(self._document)
+            if root is self._document.element
+        )
+        if self.story != main_story:
             raise UnsupportedStructureError(
                 "comments anchor in the main document story"
                 f" (span is in {self.story})"
@@ -415,9 +420,17 @@ class Span:
                 raise UnsupportedStructureError(
                     "span text is not inside runs; cannot anchor a comment"
                 )
-        from docx.commentops import _preflight_comment_add
+        from docx.commentops import _preflight_comment_add, _preflight_comment_range
 
         _preflight_comment_add(self._document)
+        runs = []
+        for atom in self._atoms:
+            if atom.run is not None and not any(atom.run is run for run in runs):
+                runs.append(atom.run)
+        if runs:
+            _preflight_comment_range(
+                self._document, runs[0], runs[-1], operation="anchor a comment"
+            )
         with rollback_on_error(self._document, self):
             self._isolate_edge_runs()
             runs = []
@@ -759,6 +772,21 @@ class Span:
                 "span crosses a content-control boundary; edit inside or"
                 " outside the control, not across it"
             )
+        from docx.controls import (
+            _refuse_control_write_restrictions,
+            _validate_span_surface_edit,
+        )
+
+        controls = []
+        for atom in self._atoms:
+            current = atom.element.getparent()
+            while current is not None:
+                if current.tag == _SDT and not any(current is item for item in controls):
+                    controls.append(current)
+                current = current.getparent()
+        for control in controls:
+            _validate_span_surface_edit(control)
+            _refuse_control_write_restrictions(control)
         # both modes: an untracked replace crossing a hyperlink boundary
         # would silently move text into or out of the link
         link_scopes = {
@@ -1486,30 +1514,39 @@ def replace_all(
         raise ValueError("author is required when tracked=True")
     _validate_writable_text(new_text, argument="new_text")
     _refuse_if_protected(document, "replace text")
-    spans = find_text(document, needle, story=story, view=view)
+    spans = [
+        span
+        for span in find_text(document, needle, story=story, view=view)
+        if span.text != new_text
+    ]
     by_story: "dict[str, List[Span]]" = {}
     for span in spans:
         by_story.setdefault(span.story, []).append(span)
     results: "List[ReplaceResult]" = []
     refused: "List[dict]" = []
-    for story_name in sorted(by_story):
-        ordered = sorted(
-            by_story[story_name], key=lambda s: s._norm_start, reverse=True
-        )
-        for span in ordered:
-            try:
-                results.append(
-                    span.replace(new_text, tracked=tracked, author=author, date=date)
-                )
-            except PaperRefusal as exc:
-                refused.append(
-                    {
-                        "story": span.story,
-                        "anchor": span.anchor.to_dict(),
-                        "error": type(exc).__name__,
-                        "message": str(exc),
-                    }
-                )
+    with rollback_on_error(document):
+        for story_name in sorted(by_story):
+            ordered = sorted(
+                by_story[story_name], key=lambda s: s._norm_start, reverse=True
+            )
+            for span in ordered:
+                try:
+                    results.append(
+                        span.replace(new_text, tracked=tracked, author=author, date=date)
+                    )
+                except TargetNotFoundError:
+                    # A stale target invalidates the captured batch. The outer
+                    # transaction restores replacements already applied.
+                    raise
+                except PaperRefusal as exc:
+                    refused.append(
+                        {
+                            "story": span.story,
+                            "anchor": span.anchor.to_dict(),
+                            "error": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                    )
     return ReplaceAllResult(
         replaced_count=len(results), results=tuple(results), refused=tuple(refused)
     )

--- a/src/docx/story.py
+++ b/src/docx/story.py
@@ -210,7 +210,7 @@ def _story_elements(document: "Document") -> "List[Tuple[str, _Element]]":
     assert package is not None
     found: "List[Tuple[str, _Element]]" = []
     for part in package.iter_parts():
-        name = str(part.partname).lstrip("/")
+        name = str(part.partname).lstrip("/").casefold()
         element = getattr(part, "_element", None)
         if element is None:
             continue

--- a/src/docx/story.py
+++ b/src/docx/story.py
@@ -14,9 +14,10 @@ Traversal rules:
 * Paragraphs inside table cells are not emitted as separate blocks — their
   text belongs to the table block. Paragraphs inside content controls and
   text boxes ARE emitted, flagged.
-* `mc:AlternateContent` contributes only its first `mc:Choice`; fallbacks
-  (which duplicate content, e.g. VML copies of text boxes) are skipped, so
-  one visible text box yields its text exactly once.
+* `mc:AlternateContent` contributes its first supported `mc:Choice`, or its
+  `mc:Fallback` when none of the choices' required namespaces are supported.
+  Exactly one branch is traversed, so duplicated compatibility content is
+  never counted twice.
 * Empty paragraphs are emitted — block indices must be stable, and an empty
   paragraph is a real edit target.
 """
@@ -27,6 +28,7 @@ import hashlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
+from docx import _textatoms
 from docx._normalize import normalize_text
 from docx.oxml.ns import qn
 
@@ -37,6 +39,9 @@ if TYPE_CHECKING:
 
 VIEWS = ("current", "original", "all")
 
+_T = _textatoms.T
+_DEL_TEXT = _textatoms.DEL_TEXT
+_FLD_CHAR = _textatoms.FLD_CHAR
 _P = qn("w:p")
 _TBL = qn("w:tbl")
 _SDT = qn("w:sdt")
@@ -45,14 +50,8 @@ _INS = qn("w:ins")
 _DEL = qn("w:del")
 _MOVE_FROM = qn("w:moveFrom")
 _MOVE_TO = qn("w:moveTo")
-_T = qn("w:t")
-_DEL_TEXT = qn("w:delText")
-_TAB = qn("w:tab")
-_BR = qn("w:br")
-_CR = qn("w:cr")
 _TXBX = qn("w:txbxContent")
 _FLD_SIMPLE = qn("w:fldSimple")
-_FLD_CHAR = qn("w:fldChar")
 _FLD_CHAR_TYPE = qn("w:fldCharType")
 
 #: tracked property-change vocabulary — enumerable, countable, not resolvable
@@ -75,6 +74,29 @@ _FOOTNOTE_TYPE = qn("w:type")
 _MC_NS = "http://schemas.openxmlformats.org/markup-compatibility/2006"
 _MC_ALTERNATE = f"{{{_MC_NS}}}AlternateContent"
 _MC_CHOICE = f"{{{_MC_NS}}}Choice"
+_MC_FALLBACK = f"{{{_MC_NS}}}Fallback"
+
+# Namespace capabilities this traversal actually understands. ``Requires``
+# names prefixes, but support is a property of their namespace URIs; merely
+# declaring an unknown prefix does not make its choice processable.
+_SUPPORTED_MC_NAMESPACES = frozenset(
+    (
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "http://schemas.openxmlformats.org/drawingml/2006/picture",
+        "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+        "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
+        "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+        "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
+        "http://schemas.microsoft.com/office/word/2010/wordml",
+        "http://schemas.microsoft.com/office/word/2012/wordml",
+        "urn:schemas-microsoft-com:office:office",
+        "urn:schemas-microsoft-com:office:word",
+        "urn:schemas-microsoft-com:vml",
+    )
+)
+
 
 def _story_sort_key(name: str) -> Tuple[int, str]:
     """Traversal order: body, headers, footers, footnotes, endnotes, comments."""
@@ -205,15 +227,35 @@ def story_parts(document: "Document") -> Tuple[str, ...]:
 
 
 def _first_choice_children(element: "_Element") -> "List[_Element]":
-    """`element`'s children with mc:AlternateContent collapsed to its first
-    mc:Choice (fallback content is a duplicate and must not be traversed)."""
+    """Children with each ``mc:AlternateContent`` collapsed to one branch.
+
+    Choices are considered in document order and selected only when every
+    prefix in their required namespace list is one this traversal supports.
+    If no choice qualifies, the fallback branch is used. Missing fallback
+    content honestly contributes nothing.
+    """
+
+    def choice_is_supported(choice: "_Element") -> bool:
+        requires = (choice.get("Requires") or "").split()
+        return bool(requires) and all(
+            choice.nsmap.get(prefix) in _SUPPORTED_MC_NAMESPACES
+            for prefix in requires
+        )
+
     result: "List[_Element]" = []
     for child in element:
         if child.tag == _MC_ALTERNATE:
+            selected = None
+            fallback = None
             for alt_child in child:
-                if alt_child.tag == _MC_CHOICE:
-                    result.extend(_first_choice_children(alt_child))
+                if alt_child.tag == _MC_CHOICE and choice_is_supported(alt_child):
+                    selected = alt_child
                     break
+                if alt_child.tag == _MC_FALLBACK and fallback is None:
+                    fallback = alt_child
+            selected = selected if selected is not None else fallback
+            if selected is not None:
+                result.extend(_first_choice_children(selected))
         else:
             result.append(child)
     return result
@@ -272,12 +314,21 @@ class _TextVisitor:
                 return
             self._emit(element.text or "", in_ins, True, in_sdt, in_txbx)
             return
-        if tag in (_TAB, _BR, _CR):
+        if tag == _textatoms.INSTR_TEXT:
+            # Field instructions are searchable so edits can detect and
+            # refuse them, but they are not visible document text.
+            return
+        if _textatoms.is_direct_run_child(element):
+            projection = _textatoms.project_run_child(element)
+            if projection.barrier:
+                return
+            if not projection.text:
+                return
             if self.view == "current" and in_del:
                 return
             if self.view == "original" and in_ins:
                 return
-            self._emit("\t" if tag == _TAB else "\n", in_ins, in_del, in_sdt, in_txbx)
+            self._emit(projection.text, in_ins, in_del, in_sdt, in_txbx)
             return
         for child in _first_choice_children(element):
             self.visit(child, in_ins=in_ins, in_del=in_del, in_sdt=in_sdt,
@@ -493,7 +544,7 @@ def _count_blind_regions(root: "_Element") -> Dict[str, int]:
     text hold content this package does not surface; a non-zero count says
     "there is more here than the outline shows".
     """
-    counts = {key: 0 for key in BLIND_REGION_KEYS}
+    counts = dict.fromkeys(BLIND_REGION_KEYS, 0)
     tag_keys = {
         _INS: "tracked_insertions",
         _DEL: "tracked_deletions",
@@ -564,7 +615,7 @@ def outline(document: "Document", *, view: str = "current") -> Outline:
     on every call (inspection determinism).
     """
     blocks = tuple(iter_blocks(document, view=view))
-    totals = {key: 0 for key in BLIND_REGION_KEYS}
+    totals = dict.fromkeys(BLIND_REGION_KEYS, 0)
     for _, root in _story_elements(document):
         for key, value in _count_blind_regions(root).items():
             totals[key] += value

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -22,8 +22,8 @@ from docx.errors import (
     UnsupportedStructureError,
 )
 from docx.oxml.ns import qn
-from docx.protection import _refuse_if_protected
 from docx.oxml.revision import CT_RunTrackChange
+from docx.protection import _refuse_if_protected
 from docx.search import (
     ReplaceResult,
     Span,
@@ -45,6 +45,7 @@ _GRID_SPAN = qn("w:gridSpan")
 _V_MERGE = qn("w:vMerge")
 _TBL = qn("w:tbl")
 _TC = qn("w:tc")
+_SDT = qn("w:sdt")
 _W_VAL = qn("w:val")
 
 
@@ -100,6 +101,22 @@ def _row_continues_merge_from_above(tr) -> bool:
     return False
 
 
+def _refuse_tracked_template_row(tr, *, row: int) -> None:
+    from docx.revision import _MARKUP_SCAN_TAGS
+
+    revision = next(
+        (node for node in tr.iter() if node.tag in _MARKUP_SCAN_TAGS),
+        None,
+    )
+    if revision is None:
+        return
+    marker = revision.tag.rpartition("}")[2]
+    raise UnsupportedStructureError(
+        f"template row {row} contains tracked revision metadata ({marker});"
+        " resolve its pending revisions before copying formatting from it"
+    )
+
+
 def _refuse_row_op(table: "Table", *, affected_rows, splits_before=None) -> None:
     """Row-op guard: refuse only when the AFFECTED rows intersect a
     vertical merge or hold a nested table, or when insertion would split a
@@ -116,12 +133,15 @@ def _refuse_row_op(table: "Table", *, affected_rows, splits_before=None) -> None
                 f"row {index} contains a nested table; refusing rather than"
                 " duplicating or destroying it wholesale"
             )
-    if splits_before is not None and splits_before < len(table.rows):
-        if _row_continues_merge_from_above(table.rows[splits_before]._tr):
-            raise UnsupportedStructureError(
-                f"inserting between rows {splits_before - 1} and {splits_before}"
-                " would split a vertical merge"
-            )
+    if (
+        splits_before is not None
+        and splits_before < len(table.rows)
+        and _row_continues_merge_from_above(table.rows[splits_before]._tr)
+    ):
+        raise UnsupportedStructureError(
+            f"inserting between rows {splits_before - 1} and {splits_before}"
+            " would split a vertical merge"
+        )
 
 
 def _document_of(table: "Table") -> "Document":
@@ -215,13 +235,22 @@ def update_cell(
         )
     story, block_index = _locate_table_block(document, table)
     target_paragraph = populated[0] if populated else cell.paragraphs[0]
-    atoms = [
-        atom
-        for atom in _collect_block_atoms(
-            story, block_index, target_paragraph._p, skip_text_boxes=False, in_txbx=False
+    all_atoms = list(
+        _collect_block_atoms(
+            story,
+            block_index,
+            target_paragraph._p,
+            skip_text_boxes=False,
+            in_txbx=False,
         )
-        if atom.tag == _T
-    ]
+    )
+    if any(atom.is_synthetic for atom in all_atoms):
+        raise UnsupportedStructureError(
+            "cell text contains a tab, break, no-break hyphen, or other"
+            " visible run content that cannot be represented by new_text;"
+            " update its text segments individually instead"
+        )
+    atoms = [atom for atom in all_atoms if atom.tag == _T]
     if not atoms:
         return _fill_empty_cell(
             document, story, target_paragraph, new_text,
@@ -306,6 +335,7 @@ def insert_row_after(
     # rows[..].cells, so positional value assignment would silently drop or
     # misplace values — refuse instead
     template_tr = rows[template_index]._tr
+    _refuse_tracked_template_row(template_tr, row=template_index)
     if any(
         tc.find(_TC_PR) is not None and tc.find(_TC_PR).find(_GRID_SPAN) is not None
         for tc in _row_cells(template_tr)
@@ -316,18 +346,32 @@ def insert_row_after(
             " copy formatting from an unmerged row"
         )
 
-    # -- validated; mutate --
+    # Populate the copied row while detached. Any refusal or unexpected error
+    # leaves the table tree untouched.
     new_tr = copy.deepcopy(rows[template_index]._tr)
-    rows[row]._tr.addnext(new_tr)
-    for index, cell in enumerate(table.rows[row + 1].cells):
+    from docx.table import _Cell
+
+    detached_cells = tuple(_Cell(tc, table) for tc in _row_cells(new_tr))
+    for index, cell in enumerate(detached_cells):
         _set_cell_text_keeping_format(
             cell, values[index] if index < len(values) else ""
         )
+    rows[row]._tr.addnext(new_tr)
 
 
 def _set_cell_text_keeping_format(cell: "_Cell", text: str) -> None:
     """Replace a copied cell's text, keeping its paragraph and run formatting
     (the upstream `.text` setter would drop the template's run properties)."""
+    if next(iter(cell._tc.iter(_SDT)), None) is not None:
+        raise UnsupportedStructureError(
+            "template cell contains a content control that cannot be populated"
+            " safely; nothing was changed"
+        )
+    if not cell.paragraphs:
+        raise UnsupportedStructureError(
+            "template cell has no direct paragraph that can be populated safely;"
+            " nothing was changed"
+        )
     paragraph = cell.paragraphs[0]
     template_rpr = None
     for run in paragraph.runs:

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -47,6 +47,25 @@ _TBL = qn("w:tbl")
 _TC = qn("w:tc")
 _SDT = qn("w:sdt")
 _W_VAL = qn("w:val")
+_FLD_CHAR = qn("w:fldChar")
+
+
+def _refuse_whole_cell_semantics(tc) -> None:
+    """Refuse semantics that may begin/end outside the chosen paragraph."""
+    from docx.revision import _MARKUP_SCAN_TAGS
+
+    if (
+        next(tc.iter(_FLD_CHAR), None) is not None
+        or next(tc.iter(qn("w:fldSimple")), None) is not None
+    ):
+        raise UnsupportedStructureError(
+            "cell contains a Word field; update its field/result explicitly"
+        )
+    revision = next((node for node in tc.iter() if node.tag in _MARKUP_SCAN_TAGS), None)
+    if revision is not None:
+        raise UnsupportedStructureError(
+            "cell contains pending revision markup; resolve it before replacing the cell"
+        )
 
 
 def _cell_is_merged(tc) -> bool:
@@ -193,12 +212,14 @@ def _cell_at(table: "Table", row: int, column: int) -> "_Cell":
     rows = table.rows
     if not 0 <= row < len(rows):
         raise TargetNotFoundError(f"row {row} does not exist (0..{len(rows) - 1})")
-    cells = rows[row].cells
-    if not 0 <= column < len(cells):
+    row_proxy = rows[row]
+    offset = column - row_proxy.grid_cols_before
+    cells = row_proxy.cells
+    if offset < 0 or offset >= len(cells):
         raise TargetNotFoundError(
-            f"column {column} does not exist (0..{len(cells) - 1})"
+            f"layout-grid column {column} has no cell in row {row}"
         )
-    return cells[column]
+    return cells[offset]
 
 
 def update_cell(
@@ -226,6 +247,7 @@ def update_cell(
     _refuse_if_protected(document, "update a table cell")
     cell = _cell_at(table, row, column)
     _refuse_complex_cell(cell._tc, row=row, column=column)
+    _refuse_whole_cell_semantics(cell._tc)
 
     populated = [p for p in cell.paragraphs if p.text]
     if len(populated) > 1:
@@ -252,6 +274,11 @@ def update_cell(
         )
     atoms = [atom for atom in all_atoms if atom.tag == _T]
     if not atoms:
+        if next(cell._tc.iter(_SDT), None) is not None:
+            raise UnsupportedStructureError(
+                "empty cell contains a content control; set it through"
+                " Control.set_value() instead"
+            )
         return _fill_empty_cell(
             document, story, target_paragraph, new_text,
             tracked=tracked, author=author, date=date,

--- a/src/docx/text/run.py
+++ b/src/docx/text/run.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import IO, TYPE_CHECKING, Iterator, cast
 
+from docx._transaction import rollback_xml_on_error
 from docx.drawing import Drawing
 from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.text import WD_BREAK
+from docx.errors import UnsupportedStructureError
 from docx.oxml.drawing import CT_Drawing
 from docx.oxml.text.pagebreak import CT_LastRenderedPageBreak
 from docx.shape import InlineShape
@@ -178,12 +180,25 @@ class Run(StoryChild):
 
         `comment_id` identfies the comment that references this range.
         """
-        # -- insert `w:commentRangeStart` with `comment_id` before this (first) run --
-        self._r.insert_comment_range_start_above(comment_id)
+        root = self._r.getroottree().getroot()
+        if root is not last_run._r.getroottree().getroot():
+            raise UnsupportedStructureError(
+                "comment range runs belong to different documents; nothing was changed"
+            )
+        for element in root.iter():
+            if element is self._r:
+                break
+            if element is last_run._r:
+                raise UnsupportedStructureError(
+                    "comment range ends before it starts; nothing was changed"
+                )
+        with rollback_xml_on_error(root):
+            # -- insert `w:commentRangeStart` with `comment_id` before this (first) run --
+            self._r.insert_comment_range_start_above(comment_id)
 
-        # -- insert `w:commentRangeEnd` and `w:commentReference` run with `comment_id` after
-        # -- `last_run`
-        last_run._r.insert_comment_range_end_and_reference_below(comment_id)
+            # -- insert `w:commentRangeEnd` and `w:commentReference` run with `comment_id` after
+            # -- `last_run`
+            last_run._r.insert_comment_range_end_and_reference_below(comment_id)
 
     @property
     def style(self) -> CharacterStyle:

--- a/src/paper_docx_doctor/__init__.py
+++ b/src/paper_docx_doctor/__init__.py
@@ -97,7 +97,12 @@ def _verify_docx_record(dist: Distribution) -> Path:
         if not path.is_file():
             raise DoctorError(f"paper-docx file is missing: {relative_path}")
         algorithm, expected = _parse_hash(hash_spec, relative_path)
-        actual = _file_digest(path, algorithm)
+        try:
+            actual = _file_digest(path, algorithm)
+        except OSError as exc:
+            raise DoctorError(
+                f"paper-docx file cannot be read: {relative_path}"
+            ) from exc
         if not hmac.compare_digest(actual, expected):
             raise DoctorError(f"paper-docx file hash mismatch: {relative_path}")
 
@@ -127,16 +132,21 @@ def _verify_docx_import_path(docx: object, docx_root: Path) -> None:
 
 
 def _docx_record_entries(record: str) -> Iterable[Tuple[PurePosixPath, str]]:
-    for row in csv.reader(StringIO(record)):
-        if len(row) != 3:
-            raise DoctorError("paper-docx RECORD contains a malformed row")
-        raw_path, hash_spec, _size = row
-        path = PurePosixPath(raw_path)
-        if not path.parts or path.parts[0] != "docx":
-            continue
-        if path.is_absolute() or ".." in path.parts:
-            raise DoctorError(f"paper-docx RECORD contains an unsafe path: {raw_path}")
-        yield path, hash_spec
+    try:
+        for row in csv.reader(StringIO(record)):
+            if len(row) != 3:
+                raise DoctorError("paper-docx RECORD contains a malformed row")
+            raw_path, hash_spec, _size = row
+            path = PurePosixPath(raw_path)
+            if not path.parts or path.parts[0] != "docx":
+                continue
+            if path.is_absolute() or ".." in path.parts:
+                raise DoctorError(
+                    f"paper-docx RECORD contains an unsafe path: {raw_path}"
+                )
+            yield path, hash_spec
+    except csv.Error as exc:
+        raise DoctorError("paper-docx RECORD contains malformed CSV") from exc
 
 
 def _parse_hash(hash_spec: str, relative_path: PurePosixPath) -> Tuple[str, str]:

--- a/src/paper_docx_doctor/__init__.py
+++ b/src/paper_docx_doctor/__init__.py
@@ -40,12 +40,14 @@ def verify_install() -> str:
             "docx package"
         )
 
-    _verify_docx_record(paper)
+    docx_root = _verify_docx_record(paper)
 
     try:
         docx = importlib.import_module("docx")
     except Exception as exc:
         raise DoctorError(f"docx cannot be imported: {exc}") from exc
+
+    _verify_docx_import_path(docx, docx_root)
 
     sentinel = getattr(docx, "__paper_version__", None)
     if sentinel is None:
@@ -77,7 +79,7 @@ def _installed_distribution(name: str) -> Optional[Distribution]:
         return None
 
 
-def _verify_docx_record(dist: Distribution) -> None:
+def _verify_docx_record(dist: Distribution) -> Path:
     record = dist.read_text("RECORD")
     if record is None:
         raise DoctorError("paper-docx RECORD is missing")
@@ -98,6 +100,30 @@ def _verify_docx_record(dist: Distribution) -> None:
         actual = _file_digest(path, algorithm)
         if not hmac.compare_digest(actual, expected):
             raise DoctorError(f"paper-docx file hash mismatch: {relative_path}")
+
+    try:
+        return Path(dist.locate_file(PurePosixPath("docx"))).resolve(strict=True)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        raise DoctorError("paper-docx owned docx root cannot be resolved") from exc
+
+
+def _verify_docx_import_path(docx: object, docx_root: Path) -> None:
+    module_file = getattr(docx, "__file__", None)
+    if not module_file:
+        raise DoctorError("docx.__file__ is missing")
+
+    try:
+        imported_path = Path(module_file).resolve(strict=True)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        raise DoctorError("docx.__file__ cannot be resolved") from exc
+
+    try:
+        imported_path.relative_to(docx_root)
+    except ValueError:
+        raise DoctorError(
+            "docx.__file__ is outside the paper-docx owned docx root "
+            f"({imported_path} is not within {docx_root})"
+        ) from None
 
 
 def _docx_record_entries(record: str) -> Iterable[Tuple[PurePosixPath, str]]:

--- a/src/paper_docx_doctor/__init__.py
+++ b/src/paper_docx_doctor/__init__.py
@@ -1,0 +1,139 @@
+"""Verify that the frozen ``docx`` import belongs to ``paper-docx``."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import hmac
+import importlib
+import sys
+from importlib.metadata import Distribution, PackageNotFoundError, distribution
+from io import StringIO
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Optional, Tuple
+
+
+class DoctorError(RuntimeError):
+    """The installed ``docx`` package cannot be trusted as ``paper-docx``."""
+
+
+_REMEDY = (
+    "python -m pip uninstall -y python-docx paper-docx && "
+    "python -m pip install --force-reinstall paper-docx"
+)
+
+
+def verify_install() -> str:
+    """Verify distribution ownership, installed bytes, and the fork sentinel.
+
+    Returns the installed ``paper-docx`` version. Raises :class:`DoctorError`
+    without importing ``docx`` until its wheel-owned files have been checked.
+    """
+    paper = _installed_distribution("paper-docx")
+    upstream = _installed_distribution("python-docx")
+    if paper is None:
+        raise DoctorError("paper-docx distribution metadata is missing")
+    if upstream is not None:
+        raise DoctorError(
+            "paper-docx and python-docx are both installed and own the same "
+            "docx package"
+        )
+
+    _verify_docx_record(paper)
+
+    try:
+        docx = importlib.import_module("docx")
+    except Exception as exc:
+        raise DoctorError(f"docx cannot be imported: {exc}") from exc
+
+    sentinel = getattr(docx, "__paper_version__", None)
+    if sentinel is None:
+        raise DoctorError("docx.__paper_version__ is missing")
+    if sentinel != paper.version:
+        raise DoctorError(
+            "docx.__paper_version__ does not match the installed paper-docx "
+            f"version ({sentinel!r} != {paper.version!r})"
+        )
+    return paper.version
+
+
+def main() -> int:
+    """Console entry point for ``paper-docx-doctor``."""
+    try:
+        version = verify_install()
+    except DoctorError as exc:
+        print(f"paper-docx-doctor: FAIL: {exc}", file=sys.stderr)
+        print(f"Remedy: {_REMEDY}", file=sys.stderr)
+        return 1
+    print(f"paper-docx-doctor: OK (paper-docx {version})")
+    return 0
+
+
+def _installed_distribution(name: str) -> Optional[Distribution]:
+    try:
+        return distribution(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _verify_docx_record(dist: Distribution) -> None:
+    record = dist.read_text("RECORD")
+    if record is None:
+        raise DoctorError("paper-docx RECORD is missing")
+
+    entries = tuple(
+        (relative_path, hash_spec)
+        for relative_path, hash_spec in _docx_record_entries(record)
+        if hash_spec
+    )
+    if not entries:
+        raise DoctorError("paper-docx RECORD has no hashed docx package files")
+
+    for relative_path, hash_spec in entries:
+        path = Path(dist.locate_file(relative_path))
+        if not path.is_file():
+            raise DoctorError(f"paper-docx file is missing: {relative_path}")
+        algorithm, expected = _parse_hash(hash_spec, relative_path)
+        actual = _file_digest(path, algorithm)
+        if not hmac.compare_digest(actual, expected):
+            raise DoctorError(f"paper-docx file hash mismatch: {relative_path}")
+
+
+def _docx_record_entries(record: str) -> Iterable[Tuple[PurePosixPath, str]]:
+    for row in csv.reader(StringIO(record)):
+        if len(row) != 3:
+            raise DoctorError("paper-docx RECORD contains a malformed row")
+        raw_path, hash_spec, _size = row
+        path = PurePosixPath(raw_path)
+        if not path.parts or path.parts[0] != "docx":
+            continue
+        if path.is_absolute() or ".." in path.parts:
+            raise DoctorError(f"paper-docx RECORD contains an unsafe path: {raw_path}")
+        yield path, hash_spec
+
+
+def _parse_hash(hash_spec: str, relative_path: PurePosixPath) -> Tuple[str, str]:
+    try:
+        algorithm, expected = hash_spec.split("=", 1)
+        hashlib.new(algorithm)
+    except (TypeError, ValueError):
+        raise DoctorError(
+            f"paper-docx RECORD has an invalid hash for {relative_path}"
+        ) from None
+    if not expected:
+        raise DoctorError(
+            f"paper-docx RECORD has an invalid hash for {relative_path}"
+        )
+    return algorithm, expected.rstrip("=")
+
+
+def _file_digest(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode("ascii")
+
+
+__all__ = ["DoctorError", "main", "verify_install"]

--- a/src/paper_docx_doctor/__main__.py
+++ b/src/paper_docx_doctor/__main__.py
@@ -1,0 +1,5 @@
+"""Run ``paper-docx-doctor`` with ``python -m paper_docx_doctor``."""
+
+from . import main
+
+raise SystemExit(main())

--- a/tests/opc/test_package.py
+++ b/tests/opc/test_package.py
@@ -20,6 +20,7 @@ from ..unitutil.mock import (
     Mock,
     call,
     class_mock,
+    function_mock,
     instance_mock,
     loose_mock,
     method_mock,
@@ -120,14 +121,14 @@ class DescribeOpcPackage:
         assert related_part is related_part_
 
     def it_can_save_to_a_pkg_file(
-        self, pkg_file_: Mock, PackageWriter_: Mock, parts_prop_: Mock, parts_: list[Mock]
+        self, pkg_file_: Mock, atomic_stream_write_: Mock, parts_prop_: Mock, parts_: list[Mock]
     ):
         parts_prop_.return_value = parts_
         pkg = OpcPackage()
         pkg.save(pkg_file_)
         for part in parts_:
             part.before_marshal.assert_called_once_with()
-        PackageWriter_.write.assert_called_once_with(pkg_file_, pkg.rels, parts_)
+        atomic_stream_write_.assert_called_once_with(pkg_file_, pkg.rels, parts_)
 
     def it_provides_access_to_the_core_properties(self, core_props_fixture):
         opc_package, core_properties_ = core_props_fixture
@@ -222,8 +223,8 @@ class DescribeOpcPackage:
         return instance_mock(request, PackURI)
 
     @pytest.fixture
-    def PackageWriter_(self, request: FixtureRequest):
-        return class_mock(request, "docx.opc.package.PackageWriter")
+    def atomic_stream_write_(self, request: FixtureRequest):
+        return function_mock(request, "docx.opc.package._atomic_stream_write")
 
     @pytest.fixture
     def PartFactory_(self, request: FixtureRequest):

--- a/tests/opc/test_rel.py
+++ b/tests/opc/test_rel.py
@@ -95,6 +95,18 @@ class DescribeRelationships:
         part = rels.related_parts[rId]
         assert part is known_target_part
 
+    def it_removes_an_internal_relationship_from_both_indexes(self):
+        rels = Relationships("/word")
+        target = Mock(name="target_part")
+        related_parts = rels.related_parts
+        rels.add_relationship("reltype", target, "rId1")
+
+        del rels["rId1"]
+
+        assert "rId1" not in rels
+        assert "rId1" not in related_parts
+        assert rels.related_parts is related_parts
+
     def it_raises_on_related_part_not_found(self, rels):
         with pytest.raises(KeyError):
             rels.related_parts["rId666"]

--- a/tests/paper/test_audit_commentops.py
+++ b/tests/paper/test_audit_commentops.py
@@ -1,0 +1,104 @@
+"""Regressions for comment ownership and anchor-id preflights."""
+
+from __future__ import annotations
+
+import pytest
+
+import docx
+from docx.commentops import (
+    anchored_text,
+    comment_thread,
+    parent_of,
+    reply,
+    resolve,
+)
+from docx.errors import PaperRefusal, UnsupportedStructureError
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml.ns import qn
+from docx.search import find_one
+
+from .harness.contract import assert_refusal_atomic
+
+
+def _commented_document():
+    document = docx.Document()
+    document.add_paragraph("comment target")
+    comment = find_one(document, "comment target").comment(
+        "Parent", author="Reviewer"
+    )
+    return document, comment
+
+
+class DescribeCommentRelationshipOwnership:
+    @pytest.mark.parametrize("operation", ["resolve", "thread"])
+    def it_refuses_multiple_comments_relationships_atomically(
+        self, operation: str
+    ):
+        document, comment = _commented_document()
+        package = document.part.package
+        assert package is not None
+        duplicate = Part(
+            PackURI("/word/comments-duplicate.xml"),
+            CT.WML_COMMENTS,
+            b"<comments/>",
+            package,
+        )
+        document.part.relate_to(duplicate, RT.COMMENTS)
+
+        error = assert_refusal_atomic(
+            document,
+            lambda candidate: (
+                resolve(candidate, comment)
+                if operation == "resolve"
+                else comment_thread(candidate)
+            ),
+            PaperRefusal,
+        )
+
+        assert isinstance(error, UnsupportedStructureError)
+        assert "multiple comments relationships" in str(error)
+
+
+class DescribeCommentAnchorIds:
+    def it_compares_anchor_marker_ids_numerically(self):
+        document, comment = _commented_document()
+        comment._comment_elm.set(qn("w:id"), "1")  # noqa: SLF001
+        for marker in document.element.body.iter(
+            qn("w:commentRangeStart"),
+            qn("w:commentRangeEnd"),
+            qn("w:commentReference"),
+        ):
+            marker.set(qn("w:id"), "01")
+
+        assert anchored_text(document, comment) == "comment target"
+        child = reply(document, comment, "Reply", author="Second Reviewer")
+        assert parent_of(document, child) == 1
+
+    @pytest.mark.parametrize(
+        "marker_name",
+        ["commentRangeStart", "commentRangeEnd", "commentReference"],
+    )
+    @pytest.mark.parametrize("bad_id", [None, "broken"])
+    def it_refuses_invalid_anchor_marker_ids_atomically(
+        self, marker_name: str, bad_id: str | None
+    ):
+        document, comment = _commented_document()
+        marker = next(document.element.body.iter(qn(f"w:{marker_name}")))
+        if bad_id is None:
+            del marker.attrib[qn("w:id")]
+        else:
+            marker.set(qn("w:id"), bad_id)
+
+        error = assert_refusal_atomic(
+            document,
+            lambda candidate: reply(
+                candidate, comment, "Reply", author="Second Reviewer"
+            ),
+            PaperRefusal,
+        )
+
+        assert isinstance(error, UnsupportedStructureError)
+        assert f"malformed {marker_name} comment marker" in str(error)

--- a/tests/paper/test_audit_commentops.py
+++ b/tests/paper/test_audit_commentops.py
@@ -8,6 +8,7 @@ import docx
 from docx.commentops import (
     anchored_text,
     comment_thread,
+    is_resolved,
     parent_of,
     reply,
     resolve,
@@ -19,6 +20,7 @@ from docx.opc.packuri import PackURI
 from docx.opc.part import Part
 from docx.oxml.ns import qn
 from docx.search import find_one
+from docx.shared import Inches
 
 from .harness.contract import assert_refusal_atomic
 
@@ -60,6 +62,66 @@ class DescribeCommentRelationshipOwnership:
 
         assert isinstance(error, UnsupportedStructureError)
         assert "multiple comments relationships" in str(error)
+
+    def it_refuses_multiple_main_document_relationships_before_mutation(self):
+        document, comment = _commented_document()
+        package = document.part.package
+        assert package is not None
+        package.rels.add_relationship(
+            RT.OFFICE_DOCUMENT,
+            document.part,
+            "rIdDuplicateMain",
+        )
+        before = comment._comment_elm.xml  # noqa: SLF001
+
+        with pytest.raises(UnsupportedStructureError, match="multiple main-document"):
+            comment.add_paragraph("must not be added")
+
+        assert comment._comment_elm.xml == before  # noqa: SLF001
+
+
+class DescribeCommentContentMutation:
+    def it_preserves_parent_resolution_and_child_link_when_appending_text(self):
+        document, parent = _commented_document()
+        child = reply(
+            document,
+            parent,
+            "Reply",
+            author="Second Reviewer",
+        )
+        resolve(document, parent)
+
+        parent.add_paragraph("Additional context")
+
+        assert is_resolved(document, parent)
+        assert parent_of(document, child) == parent.comment_id
+
+    def it_preserves_a_reply_link_when_appending_a_table(self):
+        document, parent = _commented_document()
+        child = reply(
+            document,
+            parent,
+            "Reply",
+            author="Second Reviewer",
+        )
+
+        child.add_table(1, 1, Inches(1))
+
+        assert parent_of(document, child) == parent.comment_id
+
+
+class DescribeCommentInspection:
+    def it_does_not_create_a_comments_part_for_an_uncommented_document(self):
+        document = docx.Document()
+        package = document.part.package
+        assert package is not None
+        relationships_before = tuple(document.part.rels)
+        parts_before = tuple(part.partname for part in package.iter_parts())
+
+        assert comment_thread(document) == ()
+
+        assert tuple(document.part.rels) == relationships_before
+        assert tuple(part.partname for part in package.iter_parts()) == parts_before
 
 
 class DescribeCommentAnchorIds:

--- a/tests/paper/test_audit_compare.py
+++ b/tests/paper/test_audit_compare.py
@@ -1,0 +1,166 @@
+"""Regression coverage for strict compare safety guarantees."""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import docx
+from docx.errors import UnsupportedStructureError
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.package import compare
+
+FROZEN = dt.datetime(2026, 7, 10, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _save_pair(tmp_path: Path, build_original, build_revised):
+    paths = []
+    for name, build in (("original", build_original), ("revised", build_revised)):
+        document = docx.Document()
+        build(document)
+        path = tmp_path / f"{name}.docx"
+        document.save(path)
+        paths.append(path)
+    return paths
+
+
+class DescribeStrictComparePreflight:
+    def it_refuses_style_only_changes_without_touching_inputs(self, tmp_path: Path):
+        def original(document):
+            document.add_paragraph("Same text")
+
+        def revised(document):
+            document.add_paragraph("Same text")
+            document.styles["Normal"].font.name = "Courier New"
+
+        a, b = _save_pair(tmp_path, original, revised)
+        before = (a.read_bytes(), b.read_bytes())
+        with pytest.raises(UnsupportedStructureError, match="package part 'word/styles.xml'"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+        assert (a.read_bytes(), b.read_bytes()) == before
+
+    def it_refuses_text_and_formatting_changes(self, tmp_path: Path):
+        def original(document):
+            document.add_paragraph("Alpha content")
+
+        def revised(document):
+            run = document.add_paragraph().add_run("Alphb content")
+            run.bold = True
+
+        a, b = _save_pair(tmp_path, original, revised)
+        with pytest.raises(UnsupportedStructureError, match="formatting or structural"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+
+    def it_refuses_unmodeled_custom_xml_content(self, tmp_path: Path):
+        def build(value):
+            def _build(document):
+                wrapper = OxmlElement("w:customXml")
+                paragraph = OxmlElement("w:p")
+                run = OxmlElement("w:r")
+                text = OxmlElement("w:t")
+                text.text = value
+                run.append(text)
+                paragraph.append(run)
+                wrapper.append(paragraph)
+                document.element.body.insert(0, wrapper)
+
+            return _build
+
+        a, b = _save_pair(tmp_path, build("ORIGINAL SECRET"), build("REVISED SECRET"))
+        with pytest.raises(UnsupportedStructureError, match="does not match"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+
+    def it_refuses_package_relationship_changes(self, tmp_path: Path):
+        png = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\rIDAT\x08\xd7c\xf8\xcf\xc0\xf0\x1f\x00\x05"
+            b"\x00\x01\xff\x89\x99=\x1d\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        image = tmp_path / "pixel.png"
+        image.write_bytes(png)
+
+        def original(document):
+            document.add_paragraph("Alpha")
+
+        def revised(document):
+            document.add_paragraph("Alpha").add_run().add_picture(str(image))
+
+        a, b = _save_pair(tmp_path, original, revised)
+        with pytest.raises(UnsupportedStructureError, match="package-part addition"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+
+    def it_refuses_malformed_numbering_as_a_typed_error(self, tmp_path: Path):
+        def original(document):
+            document.add_paragraph("Anchor")
+
+        def revised(document):
+            document.add_paragraph("Anchor")
+            paragraph = document.add_paragraph("Malformed list item")
+            num_pr = OxmlElement("w:numPr")
+            num_id = OxmlElement("w:numId")
+            num_id.set(qn("w:val"), "not-an-integer")
+            num_pr.append(num_id)
+            paragraph._p.get_or_add_pPr().append(num_pr)
+
+        a, b = _save_pair(tmp_path, original, revised)
+        before = (a.read_bytes(), b.read_bytes())
+        with pytest.raises(UnsupportedStructureError, match="numbering id"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+        assert (a.read_bytes(), b.read_bytes()) == before
+
+
+class DescribeComparePairingBudget:
+    def it_refuses_an_oversized_word_pairing_before_allocating(self, tmp_path: Path):
+        def build(prefix):
+            def _build(document):
+                for index in range(101):
+                    document.add_paragraph(f"{prefix} paragraph {index:03d}")
+
+            return _build
+
+        a, b = _save_pair(tmp_path, build("Old"), build("New"))
+        with pytest.raises(UnsupportedStructureError, match="pairing budget"):
+            compare(a, b, author="Reviewer", date=FROZEN)
+
+    def it_uses_linear_whole_block_edits_in_block_mode(self, tmp_path: Path):
+        def build(prefix):
+            def _build(document):
+                for index in range(101):
+                    document.add_paragraph(f"{prefix} paragraph {index:03d}")
+
+            return _build
+
+        a, b = _save_pair(tmp_path, build("Old"), build("New"))
+        result = compare(
+            a,
+            b,
+            author="Reviewer",
+            date=FROZEN,
+            granularity="block",
+        )
+        result.document.revisions.accept_all()
+        assert [p.text for p in result.document.paragraphs] == [
+            p.text for p in docx.Document(b).paragraphs
+        ]
+
+
+def it_saves_compare_output_with_deterministic_zip_metadata(tmp_path: Path):
+    a, b = _save_pair(
+        tmp_path,
+        lambda document: document.add_paragraph("Original text"),
+        lambda document: document.add_paragraph("Revised text"),
+    )
+    result = compare(a, b, author="Reviewer", date=FROZEN)
+    stream = io.BytesIO()
+    result.document.save(stream)
+
+    with zipfile.ZipFile(stream) as package:
+        assert {info.date_time for info in package.infolist()} == {
+            (1980, 1, 1, 0, 0, 0)
+        }

--- a/tests/paper/test_audit_compare.py
+++ b/tests/paper/test_audit_compare.py
@@ -164,3 +164,75 @@ def it_saves_compare_output_with_deterministic_zip_metadata(tmp_path: Path):
         assert {info.date_time for info in package.infolist()} == {
             (1980, 1, 1, 0, 0, 0)
         }
+
+
+class DescribeCompareAlignmentTrim:
+    """The sequence budget measures the CHANGE, not the document length."""
+
+    def it_self_compares_a_long_document_with_zero_revisions(self, tmp_path: Path):
+        def build(document):
+            for index in range(1_050):
+                document.add_paragraph(f"Clause {index}: unique wording {index}.")
+
+        a, _b = _save_pair(tmp_path, build, build)
+        result = compare(a, a, author="Reviewer")
+        assert len(result.document.revisions) == 0
+
+    def and_it_redlines_one_edit_in_a_long_document(self, tmp_path: Path):
+        def original(document):
+            for index in range(1_050):
+                document.add_paragraph(f"Clause {index} body text.")
+
+        def revised(document):
+            for index in range(1_050):
+                text = f"Clause {index} body text."
+                if index == 525:
+                    text = "Clause 525 amended body text."
+                document.add_paragraph(text)
+
+        a, b = _save_pair(tmp_path, original, revised)
+        result = compare(a, b, author="Reviewer")
+        assert len(result.document.revisions) > 0
+        result.document.revisions.accept_all()
+        assert (
+            result.document.paragraphs[525].text == "Clause 525 amended body text."
+        )
+
+
+class DescribeProofErrTransparency:
+    """w:proofErr is the proofing tool's cache, not content."""
+
+    def _flagged_paragraph(self, document, text: str) -> None:
+        paragraph = document.add_paragraph(text)
+        run = paragraph.runs[0]._r
+        start = OxmlElement("w:proofErr")
+        start.set(qn("w:type"), "spellStart")
+        end = OxmlElement("w:proofErr")
+        end.set(qn("w:type"), "spellEnd")
+        run.addprevious(start)
+        run.addnext(end)
+
+    def it_redlines_a_deletion_beside_proofing_markers(self, tmp_path: Path):
+        def original(document):
+            self._flagged_paragraph(document, "Klause with a flagged typo.")
+            document.add_paragraph("A second paragraph to be deleted.")
+
+        def revised(document):
+            self._flagged_paragraph(document, "Klause with a flagged typo.")
+
+        a, b = _save_pair(tmp_path, original, revised)
+        result = compare(a, b, author="Reviewer")
+        result.document.revisions.accept_all()
+        texts = [p.text for p in result.document.paragraphs]
+        assert "A second paragraph to be deleted." not in texts
+
+    def and_a_proofing_only_difference_is_no_difference(self, tmp_path: Path):
+        def original(document):
+            self._flagged_paragraph(document, "Klause with a flagged typo.")
+
+        def revised(document):
+            document.add_paragraph("Klause with a flagged typo.")
+
+        a, b = _save_pair(tmp_path, original, revised)
+        result = compare(a, b, author="Reviewer")
+        assert len(result.document.revisions) == 0

--- a/tests/paper/test_audit_compare_raw_packages.py
+++ b/tests/paper/test_audit_compare_raw_packages.py
@@ -71,7 +71,9 @@ def _corrupt_document_relationship_id(path: Path, defect: str) -> None:
             else:
                 first_id = relationships[0].get("Id")
                 assert first_id is not None
-                relationships[1].set("Id", first_id)
+                relationships[1].set(
+                    "Id", f" {first_id} " if defect == "whitespace_duplicate" else first_id
+                )
             data = etree.tostring(root, encoding="UTF-8", xml_declaration=True)
         rewritten.append((info, data))
 
@@ -139,6 +141,11 @@ class DescribeRawPackagePreflight:
             pytest.param("missing", "missing Id", id="missing"),
             pytest.param("empty", "empty Id", id="empty"),
             pytest.param("duplicate", "duplicate relationship Id", id="duplicate"),
+            pytest.param(
+                "whitespace_duplicate",
+                "duplicate relationship Id",
+                id="whitespace-normalized-duplicate",
+            ),
         ],
     )
     def it_refuses_invalid_relationship_ids_before_loading_and_preserves_inputs(

--- a/tests/paper/test_audit_compare_raw_packages.py
+++ b/tests/paper/test_audit_compare_raw_packages.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
+from lxml import etree
 
 import docx
 import docx._compare as compare_impl
@@ -50,6 +51,34 @@ def _add_orphan_custom_xml(path: Path) -> None:
         for info, data in rewritten:
             destination.writestr(info, data)
         destination.writestr("customXml/orphan.xml", b"<orphan/>")
+    replacement.replace(path)
+
+
+def _corrupt_document_relationship_id(path: Path, defect: str) -> None:
+    with ZipFile(path, "r") as source:
+        entries = [(info, source.read(info.filename)) for info in source.infolist()]
+
+    rewritten = []
+    for info, data in entries:
+        if info.filename == "word/_rels/document.xml.rels":
+            root = etree.fromstring(data)
+            relationships = list(root)
+            assert len(relationships) >= 2
+            if defect == "missing":
+                del relationships[0].attrib["Id"]
+            elif defect == "empty":
+                relationships[0].set("Id", "")
+            else:
+                first_id = relationships[0].get("Id")
+                assert first_id is not None
+                relationships[1].set("Id", first_id)
+            data = etree.tostring(root, encoding="UTF-8", xml_declaration=True)
+        rewritten.append((info, data))
+
+    replacement = path.with_suffix(".replacement.docx")
+    with ZipFile(replacement, "w", compression=ZIP_DEFLATED) as destination:
+        for info, data in rewritten:
+            destination.writestr(info, data)
     replacement.replace(path)
 
 
@@ -100,6 +129,37 @@ class DescribeRawPackagePreflight:
 
         monkeypatch.setattr(docx, "Document", unexpected_document_load)
         with pytest.raises(UnsupportedStructureError, match="unreachable package part"):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+        assert (original.read_bytes(), revised.read_bytes()) == before
+
+    @pytest.mark.parametrize(
+        ("defect", "message"),
+        [
+            pytest.param("missing", "missing Id", id="missing"),
+            pytest.param("empty", "empty Id", id="empty"),
+            pytest.param("duplicate", "duplicate relationship Id", id="duplicate"),
+        ],
+    )
+    def it_refuses_invalid_relationship_ids_before_loading_and_preserves_inputs(
+        self,
+        defect: str,
+        message: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        def build(document):
+            document.add_paragraph("Same visible document")
+
+        original, revised = _save_pair(tmp_path, build, build)
+        _corrupt_document_relationship_id(revised, defect)
+        before = (original.read_bytes(), revised.read_bytes())
+
+        def unexpected_document_load(*args, **kwargs):
+            raise AssertionError("raw package preflight must run before Document()")
+
+        monkeypatch.setattr(docx, "Document", unexpected_document_load)
+        with pytest.raises(UnsupportedStructureError, match=message):
             compare(original, revised, author="Reviewer", date=FROZEN)
 
         assert (original.read_bytes(), revised.read_bytes()) == before

--- a/tests/paper/test_audit_compare_raw_packages.py
+++ b/tests/paper/test_audit_compare_raw_packages.py
@@ -125,11 +125,13 @@ class DescribeSequenceMatcherBudget:
     def it_refuses_table_matching_before_quadratic_work(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        def build(middle):
+        def build(prefix):
             def _build(document):
                 table = document.add_table(rows=3, cols=1)
                 for index, row in enumerate(table.rows):
-                    row.cells[0].text = middle if index == 1 else f"Stable {index}"
+                    # every row differs so no common prefix/suffix trims away:
+                    # the trimmed middle must still hit the budget pre-matcher
+                    row.cells[0].text = f"{prefix} row {index}"
 
             return _build
 

--- a/tests/paper/test_audit_compare_raw_packages.py
+++ b/tests/paper/test_audit_compare_raw_packages.py
@@ -1,0 +1,179 @@
+"""Regressions for compare's raw-package and matcher preflights."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+import docx
+import docx._compare as compare_impl
+from docx.errors import UnsupportedStructureError
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+from docx.package import compare
+
+FROZEN = dt.datetime(2026, 7, 10, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _save_pair(tmp_path: Path, build_original, build_revised):
+    paths = []
+    for name, build in (("original", build_original), ("revised", build_revised)):
+        document = docx.Document()
+        build(document)
+        path = tmp_path / f"{name}.docx"
+        document.save(path)
+        paths.append(path)
+    return paths
+
+
+def _add_orphan_custom_xml(path: Path) -> None:
+    with ZipFile(path, "r") as source:
+        entries = [(info, source.read(info.filename)) for info in source.infolist()]
+
+    marker = b"</Types>"
+    override = (
+        b'<Override PartName="/customXml/orphan.xml" '
+        b'ContentType="application/xml"/>'
+    )
+    rewritten = []
+    for info, data in entries:
+        if info.filename == "[Content_Types].xml":
+            assert marker in data
+            data = data.replace(marker, override + marker, 1)
+        rewritten.append((info, data))
+
+    replacement = path.with_suffix(".replacement.docx")
+    with ZipFile(replacement, "w", compression=ZIP_DEFLATED) as destination:
+        for info, data in rewritten:
+            destination.writestr(info, data)
+        destination.writestr("customXml/orphan.xml", b"<orphan/>")
+    replacement.replace(path)
+
+
+def _guard_large_sequence_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_matcher = compare_impl.SequenceMatcher
+
+    def guarded_matcher(isjunk=None, a="", b="", autojunk=True):
+        if not isinstance(a, str) and len(a) * len(b) > 4:
+            raise AssertionError("SequenceMatcher ran before its resource preflight")
+        return real_matcher(isjunk, a, b, autojunk=autojunk)
+
+    monkeypatch.setattr(compare_impl, "SequenceMatcher", guarded_matcher)
+    monkeypatch.setattr(compare_impl, "_MAX_SEQUENCE_CELLS", 4)
+
+
+class DescribeRawPackagePreflight:
+    def it_treats_marker_only_move_markup_as_a_pending_revision(self, tmp_path: Path):
+        def build(document):
+            paragraph = document.add_paragraph("Move markers only")._p
+            for tag, name in (
+                ("w:moveFromRangeStart", "Move1"),
+                ("w:moveFromRangeEnd", None),
+                ("w:moveToRangeStart", "Move1"),
+                ("w:moveToRangeEnd", None),
+            ):
+                marker = OxmlElement(tag)
+                marker.set(qn("w:id"), "17")
+                if name is not None:
+                    marker.set(qn("w:name"), name)
+                paragraph.append(marker)
+
+        original, revised = _save_pair(tmp_path, build, build)
+        with pytest.raises(UnsupportedStructureError, match="pending tracked revisions"):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+    def it_refuses_an_orphan_before_loading_and_preserves_both_inputs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def build(document):
+            document.add_paragraph("Same visible document")
+
+        original, revised = _save_pair(tmp_path, build, build)
+        _add_orphan_custom_xml(revised)
+        before = (original.read_bytes(), revised.read_bytes())
+
+        def unexpected_document_load(*args, **kwargs):
+            raise AssertionError("raw package preflight must run before Document()")
+
+        monkeypatch.setattr(docx, "Document", unexpected_document_load)
+        with pytest.raises(UnsupportedStructureError, match="unreachable package part"):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+        assert (original.read_bytes(), revised.read_bytes()) == before
+
+
+class DescribeSequenceMatcherBudget:
+    def it_refuses_story_matching_before_quadratic_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def build(prefix):
+            def _build(document):
+                for index in range(3):
+                    document.add_paragraph(f"{prefix} paragraph {index}")
+
+            return _build
+
+        original, revised = _save_pair(tmp_path, build("Old"), build("New"))
+        _guard_large_sequence_match(monkeypatch)
+
+        with pytest.raises(UnsupportedStructureError, match="sequence-matching budget"):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+    def it_refuses_table_matching_before_quadratic_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def build(middle):
+            def _build(document):
+                table = document.add_table(rows=3, cols=1)
+                for index, row in enumerate(table.rows):
+                    row.cells[0].text = middle if index == 1 else f"Stable {index}"
+
+            return _build
+
+        original, revised = _save_pair(tmp_path, build("Old"), build("New"))
+        _guard_large_sequence_match(monkeypatch)
+
+        with pytest.raises(
+            UnsupportedStructureError, match="table.*sequence-matching budget"
+        ):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+    def it_refuses_changed_text_before_quadratic_similarity_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def build(text):
+            def _build(document):
+                document.add_paragraph(text)
+
+            return _build
+
+        original, revised = _save_pair(tmp_path, build("A" * 8), build("B" * 8))
+        real_matcher = compare_impl.SequenceMatcher
+
+        def guarded_matcher(isjunk=None, a="", b="", autojunk=True):
+            if isinstance(a, str) and len(a) * len(b) > 4:
+                raise AssertionError(
+                    "text SequenceMatcher ran before its resource preflight"
+                )
+            return real_matcher(isjunk, a, b, autojunk=autojunk)
+
+        monkeypatch.setattr(compare_impl, "SequenceMatcher", guarded_matcher)
+        monkeypatch.setattr(compare_impl, "_MAX_TEXT_SEQUENCE_CELLS", 4)
+
+        with pytest.raises(
+            UnsupportedStructureError, match="changed-region text.*budget"
+        ):
+            compare(original, revised, author="Reviewer", date=FROZEN)
+
+    def it_refuses_token_matching_before_quadratic_work(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(compare_impl, "_MAX_TEXT_SEQUENCE_CELLS", 4)
+
+        with pytest.raises(
+            UnsupportedStructureError, match="paragraph token diff.*budget"
+        ):
+            compare_impl._token_regions("one two three", "four five six")

--- a/tests/paper/test_audit_composition.py
+++ b/tests/paper/test_audit_composition.py
@@ -1,0 +1,385 @@
+"""Adversarial ownership and composition audit cases."""
+
+from __future__ import annotations
+
+import pytest
+
+import docx
+from docx.blocks import insert_section_after
+from docx.bookmarks import (
+    _NAME_RE,
+    _iter_field_instructions,
+    create_bookmark,
+    delete_bookmark,
+    list_bookmarks,
+)
+from docx.commentops import anchored_text, resolve
+from docx.composition import append_document, insert_blocks_from
+from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import BoundaryViolationError, UnsupportedStructureError
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+from docx.search import find_one
+
+_SECT_PR = qn("w:sectPr")
+_SDT = qn("w:sdt")
+
+
+def _package_state(document) -> tuple:
+    parts = []
+    for part in document.part.package.iter_parts():
+        relationships = tuple(
+            sorted(
+                (
+                    rel.rId,
+                    rel.reltype,
+                    str(rel.target_ref),
+                    rel.is_external,
+                )
+                for rel in part.rels.values()
+            )
+        )
+        parts.append((str(part.partname), part.blob, relationships))
+    return tuple(sorted(parts, key=lambda item: item[0]))
+
+
+def _clear_body(document) -> None:
+    body = document.element.body
+    for child in list(body):
+        if child.tag != _SECT_PR:
+            body.remove(child)
+
+
+def _insert_before_sect(document, element) -> None:
+    body = document.element.body
+    sect_pr = body.find(_SECT_PR)
+    if sect_pr is None:
+        body.append(element)
+    else:
+        sect_pr.addprevious(element)
+
+
+def _protect(document) -> None:
+    protection = OxmlElement("w:documentProtection")
+    protection.set(qn("w:edit"), "readOnly")
+    protection.set(qn("w:enforcement"), "1")
+    document.settings.element.append(protection)
+
+
+def _add_bookmark(paragraph, name: str, bookmark_id: str, text: str) -> None:
+    start = OxmlElement("w:bookmarkStart")
+    start.set(qn("w:id"), bookmark_id)
+    start.set(qn("w:name"), name)
+    run = OxmlElement("w:r")
+    run.add_t(text)
+    end = OxmlElement("w:bookmarkEnd")
+    end.set(qn("w:id"), bookmark_id)
+    paragraph._p.extend((start, run, end))
+
+
+def _append_complex_reference(document, fragments: list[str]) -> None:
+    paragraph = document.add_paragraph()
+
+    def field_char(kind: str):
+        run = OxmlElement("w:r")
+        char = OxmlElement("w:fldChar")
+        char.set(qn("w:fldCharType"), kind)
+        run.append(char)
+        paragraph._p.append(run)
+
+    field_char("begin")
+    for fragment in fragments:
+        run = OxmlElement("w:r")
+        instruction = OxmlElement("w:instrText")
+        instruction.set(qn("xml:space"), "preserve")
+        instruction.text = fragment
+        run.append(instruction)
+        paragraph._p.append(run)
+    field_char("separate")
+    result = OxmlElement("w:r")
+    result.add_t("(reference)")
+    paragraph._p.append(result)
+    field_char("end")
+
+
+def _top_level_control(
+    *, text: str, data_bound: bool = False, control_id: int = 7
+):
+    control = OxmlElement("w:sdt")
+    properties = OxmlElement("w:sdtPr")
+    id_element = OxmlElement("w:id")
+    id_element.set(qn("w:val"), str(control_id))
+    properties.append(id_element)
+    if data_bound:
+        binding = OxmlElement("w:dataBinding")
+        binding.set(qn("w:xpath"), "/root/value")
+        binding.set(qn("w:storeItemID"), "{AUDIT-STORE}")
+        properties.append(binding)
+    content = OxmlElement("w:sdtContent")
+    paragraph = OxmlElement("w:p")
+    run = OxmlElement("w:r")
+    run.add_t(text)
+    paragraph.append(run)
+    content.append(paragraph)
+    control.extend((properties, content))
+    return control
+
+
+def _unsupported_top_level(kind: str):
+    if kind == "customXml":
+        wrapper = OxmlElement("w:customXml")
+        paragraph = OxmlElement("w:p")
+        run = OxmlElement("w:r")
+        run.add_t("custom XML payload")
+        paragraph.append(run)
+        wrapper.append(paragraph)
+        return wrapper
+    chunk = OxmlElement("w:altChunk")
+    chunk.set(qn("r:id"), "rIdMissingChunk")
+    return chunk
+
+
+def it_refuses_foreign_span_anchors_before_destination_protection() -> None:
+    source = docx.Document()
+    source.add_paragraph("Shared anchor text")
+    destination = docx.Document()
+    destination.add_paragraph("Shared anchor text")
+    _protect(destination)
+    foreign_span = find_one(source, "Shared anchor")
+    source_before = _package_state(source)
+    destination_before = _package_state(destination)
+
+    with pytest.raises(BoundaryViolationError, match="different document"):
+        insert_section_after(
+            destination, foreign_span, heading="Unsafe", paragraphs=[]
+        )
+    with pytest.raises(BoundaryViolationError, match="different document"):
+        create_bookmark(destination, foreign_span, "UnsafeBookmark")
+
+    assert _package_state(source) == source_before
+    assert _package_state(destination) == destination_before
+
+
+def it_refuses_a_foreign_comment_proxy_even_with_a_colliding_id() -> None:
+    source = docx.Document()
+    source_run = source.add_paragraph("Source anchor").runs[0]
+    foreign_comment = source.add_comment(
+        source_run, text="source comment", author="Source"
+    )
+    destination = docx.Document()
+    destination_run = destination.add_paragraph("Destination anchor").runs[0]
+    destination.add_comment(
+        destination_run, text="destination comment", author="Destination"
+    )
+    source_before = _package_state(source)
+    destination_before = _package_state(destination)
+
+    with pytest.raises(BoundaryViolationError, match="different document"):
+        anchored_text(destination, foreign_comment)
+    with pytest.raises(BoundaryViolationError, match="different document"):
+        resolve(destination, foreign_comment)
+
+    assert _package_state(source) == source_before
+    assert _package_state(destination) == destination_before
+
+
+@pytest.mark.parametrize("mode", ["append", "range"])
+def it_composes_top_level_content_controls_as_whole_blocks(mode: str) -> None:
+    source = docx.Document()
+    _clear_body(source)
+    source_control = _top_level_control(text="Controlled source block")
+    _insert_before_sect(source, source_control)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+
+    if mode == "append":
+        report = append_document(destination, source, section="continuous")
+    else:
+        report = insert_blocks_from(
+            destination,
+            source,
+            "Controlled source block",
+            anchor="Destination anchor",
+        )
+
+    copied = [child for child in destination.element.body if child.tag == _SDT]
+    assert report.inserted_blocks == 1
+    assert len(copied) == 1
+    assert copied[0] is not source_control
+    assert "".join(node.text or "" for node in copied[0].iter(qn("w:t"))) == (
+        "Controlled source block"
+    )
+
+
+def it_refuses_a_data_bound_control_before_composition_mutates() -> None:
+    source = docx.Document()
+    _clear_body(source)
+    _insert_before_sect(
+        source, _top_level_control(text="Bound value", data_bound=True)
+    )
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="data-bound"):
+        append_document(destination, source, section="continuous")
+
+    assert _package_state(destination) == before
+
+
+def it_keeps_all_content_control_ids_unique_when_appending_after_a_control() -> None:
+    source = docx.Document()
+    _clear_body(source)
+    _insert_before_sect(
+        source, _top_level_control(text="First imported control", control_id=2)
+    )
+    _insert_before_sect(
+        source, _top_level_control(text="Second imported control", control_id=1)
+    )
+    destination = docx.Document()
+    _clear_body(destination)
+    _insert_before_sect(
+        destination, _top_level_control(text="Existing control", control_id=1)
+    )
+
+    report = append_document(destination, source, section="continuous")
+
+    control_ids = []
+    for control in (child for child in destination.element.body if child.tag == _SDT):
+        properties = control.find(qn("w:sdtPr"))
+        id_element = properties.find(qn("w:id"))
+        control_ids.append(int(id_element.get(qn("w:val"))))
+    assert report.inserted_blocks == 2
+    assert control_ids == [1, 2, 3]
+
+
+@pytest.mark.parametrize("kind", ["customXml", "altChunk"])
+def it_refuses_unsupported_top_level_content_instead_of_omitting_it(
+    kind: str,
+) -> None:
+    source = docx.Document()
+    _clear_body(source)
+    source.add_paragraph("Safe-looking source block")
+    _insert_before_sect(source, _unsupported_top_level(kind))
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match=kind):
+        append_document(destination, source, section="continuous")
+
+    assert _package_state(destination) == before
+
+
+def it_refuses_unsupported_content_between_range_endpoints_atomically() -> None:
+    source = docx.Document()
+    _clear_body(source)
+    first = source.add_paragraph("First selected block")
+    second = source.add_paragraph("Second selected block")
+    first._p.addnext(_unsupported_top_level("customXml"))
+    assert second._p.getprevious().tag == qn("w:customXml")
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="customXml"):
+        insert_blocks_from(
+            destination,
+            source,
+            "First selected block",
+            count=2,
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+
+
+def it_authors_a_legal_fresh_bookmark_and_rewrites_a_split_lowercase_ref() -> None:
+    name = "A" * 40
+    source = docx.Document()
+    target = source.add_paragraph()
+    _add_bookmark(target, name, "1", "Source bookmark target")
+    _append_complex_reference(
+        source,
+        [" r", f"ef {name[:20]}", f"{name[20:]} \\h "],
+    )
+    destination = docx.Document()
+    anchor = destination.add_paragraph("Destination anchor")
+    _add_bookmark(anchor, name, "8", "")
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        "Source bookmark target",
+        count=2,
+        anchor="Destination anchor",
+    )
+
+    fresh = report.bookmarks_renamed[name]
+    assert len(fresh) <= 40
+    assert _NAME_RE.fullmatch(fresh)
+    instructions = [
+        instruction
+        for instruction, _nodes in _iter_field_instructions(destination.element)
+    ]
+    assert any(f"ref {fresh}".casefold() in value.casefold() for value in instructions)
+
+
+def it_sees_a_case_insensitive_split_quoted_reference_before_bookmark_delete() -> None:
+    document = docx.Document()
+    target = document.add_paragraph()
+    _add_bookmark(target, "KeyPhrase", "4", "Referenced target")
+    _append_complex_reference(
+        document, [" pa", 'geref "key', 'phrase" \\h ']
+    )
+    before = _package_state(document)
+
+    with pytest.raises(UnsupportedStructureError, match="referenced by"):
+        delete_bookmark(document, "KeyPhrase")
+
+    assert _package_state(document) == before
+
+
+def it_uses_full_run_content_for_bookmark_and_comment_anchor_text() -> None:
+    document = docx.Document()
+    paragraph = document.add_paragraph()
+    run = paragraph.add_run("A")
+    run.add_tab()
+    run.add_text("B")
+    run.add_break()
+    run.add_text("C")
+    run._r.append(OxmlElement("w:noBreakHyphen"))
+    run.add_text("D")
+    start = OxmlElement("w:bookmarkStart")
+    start.set(qn("w:id"), "12")
+    start.set(qn("w:name"), "RichAnchor")
+    end = OxmlElement("w:bookmarkEnd")
+    end.set(qn("w:id"), "12")
+    run._r.addprevious(start)
+    run._r.addnext(end)
+    comment = document.add_comment(run, text="note", author="Reviewer")
+
+    bookmarks = {item.name: item for item in list_bookmarks(document)}
+    assert bookmarks["RichAnchor"].text == "A\tB\nC-D"
+    assert anchored_text(document, comment) == "A\tB\nC-D"
+
+
+def it_refuses_malformed_ids_before_style_import() -> None:
+    source = docx.Document()
+    style = source.styles.add_style("AuditImportedStyle", WD_STYLE_TYPE.PARAGRAPH)
+    paragraph = source.add_paragraph(style=style)
+    _add_bookmark(paragraph, "Malformed", "not-a-number", "Malformed target")
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="non-numeric"):
+        insert_blocks_from(
+            destination,
+            source,
+            "Malformed target",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+    assert "AuditImportedStyle" not in {style.name for style in destination.styles}

--- a/tests/paper/test_audit_composition_safety.py
+++ b/tests/paper/test_audit_composition_safety.py
@@ -1,0 +1,208 @@
+"""Atomicity regressions for cross-document composition."""
+
+from __future__ import annotations
+
+import pytest
+
+import docx
+from docx.composition import insert_blocks_from
+from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import UnsupportedStructureError
+from docx.numbering import apply_numbering, ensure_decimal_definition
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+
+
+def _package_state(document) -> tuple:
+    parts = []
+    for part in document.part.package.iter_parts():
+        relationships = tuple(
+            sorted(
+                (
+                    rel.rId,
+                    rel.reltype,
+                    str(rel.target_ref),
+                    rel.is_external,
+                )
+                for rel in part.rels.values()
+            )
+        )
+        parts.append((str(part.partname), part.blob, relationships))
+    return tuple(sorted(parts, key=lambda item: item[0]))
+
+
+def _append_chart_reference(document, paragraph, r_id: str = "rId99") -> None:
+    chart_part = Part(
+        PackURI("/word/charts/chart1.xml"),
+        CT.DML_CHART,
+        b'<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>',
+        document.part.package,
+    )
+    document.part.load_rel(RT.CHART, chart_part, r_id)
+    drawing = OxmlElement("w:drawing")
+    chart = OxmlElement("c:chart")
+    chart.set(qn("r:id"), r_id)
+    drawing.append(chart)
+    paragraph.add_run()._r.append(drawing)
+
+
+def _append_style_reference(paragraph, tag: str, style_id: str) -> None:
+    properties = (
+        paragraph._p.get_or_add_pPr()
+        if tag == "w:pStyle"
+        else paragraph.runs[0]._r.get_or_add_rPr()
+    )
+    reference = OxmlElement(tag)
+    reference.set(qn("w:val"), style_id)
+    properties.append(reference)
+
+
+def it_refuses_a_chart_relationship_before_copying_stale_rids() -> None:
+    source = docx.Document()
+    paragraph = source.add_paragraph("Source chart")
+    _append_chart_reference(source, paragraph)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="chart relationship"):
+        insert_blocks_from(
+            destination,
+            source,
+            "Source chart",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+    assert "rId99" not in destination.element.xml
+
+
+def it_refuses_a_source_num_whose_abstract_definition_is_missing() -> None:
+    source = docx.Document()
+    num_id = ensure_decimal_definition(source)
+    paragraph = source.add_paragraph("Source numbered paragraph")
+    apply_numbering(paragraph, num_id=num_id)
+    source_numbering = source.part.numbering_part.element
+    source_num = next(
+        num
+        for num in source_numbering.findall(qn("w:num"))
+        if num.get(qn("w:numId")) == str(num_id)
+    )
+    abstract_id = source_num.find(qn("w:abstractNumId")).get(qn("w:val"))
+    source_abstract = next(
+        abstract
+        for abstract in source_numbering.findall(qn("w:abstractNum"))
+        if abstract.get(qn("w:abstractNumId")) == abstract_id
+    )
+    source_numbering.remove(source_abstract)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="missing abstract"):
+        insert_blocks_from(
+            destination,
+            source,
+            "Source numbered paragraph",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+
+
+def it_refuses_malformed_destination_numbering_before_importing_a_style() -> None:
+    source = docx.Document()
+    style = source.styles.add_style("AuditCompositionStyle", WD_STYLE_TYPE.PARAGRAPH)
+    num_id = ensure_decimal_definition(source)
+    paragraph = source.add_paragraph("Styled numbered source", style=style)
+    apply_numbering(paragraph, num_id=num_id)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    ensure_decimal_definition(destination)
+    destination_num = destination.part.numbering_part.element.find(qn("w:num"))
+    destination_num.set(qn("w:numId"), "not-a-number")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="destination numbering.*non-numeric"):
+        insert_blocks_from(
+            destination,
+            source,
+            "Styled numbered source",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+    assert "AuditCompositionStyle" not in {style.name for style in destination.styles}
+
+
+@pytest.mark.parametrize(
+    ("reference_tag", "destination_style_type"),
+    [
+        pytest.param("w:pStyle", WD_STYLE_TYPE.PARAGRAPH, id="paragraph-style"),
+        pytest.param("w:rStyle", WD_STYLE_TYPE.CHARACTER, id="character-style"),
+    ],
+)
+def it_refuses_undefined_source_style_references_before_destination_binding(
+    reference_tag: str,
+    destination_style_type: WD_STYLE_TYPE,
+) -> None:
+    source = docx.Document()
+    paragraph = source.add_paragraph("Source with an undefined style")
+    _append_style_reference(paragraph, reference_tag, "SharedStyleId")
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    destination_style = destination.styles.add_style(
+        "Unrelated destination style", destination_style_type
+    )
+    destination_style._element.set(qn("w:styleId"), "SharedStyleId")
+    before = _package_state(destination)
+
+    with pytest.raises(
+        UnsupportedStructureError, match="undefined source style 'SharedStyleId'"
+    ):
+        insert_blocks_from(
+            destination,
+            source,
+            "Source with an undefined style",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+    assert all(
+        paragraph.text != "Source with an undefined style"
+        for paragraph in destination.paragraphs
+    )
+
+
+@pytest.mark.parametrize("chain_tag", ["w:basedOn", "w:link", "w:next"])
+def it_refuses_undefined_source_style_chain_dependencies_atomically(chain_tag: str) -> None:
+    source = docx.Document()
+    source_style = source.styles.add_style("Source chain leaf", WD_STYLE_TYPE.PARAGRAPH)
+    dependency = OxmlElement(chain_tag)
+    dependency.set(qn("w:val"), "MissingDependency")
+    source_style._element.append(dependency)
+    source.add_paragraph("Source with a broken style chain", style=source_style)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    destination_style = destination.styles.add_style(
+        "Unrelated chain destination", WD_STYLE_TYPE.PARAGRAPH
+    )
+    destination_style._element.set(qn("w:styleId"), "MissingDependency")
+    before = _package_state(destination)
+
+    with pytest.raises(
+        UnsupportedStructureError, match="undefined source style 'MissingDependency'"
+    ):
+        insert_blocks_from(
+            destination,
+            source,
+            "Source with a broken style chain",
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+    assert "Source chain leaf" not in {style.name for style in destination.styles}

--- a/tests/paper/test_audit_editing.py
+++ b/tests/paper/test_audit_editing.py
@@ -1,0 +1,531 @@
+"""Audit regressions for inspection and guarded editing edge cases."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from lxml import etree
+
+import docx
+from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import (
+    BoundaryViolationError,
+    DocumentProtectedError,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import OxmlElement, parse_xml
+
+W = nsdecls("w")
+W14 = nsdecls("w", "w14")
+
+
+def _append_body_block(document, element) -> None:
+    sect_pr = document.element.body.find(qn("w:sectPr"))
+    if sect_pr is None:
+        document.element.body.append(element)
+    else:
+        sect_pr.addprevious(element)
+
+
+class DescribeRunTextProjection:
+    def it_keeps_field_instructions_out_of_visible_story_text(self):
+        from docx.story import iter_blocks
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W}><w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+                '<w:r><w:instrText> REF InternalTarget </w:instrText></w:r>'
+                '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
+                '<w:r><w:t>Visible result</w:t></w:r>'
+                '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+            ),
+        )
+        assert [block.text for block in iter_blocks(document)] == ["Visible result"]
+
+    def it_models_no_break_hyphens_for_inspection_search_and_safe_narrowing(self):
+        from docx.search import find_one
+        from docx.story import iter_blocks
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f"<w:p {W}><w:r><w:t>non</w:t><w:noBreakHyphen/>"
+                "<w:t>breaking</w:t></w:r></w:p>"
+            ),
+        )
+        assert [block.text for block in iter_blocks(document)] == ["non-breaking"]
+        find_one(document, "non-breaking").replace("non-binding")
+        assert [block.text for block in iter_blocks(document)] == ["non-binding"]
+        assert document.element.body.xpath("//w:noBreakHyphen")
+
+    def it_does_not_match_through_unmodeled_visible_run_content(self):
+        from docx.search import find_one, find_text
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f"<w:p {W}><w:r><w:t>alpha</w:t>"
+                '<w:sym w:font="Wingdings" w:char="F0FC"/>'
+                "<w:t>omega</w:t></w:r></w:p>"
+            ),
+        )
+        assert find_text(document, "alphaomega") == []
+        assert find_one(document, "alpha").text == "alpha"
+        assert find_one(document, "omega").text == "omega"
+
+
+class DescribeAlternateContentSelection:
+    def it_selects_the_first_supported_choice_then_falls_back(self):
+        from docx.story import iter_blocks
+
+        document = docx.Document()
+        namespace_attrs = (
+            f'{W} xmlns:mc="http://schemas.openxmlformats.org/'
+            'markup-compatibility/2006" '
+            'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" '
+            'xmlns:x="urn:paper:unsupported"'
+        )
+        _append_body_block(
+            document,
+            parse_xml(
+                f"<w:p {namespace_attrs}><mc:AlternateContent>"
+                '<mc:Choice Requires="x"><w:r><w:t>wrong</w:t></w:r></mc:Choice>'
+                '<mc:Choice Requires="w14"><w:r><w:t>supported</w:t></w:r>'
+                "</mc:Choice><mc:Fallback><w:r><w:t>fallback one</w:t></w:r>"
+                "</mc:Fallback></mc:AlternateContent></w:p>"
+            ),
+        )
+        _append_body_block(
+            document,
+            parse_xml(
+                f"<w:p {namespace_attrs}><mc:AlternateContent>"
+                '<mc:Choice Requires="x"><w:r><w:t>wrong again</w:t></w:r>'
+                "</mc:Choice><mc:Fallback><w:r><w:t>fallback two</w:t></w:r>"
+                "</mc:Fallback></mc:AlternateContent></w:p>"
+            ),
+        )
+        assert [block.text for block in iter_blocks(document)] == [
+            "supported",
+            "fallback two",
+        ]
+
+
+class DescribeCellReplacementGuards:
+    @pytest.mark.parametrize("kind", ["tab", "break"])
+    def it_refuses_non_text_run_content_without_leaving_it_behind(self, kind: str):
+        from docx.tableops import update_cell
+
+        document = docx.Document()
+        table = document.add_table(rows=1, cols=1)
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        run = paragraph.add_run("left")
+        run.add_tab() if kind == "tab" else run.add_break()
+        run.add_text("right")
+        before = table._tbl.xml
+        with pytest.raises(UnsupportedStructureError, match="tab, break"):
+            update_cell(table, 0, 0, "replacement")
+        assert table._tbl.xml == before
+
+
+def _change_span_context(run, kind: str) -> None:
+    if kind == "field":
+        begin = OxmlElement("w:r")
+        begin_char = OxmlElement("w:fldChar")
+        begin_char.set(qn("w:fldCharType"), "begin")
+        begin.append(begin_char)
+        end = OxmlElement("w:r")
+        end_char = OxmlElement("w:fldChar")
+        end_char.set(qn("w:fldCharType"), "end")
+        end.append(end_char)
+        run.addprevious(begin)
+        run.addnext(end)
+        return
+
+    parent = run.getparent()
+    position = parent.index(run)
+    parent.remove(run)
+    if kind == "hyperlink":
+        wrapper = OxmlElement("w:hyperlink")
+        wrapper.set(qn("w:anchor"), "ChangedTarget")
+        wrapper.append(run)
+    elif kind == "sdt":
+        wrapper = OxmlElement("w:sdt")
+        wrapper.append(OxmlElement("w:sdtPr"))
+        content = OxmlElement("w:sdtContent")
+        content.append(run)
+        wrapper.append(content)
+    else:
+        wrapper = OxmlElement("w:ins")
+        wrapper.set(qn("w:id"), "91")
+        wrapper.set(qn("w:author"), "Reviewer")
+        wrapper.append(run)
+    parent.insert(position, wrapper)
+
+
+class DescribeSpanContextFreshness:
+    @pytest.mark.parametrize("kind", ["field", "hyperlink", "sdt", "revision"])
+    def it_rejects_same_text_after_its_edit_context_changes(self, kind: str):
+        from docx.search import find_one
+
+        document = docx.Document()
+        run = document.add_paragraph("context-sensitive target").runs[0]._r
+        span = find_one(document, "context-sensitive target")
+        _change_span_context(run, kind)
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            span.replace("changed")
+        assert "context-sensitive target" in document.element.body.xml
+
+    def it_refuses_when_a_text_atom_is_inserted_inside_the_captured_interval(self):
+        from docx.search import find_one
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        run = paragraph.add_run()
+        run.add_text("adjacent ")
+        run.add_text("atoms")
+        span = find_one(document, "adjacent atoms")
+        inserted = OxmlElement("w:t")
+        inserted.text = "unexpected "
+        run._r.insert(1, inserted)
+        before = etree.tostring(document.element)
+
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            span.replace("replacement")
+
+        assert etree.tostring(document.element) == before
+
+    def it_allows_text_atoms_inserted_outside_the_captured_interval(self):
+        from docx.search import find_one
+        from docx.story import iter_blocks
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("adjacent ")
+        paragraph.add_run("atoms")
+        span = find_one(document, "adjacent atoms")
+        prefix = OxmlElement("w:r")
+        prefix.add_t("before ")
+        paragraph._p.insert(0, prefix)
+        suffix = OxmlElement("w:r")
+        suffix.add_t(" after")
+        paragraph._p.append(suffix)
+
+        span.replace("replacement")
+
+        assert [block.text for block in iter_blocks(document)] == [
+            "before replacement after"
+        ]
+
+
+class DescribeControlSetterHardening:
+    @staticmethod
+    def _text_control(document, tag: str):
+        from docx.controls import get_control
+
+        paragraph = document.add_paragraph()
+        paragraph._p.append(
+            parse_xml(
+                f'<w:sdt {W}><w:sdtPr><w:tag w:val="{tag}"/><w:text/>'
+                "</w:sdtPr><w:sdtContent><w:r><w:t>original</w:t></w:r>"
+                "</w:sdtContent></w:sdt>"
+            )
+        )
+        return get_control(document, tag=tag)
+
+    @staticmethod
+    def _protect(document) -> None:
+        protection = OxmlElement("w:documentProtection")
+        protection.set(qn("w:edit"), "readOnly")
+        protection.set(qn("w:enforcement"), "1")
+        document.settings._element.append(protection)
+
+    def it_refuses_a_detached_control_before_protection_or_mutation(self):
+        document = docx.Document()
+        control = self._text_control(document, "detached")
+        control._sdt.getparent().remove(control._sdt)
+        self._protect(document)
+        before_document = etree.tostring(document.element)
+        before_control = etree.tostring(control._sdt)
+
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            control.set_value("replacement")
+
+        assert etree.tostring(document.element) == before_document
+        assert etree.tostring(control._sdt) == before_control
+
+    def it_refuses_a_control_moved_to_another_document_atomically(self):
+        source = docx.Document()
+        control = self._text_control(source, "foreign")
+        destination = docx.Document()
+        destination.add_paragraph()._p.append(control._sdt)
+        self._protect(source)
+        before_source = etree.tostring(source.element)
+        before_destination = etree.tostring(destination.element)
+
+        with pytest.raises(BoundaryViolationError, match="different document"):
+            control.set_value("replacement")
+
+        assert etree.tostring(source.element) == before_source
+        assert etree.tostring(destination.element) == before_destination
+
+    def it_honors_declared_checkbox_glyphs(self):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W14}><w:sdt><w:sdtPr><w:tag w:val="choice"/>'
+                '<w14:checkbox><w14:checked w14:val="0"/>'
+                '<w14:checkedState w14:val="2611" w14:font="Arial Unicode MS"/>'
+                '<w14:uncheckedState w14:val="2610" w14:font="Arial Unicode MS"/>'
+                "</w14:checkbox></w:sdtPr><w:sdtContent><w:r><w:t>☐</w:t>"
+                "</w:r></w:sdtContent></w:sdt></w:p>"
+            ),
+        )
+        set_control_value(document, True, tag="choice")
+        assert get_control(document, tag="choice").value is True
+        assert "☑" in document.element.body.xml
+        (fonts,) = document.element.body.xpath("//w:sdtContent//w:rFonts")
+        assert fonts.get(qn("w:ascii")) == "Arial Unicode MS"
+        assert fonts.get(qn("w:hAnsi")) == "Arial Unicode MS"
+
+    def it_validates_checkbox_content_before_changing_its_state(self):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W14}><w:sdt><w:sdtPr><w:tag w:val="complex"/>'
+                '<w14:checkbox><w14:checked w14:val="0"/></w14:checkbox>'
+                "</w:sdtPr><w:sdtContent><w:tbl><w:tr><w:tc><w:p/>"
+                "</w:tc></w:tr></w:tbl></w:sdtContent></w:sdt></w:p>"
+            ),
+        )
+        control = get_control(document, tag="complex")
+        before = etree.tostring(control._sdt)
+        with pytest.raises(UnsupportedStructureError, match="table"):
+            set_control_value(document, True, tag="complex")
+        assert etree.tostring(control._sdt) == before
+
+    def it_formats_aware_dates_from_utc_using_the_declared_format(self):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W}><w:sdt><w:sdtPr><w:tag w:val="signed"/>'
+                '<w:date w:fullDate="2020-01-01T00:00:00Z">'
+                '<w:dateFormat w:val="MMMM d, yyyy"/><w:lid w:val="en-US"/>'
+                "</w:date></w:sdtPr><w:sdtContent><w:r><w:t>old</w:t></w:r>"
+                "</w:sdtContent></w:sdt></w:p>"
+            ),
+        )
+        value = dt.datetime(
+            2026, 7, 10, 1, 30, tzinfo=dt.timezone(dt.timedelta(hours=2))
+        )
+        set_control_value(document, value, tag="signed")
+        assert get_control(document, tag="signed").value == "July 9, 2026"
+        (date_pr,) = document.element.body.xpath("//w:sdtPr/w:date")
+        assert date_pr.get(qn("w:fullDate")) == "2026-07-09T23:30:00Z"
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            '<w:dateFormat w:val="Q yyyy"/>',
+            '<w:calendar w:val="hijri"/>',
+        ],
+    )
+    def it_refuses_unsupported_date_declarations_before_mutation(
+        self, declaration: str
+    ):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W}><w:sdt><w:sdtPr><w:tag w:val="unsupported"/>'
+                '<w:date w:fullDate="2020-01-01T00:00:00Z">'
+                f"{declaration}</w:date></w:sdtPr>"
+                "<w:sdtContent><w:r><w:t>old</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        control = get_control(document, tag="unsupported")
+        before = etree.tostring(control._sdt)
+        with pytest.raises(UnsupportedStructureError, match="unsupported"):
+            set_control_value(document, dt.date(2026, 7, 10), tag="unsupported")
+        assert etree.tostring(control._sdt) == before
+
+
+class DescribeNumberingAudit:
+    def it_reports_numbering_inherited_through_based_on_and_honors_num_id_zero(self):
+        from docx.numbering import ensure_decimal_definition, list_numbering
+
+        document = docx.Document()
+        num_id = ensure_decimal_definition(document)
+        base = document.styles.add_style("AuditListBase", WD_STYLE_TYPE.PARAGRAPH)
+        base.element.append(
+            parse_xml(
+                f'<w:pPr {W}><w:numPr><w:ilvl w:val="1"/>'
+                f'<w:numId w:val="{num_id}"/></w:numPr></w:pPr>'
+            )
+        )
+        leaf = document.styles.add_style("AuditListLeaf", WD_STYLE_TYPE.PARAGRAPH)
+        leaf.base_style = base
+        document.add_paragraph("inherited item", style=leaf)
+        suppressed = document.add_paragraph("not numbered", style=leaf)
+        suppressed_num_pr = suppressed._p.get_or_add_pPr().get_or_add_numPr()
+        suppressed_num_pr.get_or_add_numId().val = 0
+
+        report = list_numbering(document)
+        assert [(item.text, item.num_id, item.level) for item in report.numbered_paragraphs] == [
+            ("inherited item", num_id, 1)
+        ]
+
+    def it_reuses_only_structurally_canonical_definitions(self):
+        from docx.numbering import ensure_bullet_definition
+        from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+        document = docx.Document()
+        first_num_id = ensure_bullet_definition(document)
+        numbering = document.part.part_related_by(RT.NUMBERING)._element
+        first_num = next(
+            num
+            for num in numbering.findall(qn("w:num"))
+            if int(num.get(qn("w:numId"))) == first_num_id
+        )
+        abstract_id = first_num.find(qn("w:abstractNumId")).get(qn("w:val"))
+        abstract = next(
+            item
+            for item in numbering.findall(qn("w:abstractNum"))
+            if item.get(qn("w:abstractNumId")) == abstract_id
+        )
+        abstract.find(f".//{qn('w:lvlText')}").set(qn("w:val"), "not canonical")
+
+        replacement_num_id = ensure_bullet_definition(document)
+        assert replacement_num_id != first_num_id
+        assert ensure_bullet_definition(document) == replacement_num_id
+
+
+class DescribeHiddenTextScrubbing:
+    def it_removes_style_inherited_vanish_but_honors_direct_false(self):
+        document = docx.Document()
+        style = document.styles.add_style("HiddenAudit", WD_STYLE_TYPE.PARAGRAPH)
+        style.font.hidden = True
+        paragraph = document.add_paragraph(style=style)
+        paragraph.add_run("remove me")
+        visible = paragraph.add_run("keep me")
+        visible.font.hidden = False
+
+        report = document.scrub(
+            comments=False,
+            metadata=False,
+            track_changes_setting=False,
+            hidden_text=True,
+        )
+        assert report.hidden_runs_removed == 1
+        assert "remove me" not in paragraph._p.xml
+        assert "keep me" in paragraph._p.xml
+
+
+class DescribeMetadataScrubbing:
+    def it_clears_core_timestamps_and_revision(self):
+        document = docx.Document()
+        core = document.core_properties
+        core.created = dt.datetime(2020, 1, 2, 3, 4)
+        core.modified = dt.datetime(2021, 2, 3, 4, 5)
+        core.last_printed = dt.datetime(2022, 3, 4, 5, 6)
+        core.revision = 42
+
+        report = document.scrub(
+            comments=False,
+            track_changes_setting=False,
+        )
+
+        assert core.created is None
+        assert core.modified is None
+        assert core.last_printed is None
+        assert core.revision == 0
+        for name in ("created", "modified", "last_printed", "revision"):
+            assert f"core:{name}" in report.metadata_fields_cleared
+
+    def it_refuses_malformed_app_metadata_before_removing_comments(self):
+        from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+        document = docx.Document()
+        paragraph = document.add_paragraph("commented")
+        document.add_comment(paragraph.runs, text="keep", author="Audit")
+        app_part = document.part.package.part_related_by(RT.EXTENDED_PROPERTIES)
+        app_part._blob = b"<Properties>"  # noqa: SLF001 - malformed fixture
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="app.xml is malformed"):
+            document.scrub()
+
+        assert document.element.xml == before
+        assert len(document.comments) == 1
+
+
+class DescribeFormatOnlyProtection:
+    def it_reports_and_enforces_formatting_only_protection(self):
+        from docx.protection import acknowledge_protection, protection_status
+        from docx.search import find_one
+
+        document = docx.Document()
+        document.add_paragraph("protected formatting")
+        protection = OxmlElement("w:documentProtection")
+        protection.set(qn("w:formatting"), "1")
+        protection.set(qn("w:enforcement"), "1")
+        document.settings._element.append(protection)
+
+        status = protection_status(document)
+        assert status.edit is None
+        assert status.formatting
+        assert status.enforced
+        assert status.blocks_paper_edits
+        assert status.to_dict()["formatting"] is True
+        with pytest.raises(DocumentProtectedError, match="formatting-only"):
+            find_one(document, "protected formatting").replace("changed")
+
+        acknowledge_protection(document)
+        report = document.scrub(
+            comments=False, metadata=False, track_changes_setting=False
+        )
+        assert report.document_protection == {
+            "edit": None,
+            "enforced": True,
+            "note": "reported, never removed (docx.protection)",
+            "formatting": True,
+        }
+
+
+class DescribeFormattingDisclosure:
+    def it_declares_uncomputed_run_and_paragraph_categories_unresolved(self):
+        from docx.formatting import format_of
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        spacing = OxmlElement("w:spacing")
+        spacing.set(qn("w:after"), "120")
+        paragraph._p.get_or_add_pPr().append(spacing)
+        run = paragraph.add_run("formatted")
+        shading = OxmlElement("w:shd")
+        shading.set(qn("w:fill"), "FFFF00")
+        run._r.get_or_add_rPr().append(shading)
+
+        unresolved = format_of(run).unresolved
+        assert "run_shading" in unresolved
+        assert "paragraph_spacing" in unresolved
+        assert "theme_color_resolution" in unresolved

--- a/tests/paper/test_audit_editing.py
+++ b/tests/paper/test_audit_editing.py
@@ -339,6 +339,45 @@ class DescribeControlSetterHardening:
         (date_pr,) = document.element.body.xpath("//w:sdtPr/w:date")
         assert date_pr.get(qn("w:fullDate")) == "2026-07-09T23:30:00Z"
 
+    def it_refuses_a_date_without_a_declared_format_before_mutation(self):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W}><w:sdt><w:sdtPr><w:tag w:val="unformatted"/>'
+                '<w:date w:fullDate="2020-01-01T00:00:00Z"/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>old</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        control = get_control(document, tag="unformatted")
+        before = etree.tostring(control._sdt)
+        with pytest.raises(UnsupportedStructureError, match="w:dateFormat"):
+            set_control_value(document, dt.date(2026, 7, 10), tag="unformatted")
+        assert etree.tostring(control._sdt) == before
+
+    def it_refuses_named_date_tokens_without_a_declared_locale_before_mutation(self):
+        from docx.controls import get_control, set_control_value
+
+        document = docx.Document()
+        _append_body_block(
+            document,
+            parse_xml(
+                f'<w:p {W}><w:sdt><w:sdtPr><w:tag w:val="unlocalized"/>'
+                '<w:date w:fullDate="2020-01-01T00:00:00Z">'
+                '<w:dateFormat w:val="MMMM d, yyyy"/></w:date></w:sdtPr>'
+                '<w:sdtContent><w:r><w:rPr><w:lang w:val="fr-FR"/></w:rPr>'
+                "<w:t>ancien</w:t></w:r></w:sdtContent></w:sdt></w:p>"
+            ),
+        )
+        control = get_control(document, tag="unlocalized")
+        before = etree.tostring(control._sdt)
+        with pytest.raises(UnsupportedStructureError, match="w:lid"):
+            set_control_value(document, dt.date(2026, 7, 10), tag="unlocalized")
+        assert etree.tostring(control._sdt) == before
+
     @pytest.mark.parametrize(
         "declaration",
         [

--- a/tests/paper/test_audit_late_failure_atomicity.py
+++ b/tests/paper/test_audit_late_failure_atomicity.py
@@ -1,0 +1,542 @@
+"""Rollback regressions for failures raised after compound mutation begins."""
+
+from __future__ import annotations
+
+import struct
+from io import BytesIO
+
+import pytest
+from lxml import etree
+
+import docx
+import docx.revision as revision_module
+from docx import commentops, composition, scrubbing
+from docx._transaction import rollback_on_error
+from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import UnsupportedStructureError
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml import parse_xml
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.text.run import CT_R
+from docx.search import find_one
+from docx.text.run import Run
+
+from .harness.contract import assert_refusal_atomic
+
+
+def _late_refusal(*args, **kwargs):  # noqa: ANN002, ANN003
+    raise UnsupportedStructureError("forced late refusal")
+
+
+def _tracked_insert(revision_id: int, text: str):
+    return parse_xml(
+        f'<w:ins {nsdecls("w")} w:id="{revision_id}" w:author="Audit">'
+        f"<w:r><w:t>{text}</w:t></w:r></w:ins>"
+    )
+
+
+def _two_revision_document():
+    document = docx.Document()
+    paragraph = document.add_paragraph()._p
+    paragraph.append(_tracked_insert(1, "first"))
+    paragraph.append(_tracked_insert(2, "second"))
+    return document
+
+
+def _bmp(red: int, green: int, blue: int) -> bytes:
+    return (
+        struct.pack("<2sIHHI", b"BM", 58, 0, 0, 54)
+        + struct.pack("<IiiHHIIiiII", 40, 1, 1, 1, 24, 0, 4, 2835, 2835, 0, 0)
+        + bytes((blue, green, red, 0))
+    )
+
+
+class DescribeTransactionKernel:
+    def it_does_not_reparent_unchanged_namespace_scopes(self):
+        document = docx.Document()
+        node = etree.fromstring(
+            b'<x:child xmlns:x="urn:audit" xmlns:y="urn:audit" y:value="1" ref="y:Thing"/>'
+        )
+        document.element.body.append(node)
+        before = etree.tostring(node)
+
+        refusal = pytest.raises(UnsupportedStructureError)
+        with refusal, rollback_on_error(document):  # noqa: PT012
+            raise UnsupportedStructureError("forced late refusal")
+
+        assert etree.tostring(node) == before
+        assert node.get("ref") == "y:Thing"
+        assert node.nsmap["y"] == "urn:audit"
+
+    def it_restores_element_lazy_state(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("state")._p
+        paragraph.__dict__["audit_cached"] = "before"
+
+        refusal = pytest.raises(UnsupportedStructureError)
+        with refusal, rollback_on_error(document):  # noqa: PT012
+            paragraph.__dict__["audit_cached"] = "after"
+            paragraph.__dict__["audit_new"] = True
+            raise UnsupportedStructureError("forced late refusal")
+
+        assert paragraph.__dict__["audit_cached"] == "before"
+        assert "audit_new" not in paragraph.__dict__
+
+    def it_restores_cache_only_and_image_list_only_parts(self):
+        document = docx.Document()
+        package = document.part.package
+        assert package is not None
+        cached_part = Part(
+            PackURI("/word/audit-cache.bin"),
+            "application/octet-stream",
+            b"cached-before",
+            package,
+        )
+        document.part.rels._target_parts_by_rId["rIdAudit"] = cached_part
+        image_part = package.get_or_add_image_part(BytesIO(_bmp(1, 2, 3)))
+        image_parts = package.image_parts._image_parts
+        image_items = tuple(image_parts)
+        image_blob = image_part.blob
+
+        refusal = pytest.raises(UnsupportedStructureError)
+        with refusal, rollback_on_error(document):  # noqa: PT012
+            cached_part._blob = b"cached-after"
+            image_part._blob = b"image-after"
+            raise UnsupportedStructureError("forced late refusal")
+
+        assert cached_part.blob == b"cached-before"
+        assert image_part.blob == image_blob
+        assert package.image_parts._image_parts is image_parts
+        assert len(image_parts) == len(image_items)
+        assert all(current is original for current, original in zip(image_parts, image_items))
+
+    def it_restores_mutated_relationship_records(self):
+        document = docx.Document()
+        relationship = next(rel for rel in document.part.rels.values() if not rel.is_external)
+        original_target = relationship.target_part
+        replacement = Part(
+            PackURI("/word/audit-target.bin"),
+            "application/octet-stream",
+            b"replacement",
+            document.part.package,
+        )
+
+        refusal = pytest.raises(UnsupportedStructureError)
+        with refusal, rollback_on_error(document):  # noqa: PT012
+            relationship._target = replacement
+            raise UnsupportedStructureError("forced late refusal")
+
+        assert relationship.target_part is original_target
+        assert document.part.rels.related_parts[relationship.rId] is original_target
+        assert replacement.package is None
+
+
+class DescribeCompositionRollback:
+    def it_removes_a_style_imported_before_a_late_refusal(self, monkeypatch):
+        source = docx.Document()
+        style = source.styles.add_style("LateFailureStyle", WD_STYLE_TYPE.PARAGRAPH)
+        source.add_paragraph("source", style=style)
+        destination = docx.Document()
+        anchor = destination.add_paragraph("anchor")
+        anchor_element = anchor._p
+        monkeypatch.setattr(composition, "_remap_numbering", _late_refusal)
+
+        assert_refusal_atomic(
+            destination,
+            lambda document: composition.insert_blocks_from(
+                document, source, "source", anchor="anchor"
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "LateFailureStyle" not in {item.name for item in destination.styles}
+        assert destination.paragraphs[0]._p is anchor_element
+        assert anchor.text == "anchor"
+
+    def it_removes_new_media_and_image_bookkeeping(self, monkeypatch):
+        source = docx.Document()
+        paragraph = source.add_paragraph("source image")
+        paragraph.add_run().add_picture(BytesIO(_bmp(255, 0, 0)))
+        destination = docx.Document()
+        destination.add_paragraph("anchor")
+        package = destination.part.package
+        assert package is not None
+        assert "image_parts" not in package.__dict__
+        related_parts = destination.part.rels.related_parts
+        relationships_before = dict(related_parts)
+        monkeypatch.setattr(composition, "_recreate_hyperlinks", _late_refusal)
+
+        assert_refusal_atomic(
+            destination,
+            lambda document: composition.insert_blocks_from(
+                document, source, "source image", anchor="anchor"
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "image_parts" not in package.__dict__
+        assert destination.part.rels.related_parts is related_parts
+        assert destination.part.rels.related_parts == relationships_before
+        assert not any("/media/" in str(part.partname) for part in package.iter_parts())
+
+    def it_preserves_an_existing_image_parts_collection(self, monkeypatch):
+        source = docx.Document()
+        source_paragraph = source.add_paragraph("source image")
+        source_paragraph.add_run().add_picture(BytesIO(_bmp(255, 0, 0)))
+        destination = docx.Document()
+        destination.add_paragraph().add_run().add_picture(BytesIO(_bmp(0, 0, 255)))
+        destination.add_paragraph("anchor")
+        package = destination.part.package
+        assert package is not None
+        image_parts = package.image_parts._image_parts
+        image_items = tuple(image_parts)
+        monkeypatch.setattr(composition, "_recreate_hyperlinks", _late_refusal)
+
+        assert_refusal_atomic(
+            destination,
+            lambda document: composition.insert_blocks_from(
+                document, source, "source image", anchor="anchor"
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert package.image_parts._image_parts is image_parts
+        assert len(image_parts) == len(image_items)
+        assert all(current is original for current, original in zip(image_parts, image_items))
+
+    def it_rolls_back_append_after_compose_returns(self, monkeypatch):
+        source = docx.Document()
+        source.add_paragraph("appended content")
+        destination = docx.Document()
+        anchor = destination.add_paragraph("anchor")
+        anchor_element = anchor._p
+        original = composition._compose
+
+        def compose_then_refuse(*args, **kwargs):  # noqa: ANN002, ANN003
+            original(*args, **kwargs)
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(composition, "_compose", compose_then_refuse)
+
+        assert_refusal_atomic(
+            destination,
+            lambda document: composition.append_document(document, source),
+            UnsupportedStructureError,
+        )
+
+        assert destination.paragraphs[0]._p is anchor_element
+        assert anchor.text == "anchor"
+
+
+class DescribeScrubAndFinalizeRollback:
+    def it_restores_comment_parts_and_existing_comment_proxies(self, monkeypatch):
+        document = docx.Document()
+        document.add_paragraph("target")
+        comment = find_one(document, "target").comment("review note", author="Reviewer")
+        comment_element = comment._comment_elm
+        monkeypatch.setattr(scrubbing, "_scrub_comment_anchors", _late_refusal)
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.scrub(comments=True, metadata=False),
+            UnsupportedStructureError,
+        )
+
+        restored = document.comments.get(comment.comment_id)
+        assert restored is not None
+        assert restored._comment_elm is comment_element
+        assert comment.text == "review note"
+
+    def it_restores_xml_blobs_and_package_relationships(self, monkeypatch):
+        document = docx.Document()
+        document.core_properties.author = "Audit Author"
+        package = document.part.package
+        assert package is not None
+        app_part = package.part_related_by(RT.EXTENDED_PROPERTIES)
+        app_root = etree.fromstring(app_part.blob)
+        company = next(app_root.iter("{*}Company"))
+        company.text = "Audit Company"
+        app_part._blob = etree.tostring(  # noqa: SLF001 - generic Part storage
+            app_root, xml_declaration=True, encoding="UTF-8", standalone=True
+        )
+        app_blob = app_part.blob
+        monkeypatch.setattr(scrubbing, "_scrub_track_changes_setting", _late_refusal)
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.scrub(comments=False),
+            UnsupportedStructureError,
+        )
+
+        assert document.core_properties.author == "Audit Author"
+        assert app_part.blob == app_blob
+        assert package.part_related_by(RT.THUMBNAIL).partname
+
+    def it_restores_revisions_when_finalize_postcheck_refuses(self, monkeypatch):
+        document = _two_revision_document()
+        revisions = document.revisions
+        original_elements = tuple(item._element for item in revisions)
+        monkeypatch.setattr(scrubbing, "_remaining_markup", _late_refusal)
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.finalize(),
+            UnsupportedStructureError,
+        )
+
+        current = document.revisions
+        assert len(current) == 2
+        assert all(
+            current_item._element is original
+            for current_item, original in zip(current, original_elements)
+        )
+
+    def it_restores_every_scrub_target_after_a_final_stage_refusal(self, monkeypatch):
+        document = docx.Document()
+        document.add_paragraph("commented")
+        find_one(document, "commented").comment("note", author="Reviewer")
+        hidden_paragraph = document.add_paragraph()._p
+        hidden_paragraph.set(qn("w:rsidR"), "00112233")
+        hidden_paragraph.append(
+            parse_xml(f"<w:r {nsdecls('w')}><w:rPr><w:vanish/></w:rPr><w:t>hidden</w:t></w:r>")
+        )
+        document.core_properties.author = "Audit Author"
+        settings = document.settings._settings
+        settings.insert(0, parse_xml(f"<w:trackRevisions {nsdecls('w')}/>"))
+        settings.append(parse_xml(f'<w:rsids {nsdecls("w")}><w:rsid w:val="00112233"/></w:rsids>'))
+        original = scrubbing._scrub_hidden_text
+
+        def scrub_hidden_then_refuse(hidden_runs, report):
+            original(hidden_runs, report)
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(scrubbing, "_scrub_hidden_text", scrub_hidden_then_refuse)
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.scrub(rsids=True, hidden_text=True),
+            UnsupportedStructureError,
+        )
+
+        assert "hidden" in document.element.xml
+        assert hidden_paragraph.get(qn("w:rsidR")) == "00112233"
+        assert settings.find(qn("w:trackRevisions")) is not None
+        assert settings.find(qn("w:rsids")) is not None
+
+
+class DescribeRevisionRollback:
+    @pytest.mark.parametrize("operation", ["accept_all", "reject_all"])
+    def it_restores_an_earlier_revision_when_a_batch_fails(self, monkeypatch, operation: str):
+        document = _two_revision_document()
+        revisions = document.revisions
+        original_elements = tuple(item._element for item in revisions)
+        original = revision_module._resolve_one
+        calls = 0
+
+        def resolve_then_refuse(node, *, accept, document):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise UnsupportedStructureError("forced late refusal")
+            return original(node, accept=accept, document=document)
+
+        monkeypatch.setattr(revision_module, "_resolve_one", resolve_then_refuse)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: getattr(revisions, operation)(),
+            UnsupportedStructureError,
+        )
+
+        current = document.revisions
+        assert len(current) == 2
+        assert all(
+            current_item._element is original_element
+            for current_item, original_element in zip(current, original_elements)
+        )
+
+    def it_restores_a_single_revision_after_its_mutation(self, monkeypatch):
+        document = _two_revision_document()
+        revision = document.revisions[0]
+        revision_element = revision._element
+        original = revision_module._resolve_one
+
+        def resolve_then_refuse(node, *, accept, document):
+            original(node, accept=accept, document=document)
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(revision_module, "_resolve_one", resolve_then_refuse)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: revision.accept(),
+            UnsupportedStructureError,
+        )
+
+        assert document.revisions[0]._element is revision_element
+        assert revision_element.getparent() is not None
+
+    def it_restores_raw_xml_tags_changed_before_a_refusal(self, monkeypatch):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        deletion = parse_xml(
+            f'<w:del {nsdecls("w")} w:id="1" w:author="Audit">'
+            "<w:r><w:delText>deleted</w:delText></w:r></w:del>"
+        )
+        paragraph.append(deletion)
+        deleted_text = next(deletion.iter(qn("w:delText")))
+        revision = document.revisions[0]
+        original = revision_module._resolve_one
+
+        def resolve_then_refuse(node, *, accept, document):
+            original(node, accept=accept, document=document)
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(revision_module, "_resolve_one", resolve_then_refuse)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: revision.reject(),
+            UnsupportedStructureError,
+        )
+
+        assert deleted_text.tag == qn("w:delText")
+        assert deleted_text.getparent() is not None
+
+
+class DescribeCommentAuthoringRollback:
+    def it_refuses_comment_ranges_from_another_document(self):
+        document = docx.Document()
+        document.add_paragraph("destination")
+        foreign = docx.Document()
+        foreign_run = foreign.add_paragraph("foreign").runs[0]
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.add_comment(foreign_run, "note", author="Reviewer"),
+            UnsupportedStructureError,
+        )
+
+        assert foreign.paragraphs[0].text == "foreign"
+        assert not tuple(foreign.element.iter(qn("w:commentRangeStart")))
+
+    def it_refuses_a_direct_range_across_documents(self):
+        document = docx.Document()
+        run = document.add_paragraph("first").runs[0]
+        foreign = docx.Document()
+        foreign_run = foreign.add_paragraph("last").runs[0]
+        foreign_xml = foreign.element.xml
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: run.mark_comment_range(foreign_run, 7),
+            UnsupportedStructureError,
+        )
+
+        assert foreign.element.xml == foreign_xml
+
+    def it_refuses_a_comment_range_that_ends_before_it_starts(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first_run = paragraph.add_run("first")
+        last_run = paragraph.add_run("last")
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.add_comment(
+                [last_run, first_run], "note", author="Reviewer"
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert paragraph.text == "firstlast"
+        assert not any(
+            relationship.reltype == RT.COMMENTS for relationship in document.part.rels.values()
+        )
+
+    def it_restores_a_span_and_its_split_runs_after_a_late_refusal(self, monkeypatch):
+        document = docx.Document()
+        document.add_paragraph("prefix target suffix")
+        span = find_one(document, "target")
+        offsets = (span._start_offset, span._end_offset)
+        monkeypatch.setattr(CT_R, "insert_comment_range_end_and_reference_below", _late_refusal)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.comment("note", author="Reviewer"),
+            UnsupportedStructureError,
+        )
+
+        assert (span._start_offset, span._end_offset) == offsets
+        assert span.text == "target"
+        span._validate_fresh()
+
+    def it_removes_a_new_comment_when_range_authoring_refuses(self, monkeypatch):
+        document = docx.Document()
+        paragraph = document.add_paragraph("comment target")
+        run = paragraph.runs[0]
+
+        def mark_then_refuse(candidate: Run, last_run: Run, comment_id: int) -> None:
+            candidate._r.insert_comment_range_start_above(comment_id)
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(Run, "mark_comment_range", mark_then_refuse)
+
+        assert_refusal_atomic(
+            document,
+            lambda candidate: candidate.add_comment(run, "note", author="Reviewer"),
+            UnsupportedStructureError,
+        )
+
+        assert paragraph.runs[0]._r is run._r
+        assert not tuple(document.element.iter(qn("w:commentRangeStart")))
+        assert not any(
+            relationship.reltype == RT.COMMENTS for relationship in document.part.rels.values()
+        )
+
+    def it_removes_a_range_start_when_range_authoring_refuses(self, monkeypatch):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first_run = paragraph.add_run("first")
+        last_run = paragraph.add_run("last")
+        monkeypatch.setattr(CT_R, "insert_comment_range_end_and_reference_below", _late_refusal)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: first_run.mark_comment_range(last_run, 7),
+            UnsupportedStructureError,
+        )
+
+        assert first_run._r.getparent() is paragraph._p
+        assert last_run._r.getparent() is paragraph._p
+        assert not tuple(document.element.iter(qn("w:commentRangeStart")))
+
+
+class DescribeCommentThreadRollback:
+    @pytest.mark.parametrize("operation", ["reply", "resolve"])
+    def it_restores_all_thread_parts_after_late_refusal(self, monkeypatch, operation: str):
+        document = docx.Document()
+        document.add_paragraph("target")
+        comment = find_one(document, "target").comment("parent", author="Reviewer")
+        comment_element = comment._comment_elm
+        monkeypatch.setattr(commentops, "_entry_for", _late_refusal)
+
+        def mutate(candidate):
+            if operation == "reply":
+                commentops.reply(candidate, comment, "reply", author="Second Reviewer")
+            else:
+                commentops.resolve(candidate, comment)
+
+        assert_refusal_atomic(
+            document,
+            mutate,
+            UnsupportedStructureError,
+        )
+
+        restored = document.comments.get(comment.comment_id)
+        assert restored is not None
+        assert restored._comment_elm is comment_element
+        assert len(document.comments) == 1
+        assert comment.text == "parent"

--- a/tests/paper/test_audit_package.py
+++ b/tests/paper/test_audit_package.py
@@ -168,6 +168,34 @@ class DescribeZipResourceBounds:
             compression=zipfile.ZIP_DEFLATED,
         )
         monkeypatch.setattr(_zipguard, "MAX_COMPRESSION_RATIO", 2)
+        monkeypatch.setattr(_zipguard, "RATIO_ENFORCEMENT_FLOOR_BYTES", 1_024)
+        with pytest.raises(PackageLimitError, match="compression ratio"):
+            _guarded_read(path)
+
+    def and_it_exempts_members_at_or_below_the_ratio_floor(self, tmp_path: Path):
+        """Repetitive WordprocessingML legitimately exceeds 100:1; below the
+        floor the absolute limits alone bound it, so save->open round-trips."""
+        path = tmp_path / "repetitive.docx"
+        repetitive = b"<w:p><w:r><w:t>same line</w:t></w:r></w:p>" * 8_192
+        _write_archive(
+            path,
+            (("word/document.xml", repetitive),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
+        with zipfile.ZipFile(path) as archive:
+            info = archive.getinfo("word/document.xml")
+            assert info.file_size > info.compress_size * 100  # genuinely >100:1
+        assert _guarded_read(path)["word/document.xml"] == repetitive
+
+    def and_it_still_refuses_extreme_amplification_above_the_floor(
+        self, tmp_path: Path
+    ):
+        path = tmp_path / "amplified.docx"
+        _write_archive(
+            path,
+            (("word/media/blob.bin", b"\0" * (20 * 1024 * 1024)),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
         with pytest.raises(PackageLimitError, match="compression ratio"):
             _guarded_read(path)
 
@@ -198,11 +226,8 @@ class DescribeZipResourceBounds:
 class DescribeGuardedPackageApis:
     def it_refuses_open_diff_and_patch_without_touching_the_destination(self, tmp_path: Path):
         unsafe = tmp_path / "unsafe.docx"
-        _write_archive(
-            unsafe,
-            (("word/document.xml", b"A" * 1_000_000),),
-            compression=zipfile.ZIP_DEFLATED,
-        )
+        _write_archive(unsafe, (("word/document.xml", b"<document/>"),))
+        _set_encrypted_flags(unsafe)
         source = fixture_path(MINIMAL)
         document = docx.Document(str(source))
         out = tmp_path / "out.docx"
@@ -224,17 +249,14 @@ class DescribeGuardedPackageApis:
 
     def it_diagnoses_a_limit_refusal_as_an_unsafe_archive(self, tmp_path: Path):
         unsafe = tmp_path / "unsafe.docx"
-        _write_archive(
-            unsafe,
-            (("word/document.xml", b"A" * 1_000_000),),
-            compression=zipfile.ZIP_DEFLATED,
-        )
+        _write_archive(unsafe, (("word/document.xml", b"<document/>"),))
+        _set_encrypted_flags(unsafe)
 
         report = diagnose(unsafe)
 
         assert not report.readable
         assert report.kind == "unsafe-archive"
-        assert "compression ratio" in report.problems[0]
+        assert "encrypted" in report.problems[0]
 
 
 class DescribePatchSavePermissions:
@@ -283,3 +305,47 @@ class DescribeGuardedStreamReads:
             parts, _ = GuardedZipReader(archive).read_all()
 
         assert parts["word/document.xml"] == b"<document/>" * 100
+
+
+class DescribeDirectoryEntries:
+    """Folder records (zip -r style) are inert in OPC: ignored, never parts."""
+
+    def it_reads_a_package_carrying_inert_directory_entries(self, tmp_path: Path):
+        source = fixture_path(MINIMAL)
+        path = tmp_path / "rezipped.docx"
+        with zipfile.ZipFile(source) as zin, zipfile.ZipFile(
+            path, "w", zipfile.ZIP_DEFLATED
+        ) as zout:
+            added: set[str] = set()
+            for name in zin.namelist():
+                prefix_parts = name.split("/")[:-1]
+                for depth in range(1, len(prefix_parts) + 1):
+                    folder = "/".join(prefix_parts[:depth]) + "/"
+                    if folder not in added:
+                        added.add(folder)
+                        zout.writestr(
+                            zipfile.ZipInfo(folder, date_time=(1980, 1, 1, 0, 0, 0)),
+                            b"",
+                        )
+                zout.writestr(name, zin.read(name))
+        assert added  # the rezip really did interleave folder records
+
+        document = docx.Document(str(path))
+        assert document.paragraphs is not None
+        parts = _guarded_read(path)
+        assert not any(name.endswith("/") for name in parts)
+
+    def and_it_refuses_a_directory_entry_carrying_data(self, tmp_path: Path):
+        source = fixture_path(MINIMAL)
+        path = tmp_path / "smuggled.docx"
+        with zipfile.ZipFile(source) as zin, zipfile.ZipFile(
+            path, "w", zipfile.ZIP_DEFLATED
+        ) as zout:
+            zout.writestr(
+                zipfile.ZipInfo("word/", date_time=(1980, 1, 1, 0, 0, 0)),
+                b"hidden payload",
+            )
+            for name in zin.namelist():
+                zout.writestr(name, zin.read(name))
+        with pytest.raises(PackageLimitError, match="carries data"):
+            docx.Document(str(path))

--- a/tests/paper/test_audit_package.py
+++ b/tests/paper/test_audit_package.py
@@ -349,3 +349,17 @@ class DescribeDirectoryEntries:
                 zout.writestr(name, zin.read(name))
         with pytest.raises(PackageLimitError, match="carries data"):
             docx.Document(str(path))
+
+    def and_it_validates_local_records_in_a_directory_only_archive(
+        self, tmp_path: Path
+    ):
+        path = tmp_path / "directory-only.zip"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(zipfile.ZipInfo("word/"), b"")
+        data = bytearray(path.read_bytes())
+        local_offset = data.index(b"PK\x03\x04")
+        data[local_offset : local_offset + 4] = b"BAD!"
+        path.write_bytes(data)
+
+        with pytest.raises(PackageLimitError, match="invalid header"):
+            _guarded_read(path)

--- a/tests/paper/test_audit_package.py
+++ b/tests/paper/test_audit_package.py
@@ -1,0 +1,285 @@
+"""Adversarial package-I/O tests for bounded, atomic DOCX reads and writes."""
+
+from __future__ import annotations
+
+import io
+import shutil
+import stat
+import struct
+import warnings
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+import docx
+from docx import _zipguard
+from docx._zipguard import GuardedZipReader, enforce_compressed_size
+from docx.errors import PackageLimitError, PaperRefusal
+from docx.package import diagnose, diff_package, patch_save
+
+from .harness.paths import fixture_path
+
+MINIMAL = "generated/minimal-clean/minimal.docx"
+
+
+def _write_archive(
+    path: Path,
+    members: tuple[tuple[str, bytes], ...],
+    *,
+    compression: int = zipfile.ZIP_STORED,
+) -> None:
+    with zipfile.ZipFile(path, "w", compression=compression) as archive:
+        for name, data in members:
+            archive.writestr(name, data)
+
+
+def _guarded_read(path: Path) -> dict[str, bytes]:
+    enforce_compressed_size(path)
+    with zipfile.ZipFile(path) as archive:
+        parts, _ = GuardedZipReader(archive).read_all()
+    return parts
+
+
+def _set_encrypted_flags(path: Path) -> None:
+    data = bytearray(path.read_bytes())
+    local_offset = data.index(b"PK\x03\x04")
+    central_offset = data.index(b"PK\x01\x02")
+    local_flags = struct.unpack_from("<H", data, local_offset + 6)[0]
+    central_flags = struct.unpack_from("<H", data, central_offset + 8)[0]
+    struct.pack_into("<H", data, local_offset + 6, local_flags | 0x0001)
+    struct.pack_into("<H", data, central_offset + 8, central_flags | 0x0001)
+    path.write_bytes(data)
+
+
+def _understate_expanded_size(path: Path, declared_size: int) -> None:
+    data = bytearray(path.read_bytes())
+    local_offset = data.index(b"PK\x03\x04")
+    central_offset = data.index(b"PK\x01\x02")
+    struct.pack_into("<I", data, local_offset + 22, declared_size)
+    struct.pack_into("<I", data, central_offset + 24, declared_size)
+    path.write_bytes(data)
+
+
+def _understate_stored_member(path: Path, declared_data: bytes) -> None:
+    data = bytearray(path.read_bytes())
+    local_offset = data.index(b"PK\x03\x04")
+    central_offset = data.index(b"PK\x01\x02")
+    declared_size = len(declared_data)
+    crc = zlib.crc32(declared_data) & 0xFFFFFFFF
+    struct.pack_into("<III", data, local_offset + 14, crc, declared_size, declared_size)
+    struct.pack_into("<III", data, central_offset + 16, crc, declared_size, declared_size)
+    path.write_bytes(data)
+
+
+class DescribeZipStructureGuard:
+    @pytest.mark.parametrize(
+        "kind", ["duplicate", "noncanonical", "encrypted", "compression", "symlink"]
+    )
+    def it_refuses_ambiguous_encrypted_and_unsupported_entries(self, kind: str, tmp_path: Path):
+        path = tmp_path / f"{kind}.docx"
+        if kind == "duplicate":
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                _write_archive(
+                    path,
+                    (("word/document.xml", b"<one/>"), ("word/document.xml", b"<two/>")),
+                )
+        elif kind == "noncanonical":
+            _write_archive(path, (("../word/document.xml", b"<document/>"),))
+        elif kind == "encrypted":
+            _write_archive(path, (("word/document.xml", b"<document/>"),))
+            _set_encrypted_flags(path)
+        elif kind == "compression":
+            _write_archive(
+                path,
+                (("word/document.xml", b"<document/>"),),
+                compression=zipfile.ZIP_BZIP2,
+            )
+        else:
+            info = zipfile.ZipInfo("word/document.xml")
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr(info, b"elsewhere.xml")
+
+        with pytest.raises(PackageLimitError):
+            _guarded_read(path)
+
+    def it_rejects_case_ambiguous_names(self, tmp_path: Path):
+        path = tmp_path / "case-collision.docx"
+        _write_archive(
+            path,
+            (("word/document.xml", b"<one/>"), ("WORD/document.xml", b"<two/>")),
+        )
+        with pytest.raises(PackageLimitError, match="case-ambiguous"):
+            _guarded_read(path)
+
+
+class DescribeZipResourceBounds:
+    def it_limits_the_actual_compressed_file_size(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        path = tmp_path / "compressed.docx"
+        _write_archive(path, (("word/document.xml", b"<document/>"),))
+        monkeypatch.setattr(_zipguard, "MAX_COMPRESSED_BYTES", path.stat().st_size - 1)
+        with pytest.raises(PackageLimitError, match="compressed size"):
+            _guarded_read(path)
+
+    def it_limits_member_count(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "members.docx"
+        _write_archive(path, (("one.bin", b"1"), ("two.bin", b"2")))
+        monkeypatch.setattr(_zipguard, "MAX_MEMBER_COUNT", 1)
+        with pytest.raises(PackageLimitError, match="member count"):
+            _guarded_read(path)
+
+    @pytest.mark.parametrize(
+        ("name", "limit_name"),
+        [
+            ("word/document.xml", "MAX_XML_MEMBER_BYTES"),
+            ("word/media/a.png", "MAX_BINARY_MEMBER_BYTES"),
+        ],
+    )
+    def it_applies_separate_xml_and_binary_member_limits(
+        self,
+        name: str,
+        limit_name: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "member.docx"
+        _write_archive(path, ((name, b"12345"),))
+        monkeypatch.setattr(_zipguard, limit_name, 4)
+        with pytest.raises(PackageLimitError, match="expanded size"):
+            _guarded_read(path)
+
+    def it_limits_total_expanded_bytes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "total.docx"
+        _write_archive(path, (("one.bin", b"12345"), ("two.bin", b"67890")))
+        monkeypatch.setattr(_zipguard, "MAX_TOTAL_EXPANDED_BYTES", 9)
+        with pytest.raises(PackageLimitError, match="total expanded size"):
+            _guarded_read(path)
+
+    def it_limits_compression_ratio(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "ratio.docx"
+        _write_archive(
+            path,
+            (("word/document.xml", b"A" * 4_096),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
+        monkeypatch.setattr(_zipguard, "MAX_COMPRESSION_RATIO", 2)
+        with pytest.raises(PackageLimitError, match="compression ratio"):
+            _guarded_read(path)
+
+    def it_enforces_actual_inflated_bytes_when_metadata_understates_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        path = tmp_path / "forged-size.docx"
+        _write_archive(
+            path,
+            (("word/document.xml", b"0123456789abcdef" * 64),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
+        _understate_expanded_size(path, declared_size=32)
+        monkeypatch.setattr(_zipguard, "MAX_XML_MEMBER_BYTES", 64)
+
+        with pytest.raises(PackageLimitError, match="actual expanded size"):
+            _guarded_read(path)
+
+    def it_rejects_undeclared_stored_bytes_even_with_matching_forged_crc(self, tmp_path: Path):
+        path = tmp_path / "forged-stored-size.docx"
+        _write_archive(path, (("word/media/data.bin", b"abcdefgh"),))
+        _understate_stored_member(path, declared_data=b"abcd")
+
+        with pytest.raises(PackageLimitError, match="undeclared trailing data"):
+            _guarded_read(path)
+
+
+class DescribeGuardedPackageApis:
+    def it_refuses_open_diff_and_patch_without_touching_the_destination(self, tmp_path: Path):
+        unsafe = tmp_path / "unsafe.docx"
+        _write_archive(
+            unsafe,
+            (("word/document.xml", b"A" * 1_000_000),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
+        source = fixture_path(MINIMAL)
+        document = docx.Document(str(source))
+        out = tmp_path / "out.docx"
+        sentinel = b"existing destination"
+        out.write_bytes(sentinel)
+        out.chmod(0o640)
+
+        assert issubclass(PackageLimitError, PaperRefusal)
+        with pytest.raises(PackageLimitError):
+            docx.Document(str(unsafe))
+        with pytest.raises(PackageLimitError):
+            diff_package(source, unsafe)
+        with pytest.raises(PackageLimitError):
+            patch_save(unsafe, document, out)
+
+        assert out.read_bytes() == sentinel
+        assert stat.S_IMODE(out.stat().st_mode) == 0o640
+        assert not list(tmp_path.glob("out.docx.*.partial"))
+
+    def it_diagnoses_a_limit_refusal_as_an_unsafe_archive(self, tmp_path: Path):
+        unsafe = tmp_path / "unsafe.docx"
+        _write_archive(
+            unsafe,
+            (("word/document.xml", b"A" * 1_000_000),),
+            compression=zipfile.ZIP_DEFLATED,
+        )
+
+        report = diagnose(unsafe)
+
+        assert not report.readable
+        assert report.kind == "unsafe-archive"
+        assert "compression ratio" in report.problems[0]
+
+
+class DescribePatchSavePermissions:
+    def it_preserves_an_existing_destination_mode(self, tmp_path: Path):
+        source = fixture_path(MINIMAL)
+        document = docx.Document(str(source))
+        document.add_paragraph("A bounded edit.")
+        out = tmp_path / "existing.docx"
+        out.write_bytes(b"old destination")
+        out.chmod(0o640)
+
+        patch_save(source, document, out)
+
+        assert stat.S_IMODE(out.stat().st_mode) == 0o640
+        assert docx.Document(str(out)).paragraphs[-1].text == "A bounded edit."
+
+    def it_uses_the_original_mode_for_a_new_destination(self, tmp_path: Path):
+        source = tmp_path / "source.docx"
+        shutil.copyfile(fixture_path(MINIMAL), source)
+        source.chmod(0o604)
+        out = tmp_path / "new.docx"
+
+        result = patch_save(source, docx.Document(str(source)), out)
+
+        assert result.verbatim_copy
+        assert out.read_bytes() == source.read_bytes()
+        assert stat.S_IMODE(out.stat().st_mode) == 0o604
+
+
+class DescribeGuardedStreamReads:
+    def it_accepts_a_healthy_seekable_stream(self):
+        data = fixture_path(MINIMAL).read_bytes()
+        document = docx.Document(io.BytesIO(data))
+        assert document.paragraphs
+
+    def it_accepts_valid_data_descriptors_from_a_nonseekable_writer(self):
+        class NonseekableSink(io.BytesIO):
+            def seek(self, _offset: int, _whence: int = 0) -> int:
+                raise OSError("not seekable")
+
+        sink = NonseekableSink()
+        with zipfile.ZipFile(sink, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("word/document.xml", b"<document/>" * 100)
+
+        with zipfile.ZipFile(io.BytesIO(sink.getvalue())) as archive:
+            parts, _ = GuardedZipReader(archive).read_all()
+
+        assert parts["word/document.xml"] == b"<document/>" * 100

--- a/tests/paper/test_audit_revision_compounds.py
+++ b/tests/paper/test_audit_revision_compounds.py
@@ -18,6 +18,7 @@ from docx.oxml.ns import nsdecls, qn
 from .harness.paths import fixture_path
 
 NOTES = "generated/feature-isolated/footnotes-endnotes.docx"
+ROW_REVISIONS = "generated/feature-isolated/row-revisions.docx"
 W = nsdecls("w")
 
 
@@ -247,6 +248,98 @@ class DescribeCleanupPreflight:
             document.revisions.reject_all()
 
         assert document.element.xml == before
+
+
+class DescribeIndividualDestructiveClosure:
+    def it_refuses_a_row_change_with_independently_authored_nested_markup(self):
+        document = docx.Document(str(fixture_path(ROW_REVISIONS)))
+        row_marker = next(
+            revision
+            for revision in document.revisions
+            if revision.revision_type == "row_insertion"
+        )._element  # noqa: SLF001
+        tr_pr = row_marker.getparent()
+        assert tr_pr is not None
+        row = tr_pr.getparent()
+        assert row is not None
+        nested = next(node for node in row.iter(qn("w:ins")) if node is not row_marker)
+        nested.set(qn("w:author"), "Independent Reviewer")
+        row_insertion = next(
+            revision
+            for revision in document.revisions
+            if revision.revision_type == "row_insertion"
+        )
+        before = document.element.xml
+
+        with pytest.raises(
+            UnsupportedStructureError,
+            match=r"cannot reject.*row_insertion.*Independent Reviewer",
+        ):
+            row_insertion.reject()
+
+        assert document.element.xml == before
+
+    def it_refuses_accepting_an_outer_deletion_with_a_nested_revision(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision(
+                "del",
+                '<w:r><w:delText>outer</w:delText></w:r>'
+                '<w:ins w:id="21" w:author="Bob">'
+                "<w:r><w:t>nested</w:t></w:r></w:ins>",
+                20,
+                author="Alice",
+            )
+        )
+        revisions = document.revisions
+        outer = next(r for r in revisions if r.revision_type == "deletion")
+        before = document.element.xml
+
+        with pytest.raises(
+            UnsupportedStructureError,
+            match=r"cannot accept.*deletion.*unselected.*insertion",
+        ):
+            outer.accept()
+
+        assert document.element.xml == before
+        assert [
+            (revision.revision_type, revision.author)
+            for revision in document.revisions
+        ] == [("deletion", "Alice"), ("insertion", "Bob")]
+        assert document.revisions.accept_all() == 2
+        assert not document.revisions
+
+    def it_refuses_rejecting_an_outer_insertion_with_a_nested_revision(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision(
+                "ins",
+                '<w:r><w:t>outer</w:t></w:r>'
+                '<w:del w:id="23" w:author="Bob">'
+                "<w:r><w:delText>nested</w:delText></w:r></w:del>",
+                22,
+                author="Alice",
+            )
+        )
+        revisions = document.revisions
+        outer = next(r for r in revisions if r.revision_type == "insertion")
+        before = document.element.xml
+
+        with pytest.raises(
+            UnsupportedStructureError,
+            match=r"cannot reject.*insertion.*unselected.*deletion",
+        ):
+            outer.reject()
+
+        assert document.element.xml == before
+        assert [
+            (revision.revision_type, revision.author)
+            for revision in document.revisions
+        ] == [("insertion", "Alice"), ("deletion", "Bob")]
+        assert document.revisions.reject_all() == 2
+        assert not document.revisions
 
 
 class DescribeFilteredDestructiveClosure:

--- a/tests/paper/test_audit_revision_compounds.py
+++ b/tests/paper/test_audit_revision_compounds.py
@@ -1,0 +1,391 @@
+"""Regressions for compound revision resolution and refusal atomicity."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import docx
+from docx.errors import UnsupportedStructureError
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml import parse_xml
+from docx.oxml.ns import nsdecls, qn
+
+from .harness.paths import fixture_path
+
+NOTES = "generated/feature-isolated/footnotes-endnotes.docx"
+W = nsdecls("w")
+
+
+def _revision(tag: str, inner_xml: str, revision_id: int, author: str = "Audit"):
+    return parse_xml(
+        f'<w:{tag} {W} w:id="{revision_id}" w:author="{author}">'
+        f"{inner_xml}</w:{tag}>"
+    )
+
+
+def _wrap_in_insertion(element, revision_id: int) -> None:
+    wrapper = _revision("ins", "", revision_id)
+    element.addprevious(wrapper)
+    wrapper.append(element)
+
+
+def _relationship_snapshot(document) -> tuple:
+    return tuple(
+        sorted(
+            (r_id, rel.reltype, rel.target_ref)
+            for r_id, rel in document.part.rels.items()
+        )
+    )
+
+
+def _opaque_part(document, partname: str, content_type: str, blob: bytes) -> Part:
+    package = document.part.package
+    assert package is not None
+    return Part(PackURI(partname), content_type, blob, package)
+
+
+def _footnote_ids(document) -> set[int]:
+    root = document.part.part_related_by(RT.FOOTNOTES)._element  # noqa: SLF001
+    return {
+        int(note.get(qn("w:id")))
+        for note in root
+        if note.tag == qn("w:footnote")
+        and note.get(qn("w:type")) is None
+        and note.get(qn("w:id")) is not None
+    }
+
+
+class DescribeCleanupPreflight:
+    def it_refuses_duplicate_note_relationships_before_mutation(self):
+        document = docx.Document(str(fixture_path(NOTES)))
+        reference = next(document.element.iter(qn("w:footnoteReference")))
+        _wrap_in_insertion(reference.getparent(), 10)
+        duplicate = _opaque_part(
+            document,
+            "/word/footnotes-audit.xml",
+            CT.WML_FOOTNOTES,
+            b"<audit/>",
+        )
+        document.part.relate_to(duplicate, RT.FOOTNOTES)
+        before_xml = document.element.xml
+        before_rels = _relationship_snapshot(document)
+
+        with pytest.raises(UnsupportedStructureError, match="multiple.*footnotes"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before_xml
+        assert _relationship_snapshot(document) == before_rels
+
+    def it_refuses_an_opaque_note_part_before_mutation(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision(
+                "ins",
+                '<w:r><w:footnoteReference w:id="1"/></w:r>',
+                11,
+            )
+        )
+        opaque = _opaque_part(
+            document,
+            "/word/footnotes.xml",
+            CT.WML_FOOTNOTES,
+            b"not live XML",
+        )
+        document.part.relate_to(opaque, RT.FOOTNOTES)
+        before_xml = document.element.xml
+        before_rels = _relationship_snapshot(document)
+
+        with pytest.raises(UnsupportedStructureError, match="footnotes.*live XML"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before_xml
+        assert _relationship_snapshot(document) == before_rels
+
+    def it_refuses_duplicate_comment_relationships_before_mutation(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("commented")
+        document.add_comment(paragraph.runs, text="comment", author="Audit")
+        reference = next(document.element.iter(qn("w:commentReference")))
+        _wrap_in_insertion(reference.getparent(), 12)
+        duplicate = _opaque_part(
+            document,
+            "/word/comments-audit.xml",
+            CT.WML_COMMENTS,
+            b"<audit/>",
+        )
+        document.part.relate_to(duplicate, RT.COMMENTS)
+        before_xml = document.element.xml
+        before_rels = _relationship_snapshot(document)
+
+        with pytest.raises(UnsupportedStructureError, match="multiple.*comments"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before_xml
+        assert _relationship_snapshot(document) == before_rels
+
+    def it_refuses_an_opaque_comment_part_before_mutation(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision(
+                "ins",
+                '<w:r><w:commentReference w:id="1"/></w:r>',
+                13,
+            )
+        )
+        opaque = _opaque_part(
+            document,
+            "/word/comments.xml",
+            CT.WML_COMMENTS,
+            b"not live XML",
+        )
+        document.part.relate_to(opaque, RT.COMMENTS)
+        before_xml = document.element.xml
+        before_rels = _relationship_snapshot(document)
+
+        with pytest.raises(UnsupportedStructureError, match="comments.*live XML"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before_xml
+        assert _relationship_snapshot(document) == before_rels
+
+    @pytest.mark.parametrize("bad_id", ["not-a-number", ""])
+    def it_refuses_malformed_note_reference_ids_before_any_mutation(self, bad_id: str):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision("ins", "<w:r><w:t>first</w:t></w:r>", 14)
+        )
+        paragraph.append(
+            _revision(
+                "ins",
+                f'<w:r><w:footnoteReference w:id="{bad_id}"/></w:r>',
+                15,
+            )
+        )
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match=r"malformed.*w:id"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before
+
+    def it_compares_equivalent_note_ids_numerically(self):
+        document = docx.Document(str(fixture_path(NOTES)))
+        reference = next(document.element.iter(qn("w:footnoteReference")))
+        note_id = int(reference.get(qn("w:id")))
+        _wrap_in_insertion(reference.getparent(), 16)
+        surviving_run = document.add_paragraph().add_run()._r
+        surviving_run.append(
+            parse_xml(
+                f'<w:footnoteReference {W} w:id="{note_id:02d}"/>'
+            )
+        )
+
+        assert document.revisions.reject_all() == 1
+        assert note_id in _footnote_ids(document)
+
+    def it_refuses_malformed_note_body_ids_before_mutation(self):
+        document = docx.Document(str(fixture_path(NOTES)))
+        reference = next(document.element.iter(qn("w:footnoteReference")))
+        _wrap_in_insertion(reference.getparent(), 17)
+        notes_root = document.part.part_related_by(RT.FOOTNOTES)._element  # noqa: SLF001
+        note = next(
+            item
+            for item in notes_root
+            if item.tag == qn("w:footnote")
+            and item.get(qn("w:type")) is None
+        )
+        note.set(qn("w:id"), "broken")
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match=r"malformed.*w:id"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before
+
+    def it_refuses_removing_one_of_multiple_comment_references(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("commented")
+        comment = document.add_comment(
+            paragraph.runs, text="comment", author="Audit"
+        )
+        reference = next(document.element.iter(qn("w:commentReference")))
+        _wrap_in_insertion(reference.getparent(), 18)
+        duplicate_run = document.add_paragraph().add_run()._r
+        duplicate_run.append(copy.deepcopy(reference))
+        comments_root = document.part.part_related_by(RT.COMMENTS)._element  # noqa: SLF001
+        before_document = document.element.xml
+        before_comments = comments_root.xml
+
+        with pytest.raises(
+            UnsupportedStructureError, match="reference marks|exactly one"
+        ):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before_document
+        assert comments_root.xml == before_comments
+        assert document.comments.get(comment.comment_id) is not None
+
+    def it_refuses_removing_only_one_comment_range_boundary(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("commented")
+        document.add_comment(paragraph.runs, text="comment", author="Audit")
+        range_start = next(document.element.iter(qn("w:commentRangeStart")))
+        _wrap_in_insertion(range_start, 19)
+        before = document.element.xml
+
+        with pytest.raises(
+            UnsupportedStructureError, match="range markers.*reference"
+        ):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before
+
+
+class DescribeFilteredDestructiveClosure:
+    def it_refuses_an_outer_revision_that_would_consume_another_author(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision(
+                "del",
+                '<w:r><w:delText>outer</w:delText></w:r>'
+                '<w:ins w:id="21" w:author="Bob">'
+                "<w:r><w:t>nested</w:t></w:r></w:ins>",
+                20,
+                author="Alice",
+            )
+        )
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="Bob|another author"):
+            document.revisions.accept_all(author="Alice")
+
+        assert document.element.xml == before
+        assert {revision.author for revision in document.revisions} == {
+            "Alice",
+            "Bob",
+        }
+
+    def it_refuses_a_row_removal_that_would_consume_another_author(self):
+        document = docx.Document()
+        table = parse_xml(
+            f"<w:tbl {W}><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>"
+            "<w:tr><w:tc><w:tcPr/><w:p/></w:tc></w:tr>"
+            "<w:tr><w:trPr><w:del w:id='30' w:author='Alice'/></w:trPr>"
+            "<w:tc><w:tcPr/><w:p>"
+            "<w:ins w:id='31' w:author='Bob'><w:r><w:t>nested</w:t></w:r></w:ins>"
+            "</w:p></w:tc></w:tr></w:tbl>"
+        )
+        document.element.body.insert(0, table)
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="Bob|another author"):
+            document.revisions.accept_all(author="Alice")
+
+        assert document.element.xml == before
+        assert len(table.findall(qn("w:tr"))) == 2
+
+    def it_refuses_a_paragraph_join_that_would_consume_another_author(self):
+        document = docx.Document()
+        first = parse_xml(
+            f"<w:p {W}><w:pPr><w:rPr>"
+            "<w:del w:id='32' w:author='Alice'/>"
+            "<w:ins w:id='33' w:author='Bob'/>"
+            "</w:rPr></w:pPr><w:r><w:t>first</w:t></w:r></w:p>"
+        )
+        following = parse_xml(
+            f"<w:p {W}><w:r><w:t>following</w:t></w:r></w:p>"
+        )
+        document.element.body.insert(0, following)
+        document.element.body.insert(0, first)
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="Bob|another author"):
+            document.revisions.accept_all(author="Alice")
+
+        assert document.element.xml == before
+
+    def it_refuses_row_removal_that_would_consume_marker_only_move_markup(self):
+        document = docx.Document()
+        table = parse_xml(
+            f"<w:tbl {W}><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>"
+            "<w:tr><w:tc><w:tcPr/><w:p/></w:tc></w:tr>"
+            "<w:tr><w:trPr><w:del w:id='34' w:author='Alice'/></w:trPr>"
+            "<w:tc><w:tcPr/><w:p>"
+            "<w:moveFromRangeStart w:id='35' w:name='nested' w:author='Bob'/>"
+            "<w:moveFromRangeEnd w:id='35'/>"
+            "<w:moveToRangeStart w:id='36' w:name='nested' w:author='Bob'/>"
+            "<w:moveToRangeEnd w:id='36'/>"
+            "</w:p></w:tc></w:tr></w:tbl>"
+        )
+        document.element.body.insert(0, table)
+        before = document.element.xml
+
+        with pytest.raises(
+            UnsupportedStructureError, match="unselected revision markup"
+        ):
+            document.revisions.accept_all(author="Alice")
+
+        assert document.element.xml == before
+        assert len(table.findall(qn("w:tr"))) == 2
+
+
+class DescribeMoveAndParagraphCompounds:
+    @pytest.mark.parametrize("method", ["accept_all", "reject_all"])
+    def it_refuses_a_complete_marker_only_move_unit(self, method: str):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        for tag, revision_id in (
+            ("moveFromRangeStart", 40),
+            ("moveFromRangeEnd", 40),
+            ("moveToRangeStart", 41),
+            ("moveToRangeEnd", 41),
+        ):
+            name = ' w:name="marker-only"' if tag.endswith("Start") else ""
+            paragraph.append(
+                parse_xml(f'<w:{tag} {W} w:id="{revision_id}"{name}/>')
+            )
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="marker-only|resolvable"):
+            getattr(document.revisions, method)()
+
+        assert document.element.xml == before
+
+    @pytest.mark.parametrize(
+        "barrier",
+        [
+            f"<w:customXml {W}><w:p><w:r><w:t>middle</w:t></w:r></w:p></w:customXml>",
+            f'<w:altChunk {nsdecls("w", "r")} r:id="rIdMissing"/>',
+        ],
+        ids=["custom-xml", "alt-chunk"],
+    )
+    def it_refuses_a_paragraph_join_across_unrecognized_block_content(
+        self, barrier: str
+    ):
+        document = docx.Document()
+        first = parse_xml(
+            f"<w:p {W}><w:pPr><w:rPr>"
+            "<w:del w:id='50' w:author='Audit'/>"
+            "</w:rPr></w:pPr><w:r><w:t>first</w:t></w:r></w:p>"
+        )
+        following = parse_xml(
+            f"<w:p {W}><w:r><w:t>following</w:t></w:r></w:p>"
+        )
+        document.element.body.insert(0, following)
+        document.element.body.insert(0, parse_xml(barrier))
+        document.element.body.insert(0, first)
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="paragraph|block"):
+            document.revisions.accept_all()
+
+        assert document.element.xml == before

--- a/tests/paper/test_audit_revision_compounds.py
+++ b/tests/paper/test_audit_revision_compounds.py
@@ -251,31 +251,26 @@ class DescribeCleanupPreflight:
 
 
 class DescribeIndividualDestructiveClosure:
-    def it_refuses_a_row_change_with_independently_authored_nested_markup(self):
+    @pytest.mark.parametrize(
+        ("revision_type", "verb"),
+        [("row_insertion", "reject"), ("row_deletion", "accept")],
+    )
+    def it_refuses_a_row_change_that_would_consume_nested_markup(
+        self, revision_type: str, verb: str
+    ):
         document = docx.Document(str(fixture_path(ROW_REVISIONS)))
-        row_marker = next(
+        row_revision = next(
             revision
             for revision in document.revisions
-            if revision.revision_type == "row_insertion"
-        )._element  # noqa: SLF001
-        tr_pr = row_marker.getparent()
-        assert tr_pr is not None
-        row = tr_pr.getparent()
-        assert row is not None
-        nested = next(node for node in row.iter(qn("w:ins")) if node is not row_marker)
-        nested.set(qn("w:author"), "Independent Reviewer")
-        row_insertion = next(
-            revision
-            for revision in document.revisions
-            if revision.revision_type == "row_insertion"
+            if revision.revision_type == revision_type
         )
         before = document.element.xml
 
         with pytest.raises(
             UnsupportedStructureError,
-            match=r"cannot reject.*row_insertion.*Independent Reviewer",
+            match=rf"cannot {verb}.*{revision_type}.*nested unselected",
         ):
-            row_insertion.reject()
+            getattr(row_revision, verb)()
 
         assert document.element.xml == before
 

--- a/tests/paper/test_audit_revisions.py
+++ b/tests/paper/test_audit_revisions.py
@@ -1,0 +1,364 @@
+"""Regression tests for atomic revision resolution and discard cleanup."""
+
+from __future__ import annotations
+
+import struct
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+import docx
+from docx.commentops import (
+    COMMENTS_EXTENDED_RELATIONSHIP_TYPE,
+    reply,
+    resolve,
+)
+from docx.errors import UnsupportedStructureError
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml import parse_xml
+from docx.oxml.ns import nsdecls, qn
+
+from .harness.paths import fixture_path
+
+TRACKED_MOVES = "generated/feature-isolated/tracked-moves.docx"
+NOTES = "generated/feature-isolated/footnotes-endnotes.docx"
+_W15_NS = "http://schemas.microsoft.com/office/word/2012/wordml"
+
+
+def _revision(tag: str, inner_xml: str, revision_id: int):
+    return parse_xml(
+        f'<w:{tag} {nsdecls("w")} w:id="{revision_id}" w:author="Audit">'
+        f"{inner_xml}</w:{tag}>"
+    )
+
+
+def _wrap_in_insertion(element, revision_id: int) -> None:
+    wrapper = _revision("ins", "", revision_id)
+    element.addprevious(wrapper)
+    wrapper.append(element)
+
+
+def _bmp(red: int, green: int, blue: int) -> bytes:
+    """Return a valid one-pixel 24-bit BMP without an image dependency."""
+    return (
+        struct.pack("<2sIHHI", b"BM", 58, 0, 0, 54)
+        + struct.pack("<IiiHHIIiiII", 40, 1, 1, 1, 24, 0, 4, 2835, 2835, 0, 0)
+        + bytes((blue, green, red, 0))
+    )
+
+
+def _image_r_id(run) -> str:
+    blip = next(run._r.iter(qn("a:blip")))
+    return blip.get(qn("r:embed"))
+
+
+def _note_ids(document, reltype: str, note_tag: str) -> set[str]:
+    root = document.part.part_related_by(reltype)._element  # noqa: SLF001
+    return {
+        note.get(qn("w:id"))
+        for note in root
+        if note.tag == qn(note_tag) and note.get(qn("w:id")) is not None
+    }
+
+
+class DescribeAtomicRefusal:
+    @pytest.mark.parametrize(
+        ("method", "first_tag", "first_inner", "bad_tag"),
+        [
+            (
+                "accept_all",
+                "ins",
+                "<w:r><w:t>kept</w:t></w:r>",
+                "del",
+            ),
+            (
+                "reject_all",
+                "del",
+                "<w:r><w:delText>restored</w:delText></w:r>",
+                "ins",
+            ),
+        ],
+    )
+    def it_prevalidates_malformed_comment_reference_ids(
+        self, method: str, first_tag: str, first_inner: str, bad_tag: str
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(_revision(first_tag, first_inner, 1))
+        paragraph.append(
+            _revision(
+                bad_tag,
+                '<w:r><w:commentReference w:id="not-a-number"/></w:r>',
+                2,
+            )
+        )
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match=r"malformed.*w:id"):
+            getattr(document.revisions, method)()
+
+        assert document.element.xml == before
+        assert len(document.revisions) == 2
+
+    def it_prevalidates_malformed_comment_range_ids(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            parse_xml(
+                f'<w:commentRangeStart {nsdecls("w")} w:id="broken"/>'
+            )
+        )
+        paragraph.append(
+            _revision(
+                "ins", '<w:r><w:commentReference w:id="7"/></w:r>', 3
+            )
+        )
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match=r"malformed.*w:id"):
+            document.revisions.reject_all()
+
+        assert document.element.xml == before
+
+    def it_refuses_stale_revision_and_revisions_snapshots(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            _revision("ins", "<w:r><w:t>first</w:t></w:r>", 10)
+        )
+        paragraph.append(
+            _revision("ins", "<w:r><w:t>second</w:t></w:r>", 11)
+        )
+        snapshot = document.revisions
+        first, second = snapshot
+        first.accept()
+        before = document.element.xml
+
+        for stale_action in (
+            first.accept,
+            second.accept,
+            snapshot.accept_all,
+            snapshot.reject_all,
+        ):
+            with pytest.raises(UnsupportedStructureError, match="stale"):
+                stale_action()
+            assert document.element.xml == before
+
+        assert document.revisions.accept_all() == 1
+
+    def it_refuses_a_mixed_author_move_unit_before_mutation(self):
+        document = docx.Document(str(fixture_path(TRACKED_MOVES)))
+        moves = [
+            revision
+            for revision in document.revisions
+            if revision.revision_type in ("move_from", "move_to")
+        ]
+        for revision in moves:
+            revision._element.set(qn("w:author"), "Alice")  # noqa: SLF001
+        next(
+            revision for revision in moves if revision.revision_type == "move_to"
+        )._element.set(qn("w:author"), "Bob")  # noqa: SLF001
+        snapshot = document.revisions
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="authors differ"):
+            snapshot.accept_all(author="Alice")
+
+        assert document.element.xml == before
+        assert len(document.revisions) == len(snapshot)
+
+    def it_deduplicates_a_valid_author_filtered_move_unit(self):
+        document = docx.Document(str(fixture_path(TRACKED_MOVES)))
+        snapshot = document.revisions
+        expected = len(snapshot)
+
+        assert snapshot.accept_all(author="Alice Editor") == expected
+        assert len(document.revisions) == 0
+
+
+class DescribeDiscardCleanup:
+    def it_drops_unreferenced_relationships_and_payloads_but_keeps_shared_ones(
+        self, tmp_path: Path
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+
+        shared_keep = paragraph.add_run()
+        shared_keep.add_picture(BytesIO(_bmp(255, 0, 0)))
+        shared_drop = paragraph.add_run()
+        shared_drop.add_picture(BytesIO(_bmp(255, 0, 0)))
+        unique_drop = paragraph.add_run()
+        unique_drop.add_picture(BytesIO(_bmp(0, 0, 255)))
+
+        shared_r_id = _image_r_id(shared_keep)
+        assert _image_r_id(shared_drop) == shared_r_id
+        unique_r_id = _image_r_id(unique_drop)
+
+        hyperlink_r_id = document.part.relate_to(
+            "https://audit.example.invalid/", RT.HYPERLINK, is_external=True
+        )
+        hyperlink = parse_xml(
+            f'<w:hyperlink {nsdecls("w", "r")} r:id="{hyperlink_r_id}">'
+            "<w:r><w:t>discarded link</w:t></w:r></w:hyperlink>"
+        )
+
+        package = document.part.package
+        assert package is not None
+        object_part = Part(
+            PackURI("/word/embeddings/audit-object.bin"),
+            CT.OFC_OLE_OBJECT,
+            b"discarded object payload",
+            package,
+        )
+        object_r_id = document.part.relate_to(object_part, RT.OLE_OBJECT)
+        object_run = parse_xml(
+            f'<w:r {nsdecls("w", "r")} '
+            'xmlns:o="urn:schemas-microsoft-com:office:office">'
+            f'<w:object><o:OLEObject r:id="{object_r_id}"/></w:object></w:r>'
+        )
+
+        wrapper = _revision("ins", "", 20)
+        shared_drop._r.addprevious(wrapper)
+        wrapper.append(shared_drop._r)
+        wrapper.append(unique_drop._r)
+        wrapper.append(hyperlink)
+        wrapper.append(object_run)
+
+        shared_partname = str(
+            document.part.rels[shared_r_id].target_part.partname
+        ).lstrip("/")
+        unique_partname = str(
+            document.part.rels[unique_r_id].target_part.partname
+        ).lstrip("/")
+        object_partname = str(object_part.partname).lstrip("/")
+
+        assert document.revisions.reject_all() == 1
+        assert shared_r_id in document.part.rels
+        assert unique_r_id not in document.part.rels
+        assert hyperlink_r_id not in document.part.rels
+        assert object_r_id not in document.part.rels
+
+        output = tmp_path / "relationships.docx"
+        document.save(str(output))
+        with ZipFile(output) as package_zip:
+            names = set(package_zip.namelist())
+        assert shared_partname in names
+        assert unique_partname not in names
+        assert object_partname not in names
+
+    def it_removes_unreferenced_footnote_and_endnote_bodies(
+        self, tmp_path: Path
+    ):
+        document = docx.Document(str(fixture_path(NOTES)))
+        footnote_ref = next(document.element.iter(qn("w:footnoteReference")))
+        endnote_ref = next(document.element.iter(qn("w:endnoteReference")))
+        footnote_id = footnote_ref.get(qn("w:id"))
+        endnote_id = endnote_ref.get(qn("w:id"))
+        _wrap_in_insertion(footnote_ref.getparent(), 30)
+        _wrap_in_insertion(endnote_ref.getparent(), 31)
+
+        assert document.revisions.reject_all() == 2
+        assert footnote_id not in _note_ids(document, RT.FOOTNOTES, "w:footnote")
+        assert endnote_id not in _note_ids(document, RT.ENDNOTES, "w:endnote")
+
+        output = tmp_path / "notes.docx"
+        document.save(str(output))
+        reopened = docx.Document(str(output))
+        assert footnote_id not in _note_ids(reopened, RT.FOOTNOTES, "w:footnote")
+        assert endnote_id not in _note_ids(reopened, RT.ENDNOTES, "w:endnote")
+
+    def it_preserves_a_note_body_with_a_surviving_shared_reference(self):
+        document = docx.Document(str(fixture_path(NOTES)))
+        footnote_ref = next(document.element.iter(qn("w:footnoteReference")))
+        footnote_id = footnote_ref.get(qn("w:id"))
+        _wrap_in_insertion(footnote_ref.getparent(), 32)
+        surviving_run = document.add_paragraph().add_run()._r
+        surviving_run.append(
+            parse_xml(
+                f'<w:footnoteReference {nsdecls("w")} w:id="{footnote_id}"/>'
+            )
+        )
+
+        assert document.revisions.reject_all() == 1
+        assert footnote_id in _note_ids(document, RT.FOOTNOTES, "w:footnote")
+
+    def it_removes_only_matching_comments_extended_entries(self, tmp_path: Path):
+        document = docx.Document()
+        first_p = document.add_paragraph("first comment")
+        second_p = document.add_paragraph("second comment")
+        first = document.add_comment(
+            first_p.runs, text="discard me", author="Audit"
+        )
+        second = document.add_comment(
+            second_p.runs, text="keep me", author="Audit"
+        )
+        resolve(document, first)
+        resolve(document, second)
+
+        comments_root = document.part.part_related_by(RT.COMMENTS)._element  # noqa: SLF001
+        comments = {int(comment.get(qn("w:id"))): comment for comment in comments_root}
+        first_para_id = comments[first.comment_id].findall(qn("w:p"))[-1].get(
+            qn("w14:paraId")
+        )
+        second_para_id = comments[second.comment_id].findall(qn("w:p"))[-1].get(
+            qn("w14:paraId")
+        )
+        first_reference = next(
+            reference
+            for reference in document.element.iter(qn("w:commentReference"))
+            if reference.get(qn("w:id")) == str(first.comment_id)
+        )
+        _wrap_in_insertion(first_reference.getparent(), 40)
+
+        assert document.revisions.reject_all() == 1
+        assert [comment.comment_id for comment in document.comments] == [
+            second.comment_id
+        ]
+        extended_root = document.part.part_related_by(
+            COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+        )._element  # noqa: SLF001
+        remaining_para_ids = {
+            entry.get(f"{{{_W15_NS}}}paraId") for entry in extended_root
+        }
+        assert first_para_id not in remaining_para_ids
+        assert second_para_id in remaining_para_ids
+
+        output = tmp_path / "comments.docx"
+        document.save(str(output))
+        reopened = docx.Document(str(output))
+        reopened_extended = reopened.part.part_related_by(
+            COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+        )._element  # noqa: SLF001
+        assert first_para_id not in {
+            entry.get(f"{{{_W15_NS}}}paraId") for entry in reopened_extended
+        }
+
+    def it_removes_an_entire_discarded_comment_thread(self):
+        from docx.blocks import tracked_delete_paragraphs
+
+        document = docx.Document()
+        paragraph = document.add_paragraph("threaded comment")
+        parent = document.add_comment(
+            paragraph.runs, text="parent", author="Audit"
+        )
+        reply(document, parent, "reply", author="Audit")
+        assert len(document.comments) == 2
+
+        tracked_delete_paragraphs(
+            document,
+            "threaded comment",
+            count=1,
+            author="Audit",
+        )
+        assert document.revisions.accept_all() > 0
+
+        assert len(document.comments) == 0
+        extended_root = document.part.part_related_by(
+            COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+        )._element  # noqa: SLF001
+        assert len(extended_root) == 0

--- a/tests/paper/test_audit_scrub_atomicity.py
+++ b/tests/paper/test_audit_scrub_atomicity.py
@@ -1,0 +1,32 @@
+"""Audit regressions for scrub preflight atomicity."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+import docx
+from docx.oxml.ns import qn
+from docx.scrubbing import scrub
+from docx.search import find_one
+
+
+def _package_bytes(document) -> bytes:
+    stream = io.BytesIO()
+    document.save(stream)
+    return stream.getvalue()
+
+
+def it_resolves_hidden_text_before_removing_comments():
+    document = docx.Document()
+    paragraph = document.add_paragraph("comment target")
+    find_one(document, "comment target").comment("Review note", author="Reviewer")
+    size = paragraph.runs[0]._r.get_or_add_rPr().get_or_add_sz()
+    size.set(qn("w:val"), "not-a-size")
+    before = _package_bytes(document)
+
+    with pytest.raises(ValueError, match="invalid literal"):
+        scrub(document, comments=True, metadata=False, hidden_text=True)
+
+    assert _package_bytes(document) == before

--- a/tests/paper/test_audit_secondary_safety.py
+++ b/tests/paper/test_audit_secondary_safety.py
@@ -1,0 +1,62 @@
+"""Focused regressions for guarded secondary editing behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+import docx
+from docx.bookmarks import delete_bookmark
+from docx.commentops import anchored_text
+from docx.errors import UnsupportedStructureError
+from docx.numbering import ensure_bullet_definition, restart_numbering
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+from docx.search import find_one
+
+
+def it_refuses_numbering_restarts_that_would_drop_level_overrides():
+    document = docx.Document()
+    num_id = ensure_bullet_definition(document)
+    numbering = document.part.numbering_part.element
+    definition = next(
+        node
+        for node in numbering.findall(qn("w:num"))
+        if node.get(qn("w:numId")) == str(num_id)
+    )
+    override = OxmlElement("w:lvlOverride")
+    override.set(qn("w:ilvl"), "1")
+    definition.append(override)
+    before = numbering.xml
+
+    with pytest.raises(UnsupportedStructureError, match="level overrides"):
+        restart_numbering(document, num_id=num_id)
+
+    assert numbering.xml == before
+
+
+def it_refuses_duplicate_bookmark_marker_ids_atomically():
+    document = docx.Document()
+    paragraph = document.add_paragraph("bookmark targets")._p
+    for bookmark_name, bookmark_id in (("target", "5"), ("unrelated", "05")):
+        start = OxmlElement("w:bookmarkStart")
+        start.set(qn("w:id"), bookmark_id)
+        start.set(qn("w:name"), bookmark_name)
+        paragraph.append(start)
+        end = OxmlElement("w:bookmarkEnd")
+        end.set(qn("w:id"), bookmark_id)
+        paragraph.append(end)
+    before = document.element.xml
+
+    with pytest.raises(UnsupportedStructureError, match="duplicate"):
+        delete_bookmark(document, "target")
+
+    assert document.element.xml == before
+
+
+def it_preserves_paragraph_boundaries_in_anchored_comment_text():
+    document = docx.Document()
+    document.add_paragraph("Alpha")
+    document.add_paragraph("Beta")
+    comment = find_one(document, "Alpha Beta").comment("Review", author="Reviewer")
+
+    assert anchored_text(document, comment) == "Alpha\nBeta"

--- a/tests/paper/test_audit_structural_atomicity.py
+++ b/tests/paper/test_audit_structural_atomicity.py
@@ -186,3 +186,51 @@ class DescribeTrackedRowTemplateRefusal:
         assert [node.get(qn("w:id")) for node in table._tbl.iter(qn(marker_tag))] == [
             "77"
         ]
+
+
+class DescribeTrackedBlockIdentityPreflight:
+    """List blocks add numbering definitions while building nodes, so a
+    malformed identity must refuse before that side-part mutation."""
+
+    def it_leaves_numbering_untouched_when_tracked_author_is_malformed(self):
+        import io
+
+        from docx.blocks import ListBlock, insert_blocks_after
+
+        document = Document()
+        document.add_paragraph("anchor paragraph")
+        before = io.BytesIO()
+        document.save(before)
+
+        with pytest.raises(ValueError, match="author"):
+            insert_blocks_after(
+                document,
+                "anchor paragraph",
+                blocks=[ListBlock(items=["item one"], kind="bullet")],
+                tracked=True,
+                author="bad\x00author",
+            )
+
+        after = io.BytesIO()
+        document.save(after)
+        assert after.getvalue() == before.getvalue()
+
+    def and_a_string_date_refuses_before_any_mutation(self):
+        import io
+
+        from docx.blocks import tracked_delete_paragraphs
+
+        document = Document()
+        document.add_paragraph("anchor paragraph")
+        document.add_paragraph("paragraph to delete")
+        before = io.BytesIO()
+        document.save(before)
+
+        with pytest.raises(TypeError, match="datetime"):
+            tracked_delete_paragraphs(
+                document, "paragraph to delete", author="A", date="2026-01-01"
+            )
+
+        after = io.BytesIO()
+        document.save(after)
+        assert after.getvalue() == before.getvalue()

--- a/tests/paper/test_audit_structural_atomicity.py
+++ b/tests/paper/test_audit_structural_atomicity.py
@@ -1,0 +1,188 @@
+"""Regression coverage for structural editing refusal atomicity."""
+
+from __future__ import annotations
+
+import pytest
+from lxml import etree
+
+from docx import Document
+from docx.controls import get_control
+from docx.errors import UnsupportedStructureError
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+from docx.tableops import insert_row_after
+
+
+def _empty_control(tag: str, *, with_content: bool):
+    sdt = OxmlElement("w:sdt")
+    properties = OxmlElement("w:sdtPr")
+    tag_element = OxmlElement("w:tag")
+    tag_element.set(qn("w:val"), tag)
+    properties.append(tag_element)
+    properties.append(OxmlElement("w:text"))
+    sdt.append(properties)
+    if with_content:
+        sdt.append(OxmlElement("w:sdtContent"))
+    return sdt
+
+
+def _append_revision_marker(table, container_tag: str, marker_tag: str) -> None:
+    row = table.rows[0]._tr
+    cell = table.cell(0, 0)
+    paragraph = cell.paragraphs[0]
+    if container_tag == "w:tr":
+        container = row
+    elif container_tag == "w:trPr":
+        container = row.get_or_add_trPr()
+    elif container_tag == "w:tblPrEx":
+        container = OxmlElement(container_tag)
+        row.insert(0, container)
+    elif container_tag == "w:tcPr":
+        container = cell._tc.get_or_add_tcPr()
+    elif container_tag == "w:pPr":
+        container = paragraph._p.get_or_add_pPr()
+    elif container_tag == "w:rPr":
+        container = paragraph.runs[0]._r.get_or_add_rPr()
+    else:
+        assert container_tag == "w:numPr"
+        container = OxmlElement(container_tag)
+        paragraph._p.get_or_add_pPr().append(container)
+
+    marker = OxmlElement(marker_tag)
+    marker.set(qn("w:id"), "77")
+    marker.set(qn("w:author"), "Reviewer")
+    snapshot_tags = {
+        "w:trPrChange": "w:trPr",
+        "w:tblPrExChange": "w:tblPrEx",
+        "w:tcPrChange": "w:tcPr",
+        "w:pPrChange": "w:pPr",
+        "w:rPrChange": "w:rPr",
+    }
+    snapshot_tag = snapshot_tags.get(marker_tag)
+    if snapshot_tag is not None:
+        marker.append(OxmlElement(snapshot_tag))
+    container.append(marker)
+
+
+class DescribeEmptyContentControls:
+    @pytest.mark.parametrize("with_content", [False, True])
+    def it_authors_paragraph_content_for_a_block_control(self, with_content: bool):
+        document = Document()
+        sdt = _empty_control("block", with_content=with_content)
+        body = document.element.body
+        body.insert(body.index(body.sectPr), sdt)
+
+        get_control(document, tag="block").set_value("replacement")
+
+        content = sdt.find(qn("w:sdtContent"))
+        assert content is not None
+        assert [child.tag for child in content] == [qn("w:p")]
+        paragraph = content.find(qn("w:p"))
+        assert paragraph.find(qn("w:r")).find(qn("w:t")).text == "replacement"
+
+    @pytest.mark.parametrize("with_content", [False, True])
+    def it_keeps_inline_content_inline(self, with_content: bool):
+        document = Document()
+        paragraph = document.add_paragraph()
+        sdt = _empty_control("inline", with_content=with_content)
+        paragraph._p.append(sdt)
+
+        get_control(document, tag="inline").set_value("replacement")
+
+        content = sdt.find(qn("w:sdtContent"))
+        assert content is not None
+        assert [child.tag for child in content] == [qn("w:r")]
+        assert content.find(qn("w:r")).find(qn("w:t")).text == "replacement"
+
+    def it_refuses_an_empty_control_with_an_ambiguous_parent(self):
+        document = Document()
+        wrapper = OxmlElement("w:customXml")
+        sdt = _empty_control("ambiguous", with_content=True)
+        wrapper.append(sdt)
+        body = document.element.body
+        body.insert(body.index(body.sectPr), wrapper)
+        before = etree.tostring(sdt)
+
+        with pytest.raises(UnsupportedStructureError, match="ambiguous block/inline"):
+            get_control(document, tag="ambiguous").set_value("replacement")
+
+        assert etree.tostring(sdt) == before
+
+
+class DescribeDetachedRowPopulation:
+    def it_refuses_a_control_wrapped_template_atomically(self):
+        document = Document()
+        table = document.add_table(rows=1, cols=2)
+        table.cell(0, 0).text = "plain template"
+        cell = table.cell(0, 1)
+        for child in list(cell._tc):
+            if child.tag != qn("w:tcPr"):
+                cell._tc.remove(child)
+
+        sdt = _empty_control("wrapped", with_content=True)
+        content = sdt.find(qn("w:sdtContent"))
+        paragraph = OxmlElement("w:p")
+        run = OxmlElement("w:r")
+        run.add_t("template")
+        paragraph.append(run)
+        content.append(paragraph)
+        cell._tc.append(sdt)
+        before = table._tbl.xml
+
+        with pytest.raises(UnsupportedStructureError, match="content control"):
+            insert_row_after(table, 0, ["first was populated", "replacement"])
+
+        assert table._tbl.xml == before
+        assert len(table.rows) == 1
+
+
+class DescribeTrackedRowTemplateRefusal:
+    @pytest.mark.parametrize("marker_tag", ["w:ins", "w:del"])
+    def it_does_not_duplicate_tracked_row_ids(self, marker_tag: str):
+        document = Document()
+        table = document.add_table(rows=1, cols=1)
+        table.cell(0, 0).text = "template"
+        _append_revision_marker(table, "w:trPr", marker_tag)
+        before = table._tbl.xml
+
+        with pytest.raises(UnsupportedStructureError, match="tracked revision metadata"):
+            insert_row_after(table, 0, ["new row"])
+
+        assert table._tbl.xml == before
+        assert len(table.rows) == 1
+        assert [node.get(qn("w:id")) for node in table._tbl.iter(qn(marker_tag))] == [
+            "77"
+        ]
+
+    @pytest.mark.parametrize(
+        ("container_tag", "marker_tag"),
+        [
+            pytest.param("w:tr", "w:moveFromRangeStart", id="move-range"),
+            pytest.param("w:trPr", "w:trPrChange", id="row-properties"),
+            pytest.param("w:tblPrEx", "w:tblPrExChange", id="table-property-exceptions"),
+            pytest.param("w:tcPr", "w:cellIns", id="cell-insertion"),
+            pytest.param("w:tcPr", "w:cellDel", id="cell-deletion"),
+            pytest.param("w:tcPr", "w:cellMerge", id="cell-merge"),
+            pytest.param("w:tcPr", "w:tcPrChange", id="cell-properties"),
+            pytest.param("w:pPr", "w:pPrChange", id="paragraph-properties"),
+            pytest.param("w:rPr", "w:rPrChange", id="run-properties"),
+            pytest.param("w:numPr", "w:numberingChange", id="numbering-properties"),
+        ],
+    )
+    def it_refuses_other_revision_metadata_that_the_row_clone_would_retain(
+        self, container_tag: str, marker_tag: str
+    ):
+        document = Document()
+        table = document.add_table(rows=1, cols=1)
+        table.cell(0, 0).text = "template"
+        _append_revision_marker(table, container_tag, marker_tag)
+        before = table._tbl.xml
+
+        with pytest.raises(UnsupportedStructureError, match="tracked revision metadata"):
+            insert_row_after(table, 0, ["new row"])
+
+        assert table._tbl.xml == before
+        assert len(table.rows) == 1
+        assert [node.get(qn("w:id")) for node in table._tbl.iter(qn(marker_tag))] == [
+            "77"
+        ]

--- a/tests/paper/test_audit_text_atomicity.py
+++ b/tests/paper/test_audit_text_atomicity.py
@@ -113,3 +113,26 @@ class DescribeXmlCharacterValidation:
             resolve(document, comment)
 
         assert _package_bytes(document) == before
+
+
+class DescribeTrackedIdentityPreflight:
+    """w:author/w:date are stamped after mutation begins, so malformed
+    identity must refuse while nothing has changed."""
+
+    def it_refuses_a_malformed_tracked_author_before_mutating(self):
+        document = docx.Document()
+        document.add_paragraph("replace target here")
+        span = find_one(document, "target")
+        before = _package_bytes(document)
+        with pytest.raises(ValueError, match="author"):
+            span.replace("changed", tracked=True, author="bad\x00author")
+        assert _package_bytes(document) == before
+
+    def and_it_refuses_a_string_date_before_mutating(self):
+        document = docx.Document()
+        document.add_paragraph("replace target here")
+        span = find_one(document, "target")
+        before = _package_bytes(document)
+        with pytest.raises(TypeError, match="datetime"):
+            span.replace("changed", tracked=True, author="A", date="2026-01-01")
+        assert _package_bytes(document) == before

--- a/tests/paper/test_audit_text_atomicity.py
+++ b/tests/paper/test_audit_text_atomicity.py
@@ -1,0 +1,115 @@
+"""Audit regressions for XML text and comment refusal atomicity."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+import docx
+from docx.commentops import reply, resolve
+from docx.errors import PaperRefusal
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.oxml.ns import qn
+from docx.search import find_one
+
+
+def _package_bytes(document) -> bytes:
+    stream = io.BytesIO()
+    document.save(stream)
+    return stream.getvalue()
+
+
+class DescribeXmlCharacterValidation:
+    @pytest.mark.parametrize("tracked", [False, True])
+    def it_refuses_xml_illegal_replacement_before_mutation(self, tracked: bool):
+        document = docx.Document()
+        document.add_paragraph("replace target")
+        span = find_one(document, "replace target")
+        before = _package_bytes(document)
+
+        with pytest.raises(ValueError, match="XML 1.0"):
+            span.replace(
+                "invalid\x00text",
+                tracked=tracked,
+                author="Reviewer" if tracked else None,
+            )
+
+        assert _package_bytes(document) == before
+
+    def it_refuses_invalid_comment_text_before_splitting_runs(self):
+        document = docx.Document()
+        document.add_paragraph("prefix target suffix")
+        span = find_one(document, "target")
+        before = _package_bytes(document)
+
+        with pytest.raises(ValueError, match="XML 1.0"):
+            span.comment("invalid\x00comment", author="Reviewer")
+
+        assert _package_bytes(document) == before
+
+    def it_refuses_invalid_reply_text_before_thread_metadata_changes(self):
+        document = docx.Document()
+        document.add_paragraph("comment target")
+        comment = find_one(document, "comment target").comment(
+            "Parent comment", author="Reviewer"
+        )
+        before = _package_bytes(document)
+
+        with pytest.raises(ValueError, match="XML 1.0"):
+            reply(document, comment, "invalid\x00reply", author="Second reviewer")
+
+        assert _package_bytes(document) == before
+
+    def it_refuses_malformed_existing_comment_ids_before_splitting_runs(self):
+        document = docx.Document()
+        document.add_paragraph("existing comment")
+        existing = find_one(document, "existing comment").comment(
+            "Existing", author="Reviewer"
+        )
+        existing._comment_elm.set(qn("w:id"), "broken")  # noqa: SLF001
+        document.add_paragraph("prefix target suffix")
+        span = find_one(document, "target")
+        before = _package_bytes(document)
+
+        with pytest.raises(PaperRefusal, match="malformed comment"):
+            span.comment("New", author="Reviewer")
+
+        assert _package_bytes(document) == before
+
+    def it_refuses_malformed_unrelated_comment_ids_before_reply_metadata(self):
+        document = docx.Document()
+        document.add_paragraph("parent")
+        parent = find_one(document, "parent").comment("Parent", author="Reviewer")
+        document.add_paragraph("other")
+        other = find_one(document, "other").comment("Other", author="Reviewer")
+        other._comment_elm.set(qn("w:id"), "broken")  # noqa: SLF001
+        before = _package_bytes(document)
+
+        with pytest.raises(PaperRefusal, match="malformed comment"):
+            reply(document, parent, "Reply", author="Second reviewer")
+
+        assert _package_bytes(document) == before
+
+    def it_refuses_a_colliding_comments_extended_part_before_resolution(self):
+        document = docx.Document()
+        document.add_paragraph("comment target")
+        comment = find_one(document, "comment target").comment(
+            "Comment", author="Reviewer"
+        )
+        package = document.part.package
+        assert package is not None
+        collision = Part(
+            PackURI("/word/commentsExtended.xml"),
+            "application/octet-stream",
+            b"collision",
+            package,
+        )
+        document.part.relate_to(collision, "urn:paper-docx:audit-collision")
+        before = _package_bytes(document)
+
+        with pytest.raises(PaperRefusal, match="already occupies"):
+            resolve(document, comment)
+
+        assert _package_bytes(document) == before

--- a/tests/paper/test_audit_zip_preflight.py
+++ b/tests/paper/test_audit_zip_preflight.py
@@ -1,0 +1,226 @@
+"""Regressions for ZIP preflight and OPC-aware expansion limits."""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import docx
+from docx import _paperpkg, _zipguard
+from docx.errors import PackageLimitError
+from docx.opc import phys_pkg
+
+_END_RECORD = struct.Struct("<4s4H2LH")
+_ZIP64_END_RECORD = struct.Struct("<4sQ2H2L4Q")
+_ZIP64_LOCATOR = struct.Struct("<4sLQL")
+
+
+def _write_archive(path: Path, members: tuple[tuple[str, bytes], ...]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name, data in members:
+            archive.writestr(name, data)
+
+
+def _zip64_count_only_archive(member_count: int) -> bytes:
+    zip64_end = _ZIP64_END_RECORD.pack(
+        b"PK\x06\x06",
+        44,
+        45,
+        45,
+        0,
+        0,
+        member_count,
+        member_count,
+        0,
+        0,
+    )
+    locator = _ZIP64_LOCATOR.pack(b"PK\x06\x07", 0, 0, 1)
+    legacy_end = _END_RECORD.pack(
+        b"PK\x05\x06",
+        0,
+        0,
+        0xFFFF,
+        0xFFFF,
+        0xFFFFFFFF,
+        0xFFFFFFFF,
+        0,
+    )
+    return zip64_end + locator + legacy_end
+
+
+class DescribeCentralDirectoryPreflight:
+    def it_refuses_zip64_member_count_before_constructing_zipfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "too-many.docx"
+        path.write_bytes(_zip64_count_only_archive(_zipguard.MAX_MEMBER_COUNT + 1))
+        constructions = 0
+
+        class UnexpectedZipFile:
+            def __init__(self, *_args, **_kwargs):
+                nonlocal constructions
+                constructions += 1
+                raise AssertionError("ZipFile must not be constructed before count refusal")
+
+        monkeypatch.setattr(_paperpkg.zipfile, "ZipFile", UnexpectedZipFile)
+
+        with pytest.raises(PackageLimitError, match="member count"):
+            _paperpkg._read_zip(path)
+
+        assert constructions == 0
+
+    def it_preflights_an_ordinary_document_open_before_constructing_zipfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "too-many-on-open.docx"
+        path.write_bytes(_zip64_count_only_archive(_zipguard.MAX_MEMBER_COUNT + 1))
+        constructions = 0
+
+        class UnexpectedZipFile:
+            def __init__(self, *_args, **_kwargs):
+                nonlocal constructions
+                constructions += 1
+                raise AssertionError("ZipFile must not be constructed before count refusal")
+
+        monkeypatch.setattr(phys_pkg, "ZipFile", UnexpectedZipFile)
+
+        with pytest.raises(PackageLimitError, match="member count"):
+            docx.Document(path)
+
+        assert constructions == 0
+
+    def it_scans_records_instead_of_trusting_a_forged_low_count(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "forged-count.docx"
+        _write_archive(path, (("one.bin", b"1"), ("two.bin", b"2")))
+        data = bytearray(path.read_bytes())
+        end_offset = data.rfind(b"PK\x05\x06")
+        struct.pack_into("<HH", data, end_offset + 8, 1, 1)
+        path.write_bytes(data)
+        constructions = 0
+
+        class UnexpectedZipFile:
+            def __init__(self, *_args, **_kwargs):
+                nonlocal constructions
+                constructions += 1
+                raise AssertionError("ZipFile must not be constructed before count refusal")
+
+        monkeypatch.setattr(_paperpkg.zipfile, "ZipFile", UnexpectedZipFile)
+
+        with pytest.raises(PackageLimitError, match="member count"):
+            _paperpkg._read_zip(path)
+
+        assert constructions == 0
+
+    def it_bounds_central_directory_bytes_before_constructing_zipfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "large-directory.docx"
+        _write_archive(path, (("one.bin", b"1"),))
+        monkeypatch.setattr(_zipguard, "MAX_CENTRAL_DIRECTORY_BYTES", 1)
+        constructions = 0
+
+        class UnexpectedZipFile:
+            def __init__(self, *_args, **_kwargs):
+                nonlocal constructions
+                constructions += 1
+                raise AssertionError("ZipFile must not be constructed before size refusal")
+
+        monkeypatch.setattr(_paperpkg.zipfile, "ZipFile", UnexpectedZipFile)
+
+        with pytest.raises(PackageLimitError, match="central directory size"):
+            _paperpkg._read_zip(path)
+
+        assert constructions == 0
+
+
+class DescribeContentTypeAwareLimits:
+    @pytest.mark.parametrize("declaration", ["override", "override-case", "default"])
+    def it_treats_non_xml_suffixes_as_xml_when_content_types_says_so(
+        self,
+        declaration: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        content_type = "application/vnd.example.document+xml"
+        if declaration.startswith("override"):
+            part_name = (
+                "/WORD/DOCUMENT.BIN" if declaration == "override-case" else "/word/document.bin"
+            )
+            entry = f'<Override PartName="{part_name}" ContentType="{content_type}"/>'
+        else:
+            entry = f'<Default Extension="bin" ContentType="{content_type}"/>'
+        content_types = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            f"{entry}</Types>"
+        ).encode()
+        path = tmp_path / f"xml-{declaration}.docx"
+        _write_archive(
+            path,
+            (
+                ("[Content_Types].xml", content_types),
+                ("word/document.bin", bytes(range(256)) * 4),
+            ),
+        )
+        monkeypatch.setattr(_zipguard, "MAX_XML_MEMBER_BYTES", 512)
+        monkeypatch.setattr(_zipguard, "MAX_BINARY_MEMBER_BYTES", 2_048)
+
+        with pytest.raises(PackageLimitError, match=r"word/document\.bin.*512-byte"):
+            _paperpkg._read_zip(path)
+
+    def it_applies_content_type_limits_on_an_ordinary_document_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        content_types = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            b'<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.'
+            b'relationships+xml"/>'
+            b'<Override PartName="/word/document.bin" ContentType="application/vnd.'
+            b'openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+            b"</Types>"
+        )
+        relationships = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/'
+            b'relationships">'
+            b'<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/'
+            b'officeDocument/2006/relationships/officeDocument" '
+            b'Target="word/document.bin"/>'
+            b"</Relationships>"
+        )
+        body = "".join(f"<w:p><w:r><w:t>{index:04d}</w:t></w:r></w:p>" for index in range(128))
+        document = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+            f"<w:body>{body}</w:body></w:document>"
+        ).encode()
+        path = tmp_path / "renamed-main-part.docx"
+        _write_archive(
+            path,
+            (
+                ("[Content_Types].xml", content_types),
+                ("_rels/.rels", relationships),
+                ("word/document.bin", document),
+            ),
+        )
+        monkeypatch.setattr(_zipguard, "MAX_XML_MEMBER_BYTES", 1_024)
+        monkeypatch.setattr(_zipguard, "MAX_BINARY_MEMBER_BYTES", len(document) + 1)
+
+        with pytest.raises(PackageLimitError, match=r"word/document\.bin.*1024-byte"):
+            docx.Document(path)

--- a/tests/paper/test_audit_zip_preflight.py
+++ b/tests/paper/test_audit_zip_preflight.py
@@ -52,6 +52,52 @@ def _zip64_count_only_archive(member_count: int) -> bytes:
 
 
 class DescribeCentralDirectoryPreflight:
+    def it_opens_package_kernel_paths_once_before_preflight(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "selected.zip"
+        replacement = tmp_path / "replacement.zip"
+        _write_archive(path, (("selected.bin", b"selected"),))
+        _write_archive(replacement, (("replacement.bin", b"replacement"),))
+        original_preflight = _paperpkg.preflight_zip
+
+        def preflight_then_swap(source: object) -> None:
+            original_preflight(source)
+            replacement.replace(path)
+
+        monkeypatch.setattr(_paperpkg, "preflight_zip", preflight_then_swap)
+
+        parts, _ = _paperpkg._read_zip(path)
+
+        assert parts == {"selected.bin": b"selected"}
+
+    def it_opens_document_paths_once_before_preflight(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "selected.docx"
+        replacement = tmp_path / "replacement.docx"
+        selected = docx.Document()
+        selected.add_paragraph("selected")
+        selected.save(path)
+        other = docx.Document()
+        other.add_paragraph("replacement")
+        other.save(replacement)
+        original_preflight = phys_pkg.preflight_zip
+
+        def preflight_then_swap(source: object) -> None:
+            original_preflight(source)
+            replacement.replace(path)
+
+        monkeypatch.setattr(phys_pkg, "preflight_zip", preflight_then_swap)
+
+        reopened = docx.Document(path)
+
+        assert [paragraph.text for paragraph in reopened.paragraphs] == ["selected"]
+
     def it_refuses_zip64_member_count_before_constructing_zipfile(
         self,
         tmp_path: Path,

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -14,6 +14,8 @@ import pytest
 
 import docx
 from docx.errors import UnsupportedStructureError
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
 from docx.package import compare
 from docx.revision import _remaining_markup
 from docx.story import iter_blocks
@@ -55,6 +57,27 @@ def _compare_fixture_pair():
 
 
 class DescribeCompareAlgebra:
+    def it_verifies_compare_algebra_for_a_protected_document(self, tmp_path: Path):
+        original_path = tmp_path / "original.docx"
+        revised_path = tmp_path / "revised.docx"
+        for path, text in ((original_path, "before"), (revised_path, "after")):
+            document = docx.Document()
+            document.add_paragraph(text)
+            protection = OxmlElement("w:documentProtection")
+            protection.set(qn("w:edit"), "readOnly")
+            protection.set(qn("w:enforcement"), "1")
+            document.settings.element.append(protection)
+            document.save(path)
+
+        result = compare(original_path, revised_path, author="Compare Engine")
+
+        assert result.revision_count > 0
+        assert any(
+            finding.kind == "document_protection_present"
+            for finding in result.findings
+        )
+        result.document.revisions.accept_all()
+
     def it_accept_alls_to_the_revised_text_across_every_story(self):
         result = _compare_fixture_pair()
         assert result.revision_count > 0

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -79,6 +79,33 @@ def _capitalize_header_part(path: Path) -> None:
 
 
 class DescribeCompareAlgebra:
+    def it_validates_and_loads_the_same_pathlike_bytes(self, tmp_path: Path):
+        class DivergentPath:
+            def __init__(self, path: Path):
+                self.path = path
+
+            def __fspath__(self):
+                return str(self.path)
+
+            def __str__(self):
+                return str(tmp_path / "wrong.docx")
+
+        original_path = tmp_path / "original.docx"
+        revised_path = tmp_path / "revised.docx"
+        for path, text in ((original_path, "before"), (revised_path, "after")):
+            document = docx.Document()
+            document.add_paragraph(text)
+            document.save(path)
+
+        result = compare(
+            DivergentPath(original_path),
+            DivergentPath(revised_path),
+            author="Compare Engine",
+        )
+
+        result.document.revisions.accept_all()
+        assert result.document.paragraphs[0].text == "after"
+
     def it_matches_loaded_story_names_case_insensitively(self, tmp_path: Path):
         original_path = tmp_path / "original.docx"
         revised_path = tmp_path / "revised.docx"

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -43,7 +43,10 @@ def _texts(document) -> dict:
 def _visible(document) -> dict:
     """Per-story visible text with block boundaries collapsed (paragraph
     merges/splits legitimately change block counts, not content)."""
-    return {story: "\n".join(t for t in items if t) for story, items in _texts(document).items()}
+    return {
+        story: "\n".join(t for t in items if t)
+        for story, items in _texts(document).items()
+    }
 
 
 def _compare_fixture_pair():
@@ -105,7 +108,10 @@ class DescribeCompareAlgebra:
         result = compare(original_path, revised_path, author="Compare Engine")
 
         assert result.revision_count > 0
-        assert any(finding.kind == "document_protection_present" for finding in result.findings)
+        assert any(
+            finding.kind == "document_protection_present"
+            for finding in result.findings
+        )
         result.document.revisions.accept_all()
 
     def it_accept_alls_to_the_revised_text_across_every_story(self):
@@ -113,13 +119,17 @@ class DescribeCompareAlgebra:
         assert result.revision_count > 0
         result.document.revisions.accept_all()
         assert _remaining_markup(result.document) == {}
-        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(REVISED))))
+        assert _visible(result.document) == _visible(
+            docx.Document(str(fixture_path(REVISED)))
+        )
 
     def it_reject_alls_back_to_the_original_text(self):
         result = _compare_fixture_pair()
         result.document.revisions.reject_all()
         assert _remaining_markup(result.document) == {}
-        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(ORIGINAL))))
+        assert _visible(result.document) == _visible(
+            docx.Document(str(fixture_path(ORIGINAL)))
+        )
 
     def it_yields_zero_revisions_for_identical_inputs(self):
         result = compare(
@@ -135,41 +145,25 @@ class DescribeCompareAlgebra:
         for run in ("a", "b"):
             result = _compare_fixture_pair()
             result.document.save(str(tmp_path / f"out-{run}.docx"))
-        assert (tmp_path / "out-a.docx").read_bytes() == (tmp_path / "out-b.docx").read_bytes()
+        assert (tmp_path / "out-a.docx").read_bytes() == (
+            tmp_path / "out-b.docx"
+        ).read_bytes()
 
-    def it_survives_an_independent_reopen_with_the_same_algebra(self, tmp_path: Path):
+    def it_survives_an_independent_reopen_with_the_same_algebra(
+        self, tmp_path: Path
+    ):
         result = _compare_fixture_pair()
         out = tmp_path / "redline.docx"
         result.document.save(str(out))
         reopened = docx.Document(str(out))
         assert len(reopened.revisions) == result.revision_count
         reopened.revisions.accept_all()
-        assert _visible(reopened) == _visible(docx.Document(str(fixture_path(REVISED))))
+        assert _visible(reopened) == _visible(
+            docx.Document(str(fixture_path(REVISED)))
+        )
 
 
 class DescribeCompareBehavior:
-    def it_maps_word_edits_after_an_inline_image(self, tmp_path: Path):
-        original_path = tmp_path / "original.docx"
-        revised_path = tmp_path / "revised.docx"
-        image_path = Path(__file__).parents[1] / "test_files" / "python-icon.png"
-        for path, ending in (
-            (original_path, "old language"),
-            (revised_path, "new language"),
-        ):
-            document = docx.Document()
-            paragraph = document.add_paragraph("Logo ")
-            paragraph.add_run().add_picture(str(image_path))
-            paragraph.add_run(f" {ending}")
-            document.save(path)
-
-        result = compare(original_path, revised_path, author="Compare Engine")
-
-        assert result.revision_count > 0
-        assert len(result.document.inline_shapes) == 1
-        result.document.revisions.accept_all()
-        assert result.document.paragraphs[0].text == "Logo  new language"
-        assert len(result.document.inline_shapes) == 1
-
     def it_redlines_a_word_level_edit_minimally(self):
         result = _compare_fixture_pair()
         revisions = result.document.revisions
@@ -187,8 +181,12 @@ class DescribeCompareBehavior:
         revisions = result.document.revisions
         # $200 -> $250 narrows to the single changed character in the cell;
         # crucially the ROW was edited cell-wise, not deleted + reinserted
-        assert any(r.revision_type == "deletion" and r.text == "0" for r in revisions)
-        assert any(r.revision_type == "insertion" and r.text == "5" for r in revisions)
+        assert any(
+            r.revision_type == "deletion" and r.text == "0" for r in revisions
+        )
+        assert any(
+            r.revision_type == "insertion" and r.text == "5" for r in revisions
+        )
         assert not any(r.revision_type.startswith("row_") for r in revisions)
         assert not any("Advisory" in r.text for r in revisions)
 
@@ -198,7 +196,9 @@ class DescribeCompareBehavior:
             assert revision.author == "Compare Engine"
             assert revision.date == FROZEN
 
-    def it_pends_changes_matching_the_text_diff_of_the_inputs(self, tmp_path: Path):
+    def it_pends_changes_matching_the_text_diff_of_the_inputs(
+        self, tmp_path: Path
+    ):
         from docx.package import pending_changes
 
         result = _compare_fixture_pair()
@@ -234,7 +234,9 @@ class DescribeCompareBehavior:
             granularity="block",
         )
         result.document.revisions.accept_all()
-        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(REVISED))))
+        assert _visible(result.document) == _visible(
+            docx.Document(str(fixture_path(REVISED)))
+        )
 
 
 class DescribePendingRevisionInputs:
@@ -279,13 +281,17 @@ class DescribeCompareOnTheGauntlet:
         )
         assert result.revision_count == 0
 
-    def it_compares_minimal_against_the_heavily_edited_variant(self, tmp_path: Path):
+    def it_compares_minimal_against_the_heavily_edited_variant(
+        self, tmp_path: Path
+    ):
         """End-to-end: edit a copy with plain (untracked) upstream calls,
         then let compare reconstruct the redline."""
         edited_path = tmp_path / "edited.docx"
         shutil.copyfile(fixture_path(MINIMAL), edited_path)
         document = docx.Document(str(edited_path))
-        document.paragraphs[1].runs[0].text = "First body paragraph with thoroughly modern text."
+        document.paragraphs[1].runs[0].text = (
+            "First body paragraph with thoroughly modern text."
+        )
         document.add_paragraph("A brand new closing paragraph.")
         document.save(str(edited_path))
 
@@ -296,4 +302,6 @@ class DescribeCompareOnTheGauntlet:
             date=FROZEN,
         )
         result.document.revisions.accept_all()
-        assert _visible(result.document) == _visible(docx.Document(str(edited_path)))
+        assert _visible(result.document) == _visible(
+            docx.Document(str(edited_path))
+        )

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -43,10 +43,7 @@ def _texts(document) -> dict:
 def _visible(document) -> dict:
     """Per-story visible text with block boundaries collapsed (paragraph
     merges/splits legitimately change block counts, not content)."""
-    return {
-        story: "\n".join(t for t in items if t)
-        for story, items in _texts(document).items()
-    }
+    return {story: "\n".join(t for t in items if t) for story, items in _texts(document).items()}
 
 
 def _compare_fixture_pair():
@@ -108,10 +105,7 @@ class DescribeCompareAlgebra:
         result = compare(original_path, revised_path, author="Compare Engine")
 
         assert result.revision_count > 0
-        assert any(
-            finding.kind == "document_protection_present"
-            for finding in result.findings
-        )
+        assert any(finding.kind == "document_protection_present" for finding in result.findings)
         result.document.revisions.accept_all()
 
     def it_accept_alls_to_the_revised_text_across_every_story(self):
@@ -119,17 +113,13 @@ class DescribeCompareAlgebra:
         assert result.revision_count > 0
         result.document.revisions.accept_all()
         assert _remaining_markup(result.document) == {}
-        assert _visible(result.document) == _visible(
-            docx.Document(str(fixture_path(REVISED)))
-        )
+        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(REVISED))))
 
     def it_reject_alls_back_to_the_original_text(self):
         result = _compare_fixture_pair()
         result.document.revisions.reject_all()
         assert _remaining_markup(result.document) == {}
-        assert _visible(result.document) == _visible(
-            docx.Document(str(fixture_path(ORIGINAL)))
-        )
+        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(ORIGINAL))))
 
     def it_yields_zero_revisions_for_identical_inputs(self):
         result = compare(
@@ -145,25 +135,41 @@ class DescribeCompareAlgebra:
         for run in ("a", "b"):
             result = _compare_fixture_pair()
             result.document.save(str(tmp_path / f"out-{run}.docx"))
-        assert (tmp_path / "out-a.docx").read_bytes() == (
-            tmp_path / "out-b.docx"
-        ).read_bytes()
+        assert (tmp_path / "out-a.docx").read_bytes() == (tmp_path / "out-b.docx").read_bytes()
 
-    def it_survives_an_independent_reopen_with_the_same_algebra(
-        self, tmp_path: Path
-    ):
+    def it_survives_an_independent_reopen_with_the_same_algebra(self, tmp_path: Path):
         result = _compare_fixture_pair()
         out = tmp_path / "redline.docx"
         result.document.save(str(out))
         reopened = docx.Document(str(out))
         assert len(reopened.revisions) == result.revision_count
         reopened.revisions.accept_all()
-        assert _visible(reopened) == _visible(
-            docx.Document(str(fixture_path(REVISED)))
-        )
+        assert _visible(reopened) == _visible(docx.Document(str(fixture_path(REVISED))))
 
 
 class DescribeCompareBehavior:
+    def it_maps_word_edits_after_an_inline_image(self, tmp_path: Path):
+        original_path = tmp_path / "original.docx"
+        revised_path = tmp_path / "revised.docx"
+        image_path = Path(__file__).parents[1] / "test_files" / "python-icon.png"
+        for path, ending in (
+            (original_path, "old language"),
+            (revised_path, "new language"),
+        ):
+            document = docx.Document()
+            paragraph = document.add_paragraph("Logo ")
+            paragraph.add_run().add_picture(str(image_path))
+            paragraph.add_run(f" {ending}")
+            document.save(path)
+
+        result = compare(original_path, revised_path, author="Compare Engine")
+
+        assert result.revision_count > 0
+        assert len(result.document.inline_shapes) == 1
+        result.document.revisions.accept_all()
+        assert result.document.paragraphs[0].text == "Logo  new language"
+        assert len(result.document.inline_shapes) == 1
+
     def it_redlines_a_word_level_edit_minimally(self):
         result = _compare_fixture_pair()
         revisions = result.document.revisions
@@ -181,12 +187,8 @@ class DescribeCompareBehavior:
         revisions = result.document.revisions
         # $200 -> $250 narrows to the single changed character in the cell;
         # crucially the ROW was edited cell-wise, not deleted + reinserted
-        assert any(
-            r.revision_type == "deletion" and r.text == "0" for r in revisions
-        )
-        assert any(
-            r.revision_type == "insertion" and r.text == "5" for r in revisions
-        )
+        assert any(r.revision_type == "deletion" and r.text == "0" for r in revisions)
+        assert any(r.revision_type == "insertion" and r.text == "5" for r in revisions)
         assert not any(r.revision_type.startswith("row_") for r in revisions)
         assert not any("Advisory" in r.text for r in revisions)
 
@@ -196,9 +198,7 @@ class DescribeCompareBehavior:
             assert revision.author == "Compare Engine"
             assert revision.date == FROZEN
 
-    def it_pends_changes_matching_the_text_diff_of_the_inputs(
-        self, tmp_path: Path
-    ):
+    def it_pends_changes_matching_the_text_diff_of_the_inputs(self, tmp_path: Path):
         from docx.package import pending_changes
 
         result = _compare_fixture_pair()
@@ -234,9 +234,7 @@ class DescribeCompareBehavior:
             granularity="block",
         )
         result.document.revisions.accept_all()
-        assert _visible(result.document) == _visible(
-            docx.Document(str(fixture_path(REVISED)))
-        )
+        assert _visible(result.document) == _visible(docx.Document(str(fixture_path(REVISED))))
 
 
 class DescribePendingRevisionInputs:
@@ -281,17 +279,13 @@ class DescribeCompareOnTheGauntlet:
         )
         assert result.revision_count == 0
 
-    def it_compares_minimal_against_the_heavily_edited_variant(
-        self, tmp_path: Path
-    ):
+    def it_compares_minimal_against_the_heavily_edited_variant(self, tmp_path: Path):
         """End-to-end: edit a copy with plain (untracked) upstream calls,
         then let compare reconstruct the redline."""
         edited_path = tmp_path / "edited.docx"
         shutil.copyfile(fixture_path(MINIMAL), edited_path)
         document = docx.Document(str(edited_path))
-        document.paragraphs[1].runs[0].text = (
-            "First body paragraph with thoroughly modern text."
-        )
+        document.paragraphs[1].runs[0].text = "First body paragraph with thoroughly modern text."
         document.add_paragraph("A brand new closing paragraph.")
         document.save(str(edited_path))
 
@@ -302,6 +296,4 @@ class DescribeCompareOnTheGauntlet:
             date=FROZEN,
         )
         result.document.revisions.accept_all()
-        assert _visible(result.document) == _visible(
-            docx.Document(str(edited_path))
-        )
+        assert _visible(result.document) == _visible(docx.Document(str(edited_path)))

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -7,7 +7,9 @@ compare(A,A) == nothing, identical inputs -> byte-identical output.
 from __future__ import annotations
 
 import datetime as dt
+import io
 import shutil
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -56,7 +58,41 @@ def _compare_fixture_pair():
     )
 
 
+def _capitalize_header_part(path: Path) -> None:
+    source = path.read_bytes()
+    output = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(source)) as incoming, zipfile.ZipFile(
+        output, "w", zipfile.ZIP_DEFLATED
+    ) as outgoing:
+        for name in incoming.namelist():
+            blob = incoming.read(name)
+            target_name = name
+            if name == "word/header1.xml":
+                target_name = "Word/Header1.xml"
+            elif name == "[Content_Types].xml":
+                blob = blob.replace(
+                    b'PartName="/word/header1.xml"',
+                    b'PartName="/Word/Header1.xml"',
+                )
+            outgoing.writestr(target_name, blob)
+    path.write_bytes(output.getvalue())
+
+
 class DescribeCompareAlgebra:
+    def it_matches_loaded_story_names_case_insensitively(self, tmp_path: Path):
+        original_path = tmp_path / "original.docx"
+        revised_path = tmp_path / "revised.docx"
+        for path, text in ((original_path, "before"), (revised_path, "after")):
+            document = docx.Document()
+            document.add_paragraph(text)
+            document.sections[0].header.paragraphs[0].text = "Header"
+            document.save(path)
+            _capitalize_header_part(path)
+
+        result = compare(original_path, revised_path, author="Compare Engine")
+
+        assert result.revision_count > 0
+
     def it_verifies_compare_algebra_for_a_protected_document(self, tmp_path: Path):
         original_path = tmp_path / "original.docx"
         revised_path = tmp_path / "revised.docx"

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -164,6 +164,28 @@ class DescribeCompareAlgebra:
 
 
 class DescribeCompareBehavior:
+    def it_maps_word_edits_after_an_inline_image(self, tmp_path: Path):
+        original_path = tmp_path / "original.docx"
+        revised_path = tmp_path / "revised.docx"
+        image_path = Path(__file__).parents[1] / "test_files" / "python-icon.png"
+        for path, ending in (
+            (original_path, "old language"),
+            (revised_path, "new language"),
+        ):
+            document = docx.Document()
+            paragraph = document.add_paragraph("Logo ")
+            paragraph.add_run().add_picture(str(image_path))
+            paragraph.add_run(f" {ending}")
+            document.save(path)
+
+        result = compare(original_path, revised_path, author="Compare Engine")
+
+        assert result.revision_count > 0
+        assert len(result.document.inline_shapes) == 1
+        result.document.revisions.accept_all()
+        assert result.document.paragraphs[0].text == "Logo  new language"
+        assert len(result.document.inline_shapes) == 1
+
     def it_redlines_a_word_level_edit_minimally(self):
         result = _compare_fixture_pair()
         revisions = result.document.revisions

--- a/tests/paper/test_distribution_doctor.py
+++ b/tests/paper/test_distribution_doctor.py
@@ -1,0 +1,128 @@
+"""Out-of-band installation diagnostics for the frozen ``docx`` import."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+
+import paper_docx_doctor as doctor
+
+
+class _Distribution:
+    def __init__(self, root, record: str, version: str = "0.1.1"):
+        self._root = root
+        self._record = record
+        self.version = version
+
+    def read_text(self, name: str):
+        return self._record if name == "RECORD" else None
+
+    def locate_file(self, path):
+        return self._root.joinpath(*path.parts)
+
+
+def _hash(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}"
+
+
+def _paper_distribution(tmp_path, data: bytes = b"paper bytes") -> _Distribution:
+    package = tmp_path / "docx"
+    package.mkdir()
+    module = package / "__init__.py"
+    module.write_bytes(data)
+    record = (
+        f"docx/__init__.py,{_hash(data)},{len(data)}\n"
+        "docx/__pycache__/__init__.pyc,,0\n"
+        "../../../bin/paper-docx-doctor,,0\n"
+    )
+    return _Distribution(tmp_path, record)
+
+
+def _install_lookup(monkeypatch, paper=None, upstream=None) -> None:
+    def lookup(name: str):
+        found = {"paper-docx": paper, "python-docx": upstream}[name]
+        if found is None:
+            raise doctor.PackageNotFoundError(name)
+        return found
+
+    monkeypatch.setattr(doctor, "distribution", lookup)
+
+
+class DescribePaperDocxDoctor:
+    def it_accepts_a_clean_install(self, monkeypatch, tmp_path):
+        paper = _paper_distribution(tmp_path)
+        _install_lookup(monkeypatch, paper=paper)
+        monkeypatch.setattr(
+            doctor.importlib,
+            "import_module",
+            lambda _name: SimpleNamespace(__paper_version__="0.1.1"),
+        )
+
+        assert doctor.verify_install() == "0.1.1"
+
+    def it_refuses_missing_paper_distribution_metadata(self, monkeypatch):
+        _install_lookup(monkeypatch)
+
+        with pytest.raises(doctor.DoctorError, match="metadata is missing"):
+            doctor.verify_install()
+
+    def it_refuses_when_both_distributions_are_installed(
+        self, monkeypatch, tmp_path
+    ):
+        paper = _paper_distribution(tmp_path)
+        _install_lookup(monkeypatch, paper=paper, upstream=object())
+
+        with pytest.raises(doctor.DoctorError, match="both installed"):
+            doctor.verify_install()
+
+    def it_refuses_a_missing_recorded_docx_file(self, monkeypatch, tmp_path):
+        paper = _paper_distribution(tmp_path)
+        (tmp_path / "docx" / "__init__.py").unlink()
+        _install_lookup(monkeypatch, paper=paper)
+
+        with pytest.raises(doctor.DoctorError, match="file is missing"):
+            doctor.verify_install()
+
+    def it_refuses_a_hash_mismatch(self, monkeypatch, tmp_path):
+        paper = _paper_distribution(tmp_path)
+        (tmp_path / "docx" / "__init__.py").write_bytes(b"upstream bytes")
+        _install_lookup(monkeypatch, paper=paper)
+
+        with pytest.raises(doctor.DoctorError, match="hash mismatch"):
+            doctor.verify_install()
+
+    @pytest.mark.parametrize(
+        ("sentinel", "message"),
+        [(None, "is missing"), ("9.9.9", "does not match")],
+    )
+    def it_refuses_a_missing_or_wrong_sentinel(
+        self, monkeypatch, tmp_path, sentinel, message
+    ):
+        paper = _paper_distribution(tmp_path)
+        _install_lookup(monkeypatch, paper=paper)
+        imported = SimpleNamespace()
+        if sentinel is not None:
+            imported.__paper_version__ = sentinel
+        monkeypatch.setattr(
+            doctor.importlib, "import_module", lambda _name: imported
+        )
+
+        with pytest.raises(doctor.DoctorError, match=message):
+            doctor.verify_install()
+
+    def it_prints_a_clean_reinstall_remedy(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            doctor,
+            "verify_install",
+            lambda: (_ for _ in ()).throw(doctor.DoctorError("broken")),
+        )
+
+        assert doctor.main() == 1
+        stderr = capsys.readouterr().err
+        assert "uninstall -y python-docx paper-docx" in stderr
+        assert "--force-reinstall paper-docx" in stderr

--- a/tests/paper/test_distribution_doctor.py
+++ b/tests/paper/test_distribution_doctor.py
@@ -60,7 +60,10 @@ class DescribePaperDocxDoctor:
         monkeypatch.setattr(
             doctor.importlib,
             "import_module",
-            lambda _name: SimpleNamespace(__paper_version__="0.1.1"),
+            lambda _name: SimpleNamespace(
+                __file__=str(tmp_path / "docx" / "__init__.py"),
+                __paper_version__="0.1.1",
+            ),
         )
 
         assert doctor.verify_install() == "0.1.1"
@@ -96,6 +99,46 @@ class DescribePaperDocxDoctor:
         with pytest.raises(doctor.DoctorError, match="hash mismatch"):
             doctor.verify_install()
 
+    def it_refuses_a_matching_sentinel_outside_the_owned_docx_root(
+        self, monkeypatch, tmp_path
+    ):
+        paper = _paper_distribution(tmp_path)
+        foreign_module = tmp_path / "shadow" / "docx" / "__init__.py"
+        foreign_module.parent.mkdir(parents=True)
+        foreign_module.write_bytes(b"paper bytes")
+        _install_lookup(monkeypatch, paper=paper)
+        monkeypatch.setattr(
+            doctor.importlib,
+            "import_module",
+            lambda _name: SimpleNamespace(
+                __file__=str(foreign_module), __paper_version__="0.1.1"
+            ),
+        )
+
+        with pytest.raises(doctor.DoctorError, match="outside.*owned docx root"):
+            doctor.verify_install()
+
+    def it_resolves_the_import_path_before_checking_ownership(
+        self, monkeypatch, tmp_path
+    ):
+        paper = _paper_distribution(tmp_path)
+        foreign_module = tmp_path / "shadow" / "__init__.py"
+        foreign_module.parent.mkdir()
+        foreign_module.write_bytes(b"paper bytes")
+        linked_module = tmp_path / "docx" / "shadow.py"
+        linked_module.symlink_to(foreign_module)
+        _install_lookup(monkeypatch, paper=paper)
+        monkeypatch.setattr(
+            doctor.importlib,
+            "import_module",
+            lambda _name: SimpleNamespace(
+                __file__=str(linked_module), __paper_version__="0.1.1"
+            ),
+        )
+
+        with pytest.raises(doctor.DoctorError, match="outside.*owned docx root"):
+            doctor.verify_install()
+
     @pytest.mark.parametrize(
         ("sentinel", "message"),
         [(None, "is missing"), ("9.9.9", "does not match")],
@@ -105,7 +148,9 @@ class DescribePaperDocxDoctor:
     ):
         paper = _paper_distribution(tmp_path)
         _install_lookup(monkeypatch, paper=paper)
-        imported = SimpleNamespace()
+        imported = SimpleNamespace(
+            __file__=str(tmp_path / "docx" / "__init__.py")
+        )
         if sentinel is not None:
             imported.__paper_version__ = sentinel
         monkeypatch.setattr(

--- a/tests/paper/test_distribution_doctor.py
+++ b/tests/paper/test_distribution_doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import csv
 import hashlib
 from types import SimpleNamespace
 
@@ -98,6 +99,24 @@ class DescribePaperDocxDoctor:
 
         with pytest.raises(doctor.DoctorError, match="hash mismatch"):
             doctor.verify_install()
+
+    def it_reports_an_unreadable_owned_file(self, monkeypatch, tmp_path):
+        paper = _paper_distribution(tmp_path)
+        _install_lookup(monkeypatch, paper=paper)
+        monkeypatch.setattr(
+            doctor,
+            "_file_digest",
+            lambda *_args: (_ for _ in ()).throw(PermissionError("denied")),
+        )
+
+        with pytest.raises(doctor.DoctorError, match="cannot be read"):
+            doctor.verify_install()
+
+    def it_reports_malformed_record_csv(self):
+        oversized = "docx/" + "x" * (csv.field_size_limit() + 1) + ",sha256=x,1\n"
+
+        with pytest.raises(doctor.DoctorError, match="malformed CSV"):
+            tuple(doctor._docx_record_entries(oversized))
 
     def it_refuses_a_matching_sentinel_outside_the_owned_docx_root(
         self, monkeypatch, tmp_path

--- a/tests/paper/test_distribution_identity.py
+++ b/tests/paper/test_distribution_identity.py
@@ -1,0 +1,23 @@
+"""Distribution/import identity regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from docx import _version
+
+
+class DescribeDistributionIdentity:
+    def it_refuses_when_both_distributions_are_installed(self, monkeypatch):
+        monkeypatch.setattr(_version, "distribution", lambda _name: object())
+        with pytest.raises(ImportError, match="both installed"):
+            _version.assert_distribution_identity()
+
+    def it_allows_a_clean_paper_docx_install(self, monkeypatch):
+        def distribution(name):
+            if name == "python-docx":
+                raise _version.PackageNotFoundError(name)
+            return object()
+
+        monkeypatch.setattr(_version, "distribution", distribution)
+        _version.assert_distribution_identity()

--- a/tests/paper/test_fields_bookmarks.py
+++ b/tests/paper/test_fields_bookmarks.py
@@ -25,6 +25,8 @@ from docx.fields import (
     add_reference_field,
     insert_toc_after,
 )
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
 from docx.search import find_one
 
 from .harness.contract import save_and_reopen
@@ -75,6 +77,14 @@ class DescribeBookmarks:
                 document, find_one(document, "for definitions"), "DefinedTerm"
             )
 
+    def it_treats_bookmark_names_as_case_insensitive(self):
+        document = docx.Document()
+        document.add_paragraph("first second")
+        create_bookmark(document, find_one(document, "first"), "DefinedTerm")
+
+        with pytest.raises(UnsupportedStructureError, match="already exists"):
+            create_bookmark(document, find_one(document, "second"), "definedterm")
+
     def it_validates_word_legal_names(self):
         document = _doc()
         span = find_one(document, "perfectly ordinary")
@@ -97,6 +107,44 @@ class DescribeBookmarks:
         add_reference_field(paragraph, bookmark="DefinedTerm")
         with pytest.raises(UnsupportedStructureError, match="referenced by"):
             delete_bookmark(document, "DefinedTerm")
+
+    def it_refuses_deleting_an_implicitly_referenced_bookmark(self):
+        document = _doc(BOOKMARKS)
+        field = OxmlElement("w:fldSimple")
+        field.set(qn("w:instr"), " DefinedTerm \\* MERGEFORMAT ")
+        document.add_paragraph()._p.append(field)
+
+        with pytest.raises(UnsupportedStructureError, match="referenced by"):
+            delete_bookmark(document, "DefinedTerm")
+
+    def it_never_treats_quote_literal_text_as_a_bookmark_reference(self):
+        document = _doc(BOOKMARKS)
+        field = OxmlElement("w:fldSimple")
+        instruction = ' QUOTE "literal REF DefinedTerm text" '
+        field.set(qn("w:instr"), instruction)
+        document.add_paragraph()._p.append(field)
+
+        delete_bookmark(document, "DefinedTerm")
+
+        assert field.get(qn("w:instr")) == instruction
+
+    def it_ignores_a_reference_to_a_different_bookmark(self):
+        document = _doc(BOOKMARKS)
+        field = OxmlElement("w:fldSimple")
+        field.set(qn("w:instr"), " REF OtherBookmark ")
+        document.add_paragraph()._p.append(field)
+
+        delete_bookmark(document, "DefinedTerm")
+
+    def it_does_not_mistake_an_embed_field_for_an_implicit_reference(self):
+        document = docx.Document()
+        document.add_paragraph("embedded")
+        create_bookmark(document, find_one(document, "embedded"), "EMBED")
+        field = OxmlElement("w:fldSimple")
+        field.set(qn("w:instr"), " EMBED Word.Document.12 ")
+        document.add_paragraph()._p.append(field)
+
+        delete_bookmark(document, "EMBED")
 
     def it_refuses_unknown_names(self):
         with pytest.raises(TargetNotFoundError):

--- a/tests/paper/test_fields_bookmarks.py
+++ b/tests/paper/test_fields_bookmarks.py
@@ -48,6 +48,35 @@ class DescribeBookmarks:
         assert named["DefinedTerm"].is_point is False
         assert named["_GoBack"].is_point is True
 
+    def it_lists_only_current_view_text_inside_a_bookmark(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        start = OxmlElement("w:bookmarkStart")
+        start.set(qn("w:id"), "1")
+        start.set(qn("w:name"), "CurrentText")
+        paragraph.append(start)
+        first = OxmlElement("w:r")
+        first.add_t("A")
+        paragraph.append(first)
+        moved_from = OxmlElement("w:moveFrom")
+        moved_from.set(qn("w:id"), "2")
+        hidden = OxmlElement("w:r")
+        hidden.add_t("B")
+        moved_from.append(hidden)
+        paragraph.append(moved_from)
+        last = OxmlElement("w:r")
+        last.add_t("C")
+        paragraph.append(last)
+        end = OxmlElement("w:bookmarkEnd")
+        end.set(qn("w:id"), "1")
+        paragraph.append(end)
+
+        bookmark = next(
+            item for item in list_bookmarks(document) if item.name == "CurrentText"
+        )
+
+        assert bookmark.text == "AC"
+
     def it_creates_a_bookmark_on_an_exact_span(self, tmp_path: Path):
         document = _doc()
         span = find_one(document, "perfectly ordinary")
@@ -61,6 +90,31 @@ class DescribeBookmarks:
             "First body paragraph with perfectly ordinary text."
             in [p.text for p in reopened.paragraphs]
         )
+
+    def it_refuses_a_current_view_span_crossing_deleted_content(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        first = OxmlElement("w:r")
+        first.add_t("A")
+        paragraph.append(first)
+        deleted = OxmlElement("w:del")
+        deleted.set(qn("w:id"), "1")
+        deleted_run = OxmlElement("w:r")
+        deleted_text = OxmlElement("w:delText")
+        deleted_text.text = "B"
+        deleted_run.append(deleted_text)
+        deleted.append(deleted_run)
+        paragraph.append(deleted)
+        last = OxmlElement("w:r")
+        last.add_t("C")
+        paragraph.append(last)
+        span = find_one(document, "AC")
+        before = paragraph.xml
+
+        with pytest.raises(UnsupportedStructureError, match="pending revision"):
+            create_bookmark(document, span, "UnstableRange")
+
+        assert paragraph.xml == before
 
     def it_allocates_globally_unique_ids(self):
         document = _doc(BOOKMARKS)

--- a/tests/paper/test_fields_bookmarks.py
+++ b/tests/paper/test_fields_bookmarks.py
@@ -85,6 +85,18 @@ class DescribeBookmarks:
         with pytest.raises(UnsupportedStructureError, match="already exists"):
             create_bookmark(document, find_one(document, "second"), "definedterm")
 
+    def it_refuses_an_unrelated_malformed_bookmark_before_deletion(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        create_bookmark(document, find_one(document, "target"), "Target")
+        malformed = OxmlElement("w:bookmarkStart")
+        malformed.set(qn("w:id"), "bad")
+        malformed.set(qn("w:name"), "Other")
+        document.paragraphs[0]._p.append(malformed)
+
+        with pytest.raises(UnsupportedStructureError, match="non-numeric"):
+            delete_bookmark(document, "Target")
+
     def it_validates_word_legal_names(self):
         document = _doc()
         span = find_one(document, "perfectly ordinary")

--- a/tests/paper/test_practical_composition_table_hardening.py
+++ b/tests/paper/test_practical_composition_table_hardening.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from lxml import etree
 
 import docx
 from docx.bookmarks import create_bookmark
@@ -10,8 +11,8 @@ from docx.composition import insert_blocks_from
 from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.numbering import apply_numbering, ensure_decimal_definition, list_numbering
-from docx.oxml import OxmlElement
-from docx.oxml.ns import qn
+from docx.oxml import OxmlElement, parse_xml
+from docx.oxml.ns import nsdecls, qn
 from docx.search import find_one
 from docx.tableops import update_cell
 
@@ -56,6 +57,62 @@ def it_reports_a_numbered_paragraphs_visible_layout_grid_column() -> None:
     )
 
     assert item.table_cell == (0, 2, 0)
+
+
+def it_reports_numbering_inside_a_table_cell_content_control() -> None:
+    document = docx.Document()
+    num_id = ensure_decimal_definition(document)
+    cell = document.add_table(rows=1, cols=1).cell(0, 0)
+    paragraph = cell.paragraphs[0]
+    paragraph.text = "controlled clause"
+    apply_numbering(paragraph, num_id=num_id)
+    control = OxmlElement("w:sdt")
+    control.append(OxmlElement("w:sdtPr"))
+    content = OxmlElement("w:sdtContent")
+    cell._tc.remove(paragraph._p)
+    content.append(paragraph._p)
+    control.append(content)
+    cell._tc.append(control)
+
+    item = list_numbering(document).numbered_paragraphs[0]
+
+    assert item.text == "controlled clause"
+    assert item.table_cell == (0, 0, 0)
+
+
+def it_selects_one_alternate_content_branch_when_listing_numbering() -> None:
+    document = docx.Document()
+    num_id = ensure_decimal_definition(document)
+    cell = document.add_table(rows=1, cols=1).cell(0, 0)
+    cell._tc.remove(cell.paragraphs[0]._p)
+    alternate = parse_xml(
+        '<mc:AlternateContent '
+        'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" '
+        f'{nsdecls("w", "w14")}/>'
+    )
+    cell._tc.append(alternate)
+    mc_namespace = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    etree.SubElement(alternate, f"{{{mc_namespace}}}Choice", Requires="w14")
+    etree.SubElement(alternate, f"{{{mc_namespace}}}Fallback")
+    for branch, text in zip(alternate, ("selected", "fallback")):
+        paragraph = OxmlElement("w:p")
+        properties = OxmlElement("w:pPr")
+        numbering = OxmlElement("w:numPr")
+        number_id = OxmlElement("w:numId")
+        number_id.set(qn("w:val"), str(num_id))
+        numbering.append(number_id)
+        properties.append(numbering)
+        paragraph.append(properties)
+        run = OxmlElement("w:r")
+        text_element = OxmlElement("w:t")
+        text_element.text = text
+        run.append(text_element)
+        paragraph.append(run)
+        branch.append(paragraph)
+
+    report = list_numbering(document)
+
+    assert [item.text for item in report.numbered_paragraphs] == ["selected"]
 
 
 def it_refuses_updating_a_cell_with_a_cross_paragraph_field() -> None:

--- a/tests/paper/test_practical_composition_table_hardening.py
+++ b/tests/paper/test_practical_composition_table_hardening.py
@@ -1,0 +1,284 @@
+"""Focused practical composition, table, and numbering hardening."""
+
+from __future__ import annotations
+
+import pytest
+
+import docx
+from docx.bookmarks import create_bookmark
+from docx.composition import insert_blocks_from
+from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import TargetNotFoundError, UnsupportedStructureError
+from docx.numbering import apply_numbering, ensure_decimal_definition, list_numbering
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.search import find_one
+from docx.tableops import update_cell
+
+
+def _field_char(kind: str):
+    run = OxmlElement("w:r")
+    marker = OxmlElement("w:fldChar")
+    marker.set(qn("w:fldCharType"), kind)
+    run.append(marker)
+    return run
+
+
+def it_arms_copied_fields_for_update() -> None:
+    source = docx.Document()
+    paragraph = source.add_paragraph("Field source")
+    field = OxmlElement("w:fldSimple")
+    field.set(qn("w:instr"), " PAGE ")
+    paragraph._p.append(field)
+    destination = docx.Document()
+    destination.add_paragraph("Destination")
+
+    insert_blocks_from(destination, source, "Field source", anchor="Destination")
+
+    update = destination.settings.element.find(qn("w:updateFields"))
+    assert update is not None
+    assert update.get(qn("w:val")) == "true"
+
+
+def it_reports_a_numbered_paragraphs_visible_layout_grid_column() -> None:
+    document = docx.Document()
+    num_id = ensure_decimal_definition(document)
+    table = document.add_table(rows=1, cols=3)
+    table.cell(0, 0).merge(table.cell(0, 1))
+    paragraph = table.cell(0, 2).paragraphs[0]
+    paragraph.text = "third grid column"
+    apply_numbering(paragraph, num_id=num_id)
+
+    item = next(
+        item
+        for item in list_numbering(document).numbered_paragraphs
+        if item.text == "third grid column"
+    )
+
+    assert item.table_cell == (0, 2, 0)
+
+
+def it_refuses_updating_a_cell_with_a_cross_paragraph_field() -> None:
+    document = docx.Document()
+    cell = document.add_table(rows=1, cols=1).cell(0, 0)
+    cell.paragraphs[0]._p.append(_field_char("begin"))
+    cell.add_paragraph("result")
+    cell.add_paragraph()._p.append(_field_char("end"))
+
+    with pytest.raises(UnsupportedStructureError, match="Word field"):
+        update_cell(document.tables[0], 0, 0, "replacement")
+
+    assert cell.paragraphs[1].text == "result"
+
+
+def it_refuses_filling_an_empty_cell_around_a_typed_control() -> None:
+    document = docx.Document()
+    cell = document.add_table(rows=1, cols=1).cell(0, 0)
+    control = OxmlElement("w:sdt")
+    properties = OxmlElement("w:sdtPr")
+    properties.append(OxmlElement("w14:checkbox"))
+    control.append(properties)
+    control.append(OxmlElement("w:sdtContent"))
+    cell.paragraphs[0]._p.append(control)
+
+    with pytest.raises(UnsupportedStructureError, match="Control.set_value"):
+        update_cell(document.tables[0], 0, 0, "YES")
+
+    assert cell.text == ""
+
+
+def it_updates_a_cell_by_visible_grid_column_after_grid_before() -> None:
+    document = docx.Document()
+    table = document.add_table(rows=1, cols=3)
+    row = table.rows[0]
+    row._tr.remove(row._tr.tc_lst[0])
+    grid_before = OxmlElement("w:gridBefore")
+    grid_before.set(qn("w:val"), "1")
+    row._tr.get_or_add_trPr().append(grid_before)
+    row.cells[0].text = "visible column one"
+
+    update_cell(table, 0, 1, "changed")
+
+    assert row.cells[0].text == "changed"
+    with pytest.raises(TargetNotFoundError, match="has no cell"):
+        update_cell(table, 0, 0, "wrong")
+
+
+def it_reports_a_numbering_level_defined_by_an_instance_override() -> None:
+    document = docx.Document()
+    num_id = ensure_decimal_definition(document)
+    numbering = document.part.numbering_part.element
+    num = next(
+        node for node in numbering.findall(qn("w:num"))
+        if node.get(qn("w:numId")) == str(num_id)
+    )
+    override = OxmlElement("w:lvlOverride")
+    override.set(qn("w:ilvl"), "4")
+    level = OxmlElement("w:lvl")
+    level.set(qn("w:ilvl"), "4")
+    num_format = OxmlElement("w:numFmt")
+    num_format.set(qn("w:val"), "lowerLetter")
+    level_text = OxmlElement("w:lvlText")
+    level_text.set(qn("w:val"), "%5.")
+    level.extend((num_format, level_text))
+    override.append(level)
+    num.append(override)
+    paragraph = document.add_paragraph("override level")
+    apply_numbering(paragraph, num_id=num_id, level=4)
+
+    report = list_numbering(document)
+
+    assert report.numbered_paragraphs[-1].level == 4
+    assert any(level.level == 4 for level in report.definitions[-1].levels)
+
+
+def it_inserts_composed_numbering_before_the_cleanup_marker() -> None:
+    source = docx.Document()
+    source_id = ensure_decimal_definition(source)
+    source_paragraph = source.add_paragraph("Numbered source")
+    apply_numbering(source_paragraph, num_id=source_id)
+    destination = docx.Document()
+    destination.add_paragraph("Destination")
+    ensure_decimal_definition(destination)
+    cleanup = OxmlElement("w:numIdMacAtCleanup")
+    cleanup.set(qn("w:val"), "1")
+    destination.part.numbering_part.element.append(cleanup)
+
+    insert_blocks_from(destination, source, "Numbered source", anchor="Destination")
+
+    assert destination.part.numbering_part.element[-1].tag == qn("w:numIdMacAtCleanup")
+
+
+def it_quotes_a_renamed_styleref_and_carries_its_numbering_dependency() -> None:
+    source = docx.Document()
+    source_num_id = ensure_decimal_definition(source)
+    source_style = source.styles.add_style("ClauseRef", WD_STYLE_TYPE.PARAGRAPH)
+    paragraph_properties = source_style._element.get_or_add_pPr()
+    numbering_properties = OxmlElement("w:numPr")
+    numbering_id = OxmlElement("w:numId")
+    numbering_id.set(qn("w:val"), str(source_num_id))
+    numbering_properties.append(numbering_id)
+    paragraph_properties.append(numbering_properties)
+    source_paragraph = source.add_paragraph("Field source")
+    field = OxmlElement("w:fldSimple")
+    field.set(qn("w:instr"), " STYLEREF ClauseRef ")
+    source_paragraph._p.append(field)
+
+    destination = docx.Document()
+    destination.add_paragraph("Destination")
+    destination.styles.add_style("ClauseRef", WD_STYLE_TYPE.PARAGRAPH)
+    ensure_decimal_definition(destination)
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        "Field source",
+        anchor="Destination",
+        styles="import_renamed",
+    )
+
+    imported_field = next(destination.element.iter(qn("w:fldSimple")))
+    assert imported_field.get(qn("w:instr")) == ' STYLEREF "ClauseRef (imported)" '
+    assert source_num_id in report.numbering_map
+
+
+def it_remaps_bookmark_identifiers_inside_word_formulas() -> None:
+    source = docx.Document()
+    source.add_paragraph("100")
+    create_bookmark(source, find_one(source, "100"), "GrossIncome")
+    formula = OxmlElement("w:fldSimple")
+    formula.set(qn("w:instr"), " =ROUND(GrossIncome,0) ")
+    source.paragraphs[0]._p.append(formula)
+
+    destination = docx.Document()
+    destination.add_paragraph("existing")
+    create_bookmark(destination, find_one(destination, "existing"), "GrossIncome")
+
+    report = insert_blocks_from(
+        destination, source, "100", anchor="existing"
+    )
+
+    imported_formula = next(
+        field
+        for field in destination.element.iter(qn("w:fldSimple"))
+        if "ROUND" in (field.get(qn("w:instr")) or "")
+    )
+    assert report.bookmarks_renamed["GrossIncome"] == "GrossIncome_imported"
+    assert "GrossIncome_imported" in imported_formula.get(qn("w:instr"))
+
+
+def it_renames_bookmarks_that_collide_only_by_case() -> None:
+    source = docx.Document()
+    source.add_paragraph("source term")
+    create_bookmark(source, find_one(source, "source term"), "term")
+    field = OxmlElement("w:fldSimple")
+    field.set(qn("w:instr"), " REF term ")
+    source.paragraphs[0]._p.append(field)
+    destination = docx.Document()
+    destination.add_paragraph("destination term")
+    create_bookmark(destination, find_one(destination, "destination term"), "Term")
+
+    report = insert_blocks_from(
+        destination, source, "source term", anchor="destination term"
+    )
+
+    assert report.bookmarks_renamed["term"] == "term_imported"
+    imported_field = next(
+        node
+        for node in destination.element.iter(qn("w:fldSimple"))
+        if "term_imported" in (node.get(qn("w:instr")) or "")
+    )
+    assert imported_field is not None
+
+
+def it_refuses_a_bookmark_reference_whose_definition_is_outside_the_range() -> None:
+    source = docx.Document()
+    source.add_paragraph("defined term")
+    create_bookmark(source, find_one(source, "defined term"), "Term")
+    reference_paragraph = source.add_paragraph("Reference block")
+    field = OxmlElement("w:fldSimple")
+    field.set(qn("w:instr"), " REF Term ")
+    reference_paragraph._p.append(field)
+    destination = docx.Document()
+    destination.add_paragraph("Destination")
+    before = destination.element.xml
+
+    with pytest.raises(UnsupportedStructureError, match="outside the copied range"):
+        insert_blocks_from(
+            destination, source, "Reference block", anchor="Destination"
+        )
+
+    assert destination.element.xml == before
+
+
+def it_refuses_numbering_that_depends_on_a_linked_style() -> None:
+    source = docx.Document()
+    num_id = ensure_decimal_definition(source)
+    numbering = source.part.numbering_part.element
+    num = next(
+        node
+        for node in numbering.findall(qn("w:num"))
+        if node.get(qn("w:numId")) == str(num_id)
+    )
+    abstract_id = num.find(qn("w:abstractNumId")).get(qn("w:val"))
+    abstract = next(
+        node
+        for node in numbering.findall(qn("w:abstractNum"))
+        if node.get(qn("w:abstractNumId")) == abstract_id
+    )
+    style_link = OxmlElement("w:numStyleLink")
+    style_link.set(qn("w:val"), "NumLinkStyle")
+    abstract.append(style_link)
+    paragraph = source.add_paragraph("Linked numbering")
+    apply_numbering(paragraph, num_id=num_id)
+    destination = docx.Document()
+    destination.add_paragraph("Destination")
+    ensure_decimal_definition(destination)
+    before = destination.element.xml
+
+    with pytest.raises(UnsupportedStructureError, match="linked numbering style"):
+        insert_blocks_from(
+            destination, source, "Linked numbering", anchor="Destination"
+        )
+
+    assert destination.element.xml == before

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -163,6 +163,19 @@ def it_restores_a_seekable_stream_after_commit_error():
     assert stream.tell() == 7
 
 
+def it_refuses_an_append_mode_stream_without_changing_it(tmp_path: Path):
+    destination = tmp_path / "append.docx"
+    original = b"existing destination"
+    destination.write_bytes(original)
+
+    with destination.open("a+b") as stream:
+        stream.seek(0)
+        with pytest.raises(OSError, match="append-mode"):
+            docx.Document().save(stream)
+
+    assert destination.read_bytes() == original
+
+
 def it_validates_the_real_prefix_of_a_nonzero_position_stream(monkeypatch):
     prefix = b"real destination prefix"
     original = prefix + b"existing suffix"

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import docx
+import docx._paperpkg as paperpkg_module
 import docx.opc.package as package_module
 from docx._transaction import rollback_on_error
 from docx.errors import PackageLimitError
@@ -18,6 +19,7 @@ from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.packuri import PackURI
 from docx.opc.part import Part
 from docx.opc.pkgreader import _SerializedRelationships
+from docx.package import patch_save
 from docx.search import find_one
 from docx.story import story_parts
 
@@ -57,6 +59,59 @@ def it_saves_paths_atomically_preserving_mode_and_following_destination_symlink(
     assert stat.S_IMODE(target.stat().st_mode) == 0o640
     assert docx.Document(target).paragraphs[-1].text == "saved through link"
     assert not list(tmp_path.glob("*.partial"))
+
+
+def it_preserves_an_existing_files_mode_without_fchmod(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    target = tmp_path / "target.docx"
+    docx.Document().save(target)
+    target.chmod(0o640)
+    monkeypatch.delattr(package_module.os, "fchmod", raising=False)
+
+    document = docx.Document()
+    document.add_paragraph("portable save")
+    document.save(target)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+    assert docx.Document(target).paragraphs[-1].text == "portable save"
+
+
+def it_refuses_a_dtd_before_parsing_relationship_records():
+    relationships = b"""<!DOCTYPE Relationships [<!ENTITY role "unsafe">]>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="&role;" Target="word/document.xml"/>
+    </Relationships>"""
+
+    with pytest.raises(PackageLimitError, match="prohibited DTD"):
+        _SerializedRelationships.load_from_xml("/", relationships)
+
+
+def it_validates_patch_save_after_final_recompression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.docx"
+    original = docx.Document()
+    original.add_paragraph("before")
+    original.save(source)
+    document = docx.Document(source)
+    document.paragraphs[0].text = "after"
+    destination = tmp_path / "out.docx"
+    destination.write_bytes(b"existing destination")
+
+    unsafe = io.BytesIO()
+    with zipfile.ZipFile(unsafe, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("oversized.xml", b"A" * (17 * 1024 * 1024))
+    monkeypatch.setattr(
+        paperpkg_module,
+        "_deterministic_zip_bytes",
+        lambda _parts, _order: unsafe.getvalue(),
+    )
+
+    with pytest.raises(PackageLimitError, match="compression ratio"):
+        patch_save(source, document, destination)
+
+    assert destination.read_bytes() == b"existing destination"
 
 
 def it_refuses_if_the_destination_symlink_changes_during_save(

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -1,0 +1,345 @@
+"""Focused regressions for practical OPC read/write hardening."""
+
+from __future__ import annotations
+
+import copy
+import io
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import docx
+import docx.opc.package as package_module
+from docx._transaction import rollback_on_error
+from docx.errors import PackageLimitError
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.opc.pkgreader import _SerializedRelationships
+from docx.search import find_one
+from docx.story import story_parts
+
+
+def _document_bytes() -> bytes:
+    stream = io.BytesIO()
+    docx.Document().save(stream)
+    return stream.getvalue()
+
+
+def _rewrite_package(data: bytes, transform) -> bytes:
+    destination = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(data)) as source, zipfile.ZipFile(
+        destination, "w", zipfile.ZIP_DEFLATED
+    ) as output:
+        for name in source.namelist():
+            replacement = transform(name, source.read(name))
+            if replacement is not None:
+                output.writestr(*replacement)
+    return destination.getvalue()
+
+
+def it_saves_paths_atomically_preserving_mode_and_following_destination_symlink(
+    tmp_path: Path,
+):
+    target = tmp_path / "target.docx"
+    target.write_bytes(b"old")
+    target.chmod(0o640)
+    link = tmp_path / "link.docx"
+    link.symlink_to(target.name)
+
+    document = docx.Document()
+    document.add_paragraph("saved through link")
+    document.save(link)
+
+    assert link.is_symlink()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+    assert docx.Document(target).paragraphs[-1].text == "saved through link"
+    assert not list(tmp_path.glob("*.partial"))
+
+
+def it_refuses_if_the_destination_symlink_changes_during_save(
+    tmp_path: Path, monkeypatch
+):
+    old_target = tmp_path / "old.docx"
+    new_target = tmp_path / "new.docx"
+    old_target.write_bytes(b"old target")
+    new_target.write_bytes(b"new target")
+    link = tmp_path / "link.docx"
+    link.symlink_to(old_target.name)
+    validate = package_module._validate_serialized_output
+
+    def validate_and_repoint(source):
+        validate(source)
+        link.unlink()
+        link.symlink_to(new_target.name)
+
+    monkeypatch.setattr(
+        package_module, "_validate_serialized_output", validate_and_repoint
+    )
+
+    with pytest.raises(OSError, match="symlink changed"):
+        docx.Document().save(link)
+
+    assert old_target.read_bytes() == b"old target"
+    assert new_target.read_bytes() == b"new target"
+
+
+def it_restores_a_seekable_stream_after_commit_error():
+    class FailOnce(io.BytesIO):
+        failed = False
+
+        def write(self, data):
+            if not self.failed:
+                self.failed = True
+                super().write(data[:7])
+                raise OSError("commit failed")
+            return super().write(data)
+
+    original = b"prefix and original suffix"
+    stream = FailOnce(original)
+    stream.seek(7)
+
+    with pytest.raises(OSError, match="commit failed"):
+        docx.Document().save(stream)
+
+    assert stream.getvalue() == original
+    assert stream.tell() == 7
+
+
+def it_validates_the_real_prefix_of_a_nonzero_position_stream(monkeypatch):
+    prefix = b"real destination prefix"
+    original = prefix + b"existing suffix"
+    stream = io.BytesIO(original)
+    stream.seek(len(prefix))
+    validate = package_module._validate_serialized_output
+    validated_prefixes = []
+
+    def validate_and_record(source):
+        source.seek(0)
+        validated_prefixes.append(source.read(len(prefix)))
+        source.seek(0)
+        validate(source)
+
+    monkeypatch.setattr(package_module, "_validate_serialized_output", validate_and_record)
+
+    docx.Document().save(stream)
+
+    assert validated_prefixes == [prefix]
+    assert stream.getvalue().startswith(prefix)
+    stream.seek(0)
+    assert isinstance(docx.Document(stream), docx.document.Document)
+
+
+def it_refuses_before_overwriting_an_unreadable_seekable_stream():
+    class Unreadable(io.BytesIO):
+        def read(self, size=-1):
+            raise OSError("existing bytes are unavailable")
+
+    original = b"existing destination"
+    stream = Unreadable(original)
+
+    with pytest.raises(OSError, match="could not be snapshotted"):
+        docx.Document().save(stream)
+
+    assert stream.getvalue() == original
+    assert stream.tell() == 0
+
+
+def it_restores_mutables_base_uri_and_detaches_corrupt_graph_residuals():
+    class Participant:
+        def __init__(self):
+            self.values = ["original"]
+
+    document = docx.Document()
+    participant = Participant()
+    values = participant.values
+    relationships = document.part.rels
+    base_uri = relationships._baseURI
+    rogue = Part(
+        PackURI("/word/rogue.bin"), "application/octet-stream", b"rogue", document.part.package
+    )
+
+    def fail_late():
+        with rollback_on_error(document, participant):
+            values.append("changed")
+            relationships._baseURI = "/corrupt"
+            relationships._target_parts_by_rId["rId-corrupt"] = rogue
+            raise ValueError("late failure")
+
+    with pytest.raises(ValueError, match="late failure"):
+        fail_late()
+
+    assert participant.values is values
+    assert values == ["original"]
+    assert relationships._baseURI == base_uri
+    assert "rId-corrupt" not in relationships._target_parts_by_rId
+    assert rogue.package is None
+
+
+def it_resolves_unambiguous_physical_members_without_case_sensitivity():
+    source = docx.Document()
+    source.add_paragraph("case-insensitive story")
+    stream = io.BytesIO()
+    source.save(stream)
+    data = _rewrite_package(
+        stream.getvalue(),
+        lambda name, blob: (
+            ("WORD/DOCUMENT.XML", blob) if name == "word/document.xml" else (name, blob)
+        ),
+    )
+
+    document = docx.Document(io.BytesIO(data))
+
+    assert story_parts(document)[0] == "word/document.xml"
+    assert find_one(document, "case-insensitive story").story == "word/document.xml"
+
+
+def it_refuses_a_symlinked_member_in_an_expanded_package(tmp_path: Path):
+    expanded = tmp_path / "expanded"
+    with zipfile.ZipFile(io.BytesIO(_document_bytes())) as package:
+        package.extractall(expanded)
+    member = expanded / "word" / "document.xml"
+    outside = tmp_path / "outside-document.xml"
+    member.replace(outside)
+    member.symlink_to(outside)
+
+    with pytest.raises(PackageLimitError, match="symbolic link"):
+        docx.Document(expanded)
+
+
+def it_refuses_duplicate_relationship_ids():
+    relationships = b"""<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="urn:one" Target="one.xml"/>
+      <Relationship Id="rId1" Type="urn:two" Target="two.xml"/>
+    </Relationships>"""
+
+    with pytest.raises(PackageLimitError, match="duplicate Id"):
+        _SerializedRelationships.load_from_xml("/word", relationships)
+
+
+def it_refuses_multiple_main_document_relationships_before_replacing_a_path(
+    tmp_path: Path,
+):
+    destination = tmp_path / "destination.docx"
+    destination.write_bytes(b"original")
+    document = docx.Document()
+    document.part.package.load_rel(
+        RT.OFFICE_DOCUMENT, document.part, "rIdDuplicateMain"
+    )
+
+    with pytest.raises(PackageLimitError, match="multiple officeDocument"):
+        document.save(destination)
+
+    assert destination.read_bytes() == b"original"
+
+
+def it_accepts_xml_comments_in_relationship_parts():
+    def transform(name: str, blob: bytes):
+        if name == "_rels/.rels":
+            blob = blob.replace(b"<Relationship ", b"<!-- retained --><Relationship ", 1)
+        return name, blob
+
+    document = docx.Document(
+        io.BytesIO(_rewrite_package(_document_bytes(), transform))
+    )
+
+    assert document.paragraphs is not None
+
+
+def it_refuses_unexpected_relationship_elements_instead_of_dropping_them():
+    def transform(name: str, blob: bytes):
+        if name == "word/_rels/document.xml.rels":
+            from lxml import etree
+
+            root = etree.fromstring(blob)
+            relationship = next(
+                child for child in root if (child.get("Type") or "").endswith("/styles")
+            )
+            relationship.tag = relationship.tag.replace("Relationship", "Unexpected")
+            blob = etree.tostring(root, encoding="UTF-8", standalone=True)
+        return name, blob
+
+    with pytest.raises(PackageLimitError, match="unexpected element"):
+        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+
+def it_validates_case_insensitive_content_types_without_losing_duplicates():
+    def transform(name: str, blob: bytes):
+        if name != "[Content_Types].xml":
+            return name, blob
+        from lxml import etree
+
+        root = etree.fromstring(blob)
+        override = next(child for child in root if child.get("PartName"))
+        duplicate = copy.deepcopy(override)
+        duplicate.set("PartName", override.get("PartName").upper())
+        root.append(duplicate)
+        return (
+            "[CONTENT_TYPES].XML",
+            etree.tostring(root, encoding="UTF-8", standalone=True),
+        )
+
+    with pytest.raises(PackageLimitError, match="ambiguous Override"):
+        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+
+def it_refuses_a_known_relationship_role_with_the_wrong_content_type():
+    def transform(name: str, blob: bytes):
+        if name == "[Content_Types].xml":
+            blob = blob.replace(
+                b"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                b"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+            )
+        return name, blob
+
+    with pytest.raises(PackageLimitError, match="invalid content type"):
+        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+
+def it_refuses_a_relationship_to_a_missing_package_part():
+    data = _rewrite_package(
+        _document_bytes(),
+        lambda name, blob: None if name == "word/styles.xml" else (name, blob),
+    )
+
+    with pytest.raises(PackageLimitError, match="targets missing package part"):
+        docx.Document(io.BytesIO(data))
+
+
+def it_refuses_a_relationship_target_without_a_declared_content_type():
+    def transform(name: str, blob: bytes):
+        if name == "[Content_Types].xml":
+            from lxml import etree
+
+            root = etree.fromstring(blob)
+            for declaration in tuple(root):
+                if declaration.get("PartName") == "/word/styles.xml" or declaration.get(
+                    "Extension"
+                ) == "xml":
+                    root.remove(declaration)
+            blob = etree.tostring(root, encoding="UTF-8", standalone=True)
+        return name, blob
+
+    with pytest.raises(PackageLimitError, match="no declared content type"):
+        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+
+def it_retains_default_creation_for_missing_optional_core_properties():
+    def transform(name: str, blob: bytes):
+        if name == "docProps/core.xml":
+            return None
+        if name == "_rels/.rels":
+            from lxml import etree
+
+            root = etree.fromstring(blob)
+            for relationship in tuple(root):
+                if relationship.get("Target") == "docProps/core.xml":
+                    root.remove(relationship)
+            blob = etree.tostring(root, encoding="UTF-8", standalone=True)
+        return name, blob
+
+    document = docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+    assert document.core_properties.title == "Word Document"

--- a/tests/paper/test_practical_review_hardening.py
+++ b/tests/paper/test_practical_review_hardening.py
@@ -5,7 +5,13 @@ import copy
 import pytest
 
 import docx
-from docx.commentops import reply
+import docx.search as search_module
+from docx.commentops import (
+    _comments_extended_root,
+    is_resolved,
+    reply,
+    resolve,
+)
 from docx.controls import iter_controls
 from docx.errors import DocumentProtectedError, TargetNotFoundError, UnsupportedStructureError
 from docx.oxml import OxmlElement, parse_xml
@@ -15,6 +21,19 @@ from docx.shared import Inches
 
 
 class DescribePracticalReviewHardening:
+    def it_applies_comment_range_preflight_to_document_add_comment(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        run = paragraph.add_run("field result")
+        begin = OxmlElement("w:fldChar")
+        begin.set(qn("w:fldCharType"), "begin")
+        run._r.insert(0, begin)
+
+        with pytest.raises(UnsupportedStructureError, match="field boundary"):
+            document.add_comment(run, "review", author="A")
+
+        assert len(document.comments) == 0
+
     def it_keeps_a_span_live_after_an_unrelated_preceding_insert(self):
         document = docx.Document()
         target = document.add_paragraph("target")
@@ -45,6 +64,55 @@ class DescribePracticalReviewHardening:
         with pytest.raises(TargetNotFoundError, match="forced stale"):
             replace_all(document, "same", "changed")
         assert document.element.xml == before
+
+    def it_shares_one_freshness_census_across_a_replace_batch(self, monkeypatch):
+        document = docx.Document()
+        for _ in range(100):
+            document.add_paragraph("target")
+        original = search_module._story_atoms
+        calls = 0
+
+        def counted(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(search_module, "_story_atoms", counted)
+
+        result = replace_all(document, "target", "changed")
+
+        assert result.replaced_count == 100
+        assert calls == 2
+
+    def it_treats_edit_none_as_unrestricted(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        protection = OxmlElement("w:documentProtection")
+        protection.set(qn("w:edit"), "none")
+        protection.set(qn("w:enforcement"), "1")
+        document.settings.element.append(protection)
+
+        find_one(document, "target").replace("changed")
+
+        assert document.paragraphs[0].text == "changed"
+
+    def it_matches_comment_para_ids_case_insensitively(self):
+        document = docx.Document()
+        comment = document.comments.add_comment("review")
+        comment.paragraphs[-1]._p.set(qn("w14:paraId"), "abcdef12")
+        root = _comments_extended_root(document, create=True)
+        root.append(
+            parse_xml(
+                '<w15:commentEx xmlns:w15="http://schemas.microsoft.com/'
+                'office/word/2012/wordml" w15:paraId="ABCDEF12" w15:done="1"/>'
+            )
+        )
+
+        assert is_resolved(document, comment) is True
+        resolve(document, comment, resolved=False)
+
+        assert len(root) == 1
+        assert is_resolved(document, comment) is False
 
     def it_refuses_generic_replace_on_a_typed_control_surface(self):
         document = docx.Document()

--- a/tests/paper/test_practical_review_hardening.py
+++ b/tests/paper/test_practical_review_hardening.py
@@ -1,0 +1,241 @@
+"""Focused regressions for the practical review-hardening proposal."""
+
+import copy
+
+import pytest
+
+import docx
+from docx.commentops import reply
+from docx.controls import iter_controls
+from docx.errors import DocumentProtectedError, TargetNotFoundError, UnsupportedStructureError
+from docx.oxml import OxmlElement, parse_xml
+from docx.oxml.ns import nsdecls, qn
+from docx.search import Span, find_one, replace_all
+from docx.shared import Inches
+
+
+class DescribePracticalReviewHardening:
+    def it_keeps_a_span_live_after_an_unrelated_preceding_insert(self):
+        document = docx.Document()
+        target = document.add_paragraph("target")
+        span = find_one(document, "target")
+        target._p.addprevious(parse_xml(f'<w:p {nsdecls("w")}><w:r><w:t>other</w:t></w:r></w:p>'))
+
+        span.replace("changed")
+
+        assert document.paragraphs[-1].text == "changed"
+
+    def it_filters_noops_and_rolls_back_a_stale_replace_batch(self, monkeypatch):
+        document = docx.Document()
+        document.add_paragraph("same same")
+        assert replace_all(document, "same", "same").replaced_count == 0
+
+        original = Span.replace
+        calls = 0
+
+        def fail_second(self, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise TargetNotFoundError("forced stale target")
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Span, "replace", fail_second)
+        before = document.element.xml
+        with pytest.raises(TargetNotFoundError, match="forced stale"):
+            replace_all(document, "same", "changed")
+        assert document.element.xml == before
+
+    def it_refuses_generic_replace_on_a_typed_control_surface(self):
+        document = docx.Document()
+        document.element.body.insert(
+            0,
+            parse_xml(
+                f"<w:p {nsdecls('w', 'w14')}><w:sdt><w:sdtPr>"
+                "<w14:checkbox/></w:sdtPr><w:sdtContent><w:r><w:t>box</w:t>"
+                "</w:r></w:sdtContent></w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="checkbox control"):
+            find_one(document, "box").replace("changed")
+
+    def it_refuses_generic_replace_on_a_locked_text_control(self):
+        document = docx.Document()
+        document.element.body.insert(
+            0,
+            parse_xml(
+                f'<w:p {nsdecls("w")}><w:sdt><w:sdtPr>'
+                '<w:text/><w:lock w:val="contentLocked"/></w:sdtPr>'
+                '<w:sdtContent><w:r><w:t>locked</w:t></w:r></w:sdtContent></w:sdt></w:p>'
+            ),
+        )
+
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            find_one(document, "locked").replace("changed")
+
+        control = next(iter_controls(document))
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            control.set_value("changed")
+
+    def it_refuses_hidden_scrub_that_would_hollow_a_bookmark(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph._p.append(parse_xml(f'<w:bookmarkStart {nsdecls("w")} w:id="1" w:name="Term"/>'))
+        run = paragraph.add_run("hidden")
+        run.font.hidden = True
+        paragraph._p.append(parse_xml(f'<w:bookmarkEnd {nsdecls("w")} w:id="1"/>'))
+
+        with pytest.raises(UnsupportedStructureError, match="hollow out.*bookmark"):
+            document.scrub(
+                comments=False,
+                metadata=False,
+                track_changes_setting=False,
+                hidden_text=True,
+            )
+        assert paragraph.text == "hidden"
+
+    def it_refuses_a_comment_collection_after_scrub(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        comments = document.comments
+        comments.add_comment("review", author="A")
+        document.scrub(metadata=False, track_changes_setting=False)
+
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            comments.add_comment("late", author="A")
+
+    def it_refuses_a_cached_comment_after_scrub(self):
+        document = docx.Document()
+        comment = document.comments.add_comment("review", author="A")
+        document.scrub(metadata=False, track_changes_setting=False)
+
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            comment.add_paragraph("late")
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            comment.add_table(1, 1, Inches(1))
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            comment.author = "Late Author"
+
+    def it_applies_document_protection_to_inherited_comment_mutators(self):
+        document = docx.Document()
+        comments = document.comments
+        protection = OxmlElement("w:documentProtection")
+        protection.set(qn("w:edit"), "readOnly")
+        protection.set(qn("w:enforcement"), "1")
+        document.settings.element.append(protection)
+
+        with pytest.raises(DocumentProtectedError):
+            comments.add_comment("blocked", author="A")
+
+    def it_rolls_back_inherited_comment_authoring_on_invalid_text(self):
+        document = docx.Document()
+        comments = document.comments
+
+        with pytest.raises(ValueError, match="XML"):
+            comments.add_comment("invalid \x00 text", author="A")
+
+        assert len(comments) == 0
+
+    def it_refuses_a_comment_range_that_contains_a_field_boundary(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        run = paragraph.add_run()
+        begin = OxmlElement("w:fldChar")
+        begin.set(qn("w:fldCharType"), "begin")
+        run._r.append(begin)
+        run.add_text("target")
+
+        with pytest.raises(UnsupportedStructureError, match="field boundary"):
+            find_one(document, "target").comment("review", author="A")
+
+        assert len(document.comments) == 0
+
+    def it_revalidates_an_existing_comment_range_before_replying(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("target")
+        comment = find_one(document, "target").comment("review", author="A")
+        begin = OxmlElement("w:fldChar")
+        begin.set(qn("w:fldCharType"), "begin")
+        paragraph.runs[0]._r.insert(0, begin)
+
+        with pytest.raises(UnsupportedStructureError, match="field boundary"):
+            reply(document, comment, "late", author="B")
+
+        assert len(document.comments) == 1
+
+    def it_refuses_an_ambiguous_duplicate_comment_anchor(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("target")
+        comment = find_one(document, "target").comment("review", author="A")
+        start = next(paragraph._p.iter(qn("w:commentRangeStart")))
+        start.addnext(copy.deepcopy(start))
+
+        with pytest.raises(UnsupportedStructureError, match="duplicate anchor"):
+            reply(document, comment, "late", author="B")
+
+        assert len(document.comments) == 1
+
+    def it_honors_control_locks_when_scrubbing_hidden_text(self):
+        document = docx.Document()
+        document.element.body.insert(
+            0,
+            parse_xml(
+                f'<w:p {nsdecls("w")}><w:sdt><w:sdtPr>'
+                '<w:text/><w:lock w:val="contentLocked"/></w:sdtPr>'
+                '<w:sdtContent><w:r><w:rPr><w:vanish/></w:rPr>'
+                '<w:t>hidden</w:t></w:r></w:sdtContent></w:sdt></w:p>'
+            ),
+        )
+
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            document.scrub(
+                comments=False,
+                metadata=False,
+                track_changes_setting=False,
+                hidden_text=True,
+            )
+
+    def it_refuses_hidden_scrub_inside_alternate_content(self):
+        document = docx.Document()
+        document.element.body.insert(
+            0,
+            parse_xml(
+                f'<w:p {nsdecls("w", "w14")} '
+                'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">'
+                '<mc:AlternateContent>'
+                '<mc:Choice Requires="w14"><w:r><w:rPr><w:vanish/></w:rPr>'
+                '<w:t>choice hidden</w:t></w:r></mc:Choice>'
+                '<mc:Fallback><w:r><w:rPr><w:vanish/></w:rPr>'
+                '<w:t>fallback hidden</w:t></w:r></mc:Fallback>'
+                '</mc:AlternateContent></w:p>'
+            ),
+        )
+
+        with pytest.raises(UnsupportedStructureError, match="AlternateContent"):
+            document.scrub(
+                comments=False,
+                metadata=False,
+                track_changes_setting=False,
+                hidden_text=True,
+            )
+
+        xml = document.element.xml
+        assert "choice hidden" in xml
+        assert "fallback hidden" in xml
+
+    def it_does_not_let_an_empty_run_mask_bookmark_hollowing(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph._p.append(parse_xml(f'<w:bookmarkStart {nsdecls("w")} w:id="1" w:name="Term"/>'))
+        hidden = paragraph.add_run("hidden")
+        hidden.font.hidden = True
+        paragraph.add_run("")
+        paragraph._p.append(parse_xml(f'<w:bookmarkEnd {nsdecls("w")} w:id="1"/>'))
+
+        with pytest.raises(UnsupportedStructureError, match="hollow out.*bookmark"):
+            document.scrub(
+                comments=False,
+                metadata=False,
+                track_changes_setting=False,
+                hidden_text=True,
+            )

--- a/tests/paper/test_regressions_editing.py
+++ b/tests/paper/test_regressions_editing.py
@@ -239,7 +239,7 @@ class DescribeCrossParagraphCommentAnchors:
             [p1.runs[0], p2.runs[0]], text="both", author="Carol QA"
         )
         assert anchored_text(document, comment) == (
-            "First body paragraph with perfectly ordinary text."
+            "First body paragraph with perfectly ordinary text.\n"
             "Second body paragraph, equally unremarkable."
         )
 

--- a/tests/paper/test_regressions_pipeline.py
+++ b/tests/paper/test_regressions_pipeline.py
@@ -326,7 +326,6 @@ class DescribeCompareRegressions:
         # region 1 crosses the tab (refuses); region 2 after it succeeds
         # first in reverse order — the fallback must start from pristine
         result, a, b = _compare_pair(build("c d"), build("c D"), tmp_path)
-        xml = result.document.element.xml
         body = result.document.element.body
         for deletion in body.iter(qn("w:del")):
             assert deletion.find(f".//{qn('w:del')}") is None
@@ -336,7 +335,7 @@ class DescribeCompareRegressions:
         result.document.revisions.accept_all()
         assert _visible(result.document) == _visible(docx.Document(b))
 
-    def it_reports_field_flattening_as_a_finding(self, tmp_path: Path):
+    def it_refuses_field_result_changes_instead_of_flattening(self, tmp_path: Path):
         def build(result_text):
             def _build(document):
                 paragraph = document.add_paragraph()
@@ -364,12 +363,10 @@ class DescribeCompareRegressions:
 
             return _build
 
-        result, _a, b = _compare_pair(
-            build("June 1, 2026"), build("July 9, 2026"), tmp_path
-        )
-        assert any(f.kind == "field_flattened" for f in result.findings)
-        result.document.revisions.accept_all()
-        assert _visible(result.document) == _visible(docx.Document(b))
+        with pytest.raises(UnsupportedStructureError, match="cannot safely redline"):
+            _compare_pair(
+                build("June 1, 2026"), build("July 9, 2026"), tmp_path
+            )
 
     def it_stamps_one_edit_with_one_timestamp(self, tmp_path: Path):
         naive = dt.datetime(2026, 1, 2, 3, 4, 5)  # NAIVE on purpose
@@ -429,7 +426,7 @@ class DescribeCompositionRegressions:
 
     def it_remaps_numbering_referenced_only_by_an_imported_style(self, tmp_path):
         from docx.composition import insert_blocks_from
-        from docx.numbering import ensure_decimal_definition, list_numbering
+        from docx.numbering import ensure_decimal_definition
 
         source = docx.Document()
         source_num = ensure_decimal_definition(source)

--- a/tests/paper/test_resolution.py
+++ b/tests/paper/test_resolution.py
@@ -217,12 +217,19 @@ class DescribeRowRevisionResolution:
         assert len(reopened.tables[0].rows) == 3  # row kept, marker gone
         assert "row_insertion" not in {r.revision_type for r in reopened.revisions}
 
-    def it_rejects_a_single_row_insertion_removing_the_row(self, tmp_path: Path):
+    def it_refuses_a_single_row_insertion_that_would_consume_cell_revisions(
+        self, tmp_path: Path
+    ):
         document = _doc(ROW_REVISIONS)
         row_ins = next(
             r for r in document.revisions if r.revision_type == "row_insertion"
         )
-        row_ins.reject()
+        before = document.element.xml
+        with pytest.raises(UnsupportedStructureError, match="nested unselected"):
+            row_ins.reject()
+        assert document.element.xml == before
+
+        assert document.revisions.reject_all(author="Alice Editor") == 5
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         # inserted row gone; the deleted-marked row remains (its delText
         # content is invisible to upstream cell.text — still pending)
@@ -529,4 +536,3 @@ class DescribeExoticTypesStayRefused:
         with pytest.raises(UnsupportedStructureError, match="not resolve"):
             revisions.accept_all()
         assert revisions.remaining_unsupported() == {expected_type: 1}
-

--- a/tests/paper/test_scrub.py
+++ b/tests/paper/test_scrub.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import zipfile
 from pathlib import Path
 
 import pytest
 
 import docx
 from docx.errors import DocumentProtectedError, UnsupportedStructureError
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.protection import acknowledge_protection, protection_status
 from docx.revision import _remaining_markup
 
@@ -63,6 +65,27 @@ class DescribeFinalize:
 
 
 class DescribeScrub:
+    def it_removes_package_root_comment_relationships(self, tmp_path: Path):
+        document = docx.Document()
+        document.comments.add_comment("review")
+        comments_part = document.part.part_related_by(RT.COMMENTS)
+        document.part.package.relate_to(comments_part, RT.COMMENTS)
+
+        report = document.scrub(
+            metadata=False,
+            track_changes_setting=False,
+        )
+        output = tmp_path / "out.docx"
+        document.save(output)
+
+        assert "word/comments.xml" in report.removed_parts
+        assert all(
+            rel.reltype != RT.COMMENTS
+            for rel in document.part.package.rels.values()
+        )
+        with zipfile.ZipFile(output) as archive:
+            assert "word/comments.xml" not in archive.namelist()
+
     def it_scrubs_the_finalized_gauntlet_clean(self, tmp_path: Path):
         document = _doc(GAUNTLET)
         document.finalize()

--- a/tests/paper/test_scrub.py
+++ b/tests/paper/test_scrub.py
@@ -166,6 +166,31 @@ class DescribeScrub:
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert len(reopened.comments) > 0
 
+    def it_keeps_hidden_text_in_a_strict_comments_part_when_asked(self):
+        document = docx.Document()
+        comment = document.comments.add_comment(
+            "private review note", author="Reviewer"
+        )
+        hidden_run = comment.paragraphs[0].runs[0]
+        hidden_run.font.hidden = True
+        relationship = next(
+            rel for rel in document.part.rels.values() if rel.reltype == RT.COMMENTS
+        )
+        relationship._reltype = (  # noqa: SLF001 - strict-package fixture
+            "http://purl.oclc.org/ooxml/officeDocument/relationships/comments"
+        )
+
+        report = document.scrub(
+            comments=False,
+            metadata=False,
+            track_changes_setting=False,
+            hidden_text=True,
+        )
+
+        assert report.hidden_runs_removed == 0
+        assert hidden_run._r.getparent() is not None  # noqa: SLF001
+        assert comment.text == "private review note"
+
     def it_removes_hidden_text_only_on_explicit_request(self, tmp_path: Path):
         from docx.oxml import parse_xml
         from docx.oxml.ns import nsdecls

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -77,9 +77,7 @@ class DescribeUpdateCell:
 
     def it_supports_tracked_updates(self, tmp_path: Path):
         document, table = _doc_with_simple_table()
-        result = update_cell(
-            table, 0, 0, "cell 99", tracked=True, author="Carol QA", date=FROZEN
-        )
+        result = update_cell(table, 0, 0, "cell 99", tracked=True, author="Carol QA", date=FROZEN)
         assert result.tracked and result.revision_ids
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert reopened.tables[0].cell(0, 0).text.startswith("cell")
@@ -216,7 +214,8 @@ class DescribeListNumbering:
         import json
 
         payload = list_numbering(_doc(NUMBERING)).to_dict()
-        assert payload["schema"] == "paper_numbering" and payload["version"] == 1
+        assert payload["schema"] == "paper_numbering"
+        assert payload["version"] == 2
         assert json.dumps(payload) == json.dumps(list_numbering(_doc(NUMBERING)).to_dict())
 
 

--- a/tests/paper/test_verbs.py
+++ b/tests/paper/test_verbs.py
@@ -107,7 +107,7 @@ class DescribeContentControls:
         _add_sdt(
             document,
             f'<w:p {W14}><w:sdt><w:sdtPr><w:tag w:val="signed"/>'
-            "<w:date/></w:sdtPr>"
+            '<w:date><w:dateFormat w:val="yyyy-MM-dd"/></w:date></w:sdtPr>'
             "<w:sdtContent><w:r><w:t>pick a date</w:t></w:r></w:sdtContent>"
             "</w:sdt></w:p>",
         )

--- a/tests/parts/test_comments.py
+++ b/tests/parts/test_comments.py
@@ -64,6 +64,13 @@ class DescribeCommentsPart:
         )
         assert len(comments_part.element) == 0
 
+    def it_adds_a_comment_to_a_standalone_default_part(self):
+        comments_part = CommentsPart.default(Package())
+
+        comment = comments_part.comments.add_comment("standalone")
+
+        assert comment.text == "standalone"
+
     # -- fixtures --------------------------------------------------------------------------------
 
     @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 ]
 
 [[package]]
-name = "python-docx"
+name = "paper-docx"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,354 +1,472 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
 
 [[package]]
 name = "alabaster"
-version = "0.7.13"
+version = "0.7.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz", hash = "sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2", size = 11454 }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl", hash = "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3", size = 13857 },
+    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
 ]
 
 [[package]]
 name = "babel"
-version = "2.17.0"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537 },
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
 ]
 
 [[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406 }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181 },
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.13.4"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285 },
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
 name = "behave"
-version = "1.2.6"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "colorama" },
+    { name = "cucumber-expressions", version = "18.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cucumber-expressions", version = "20.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "cucumber-tag-expressions", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cucumber-tag-expressions", version = "10.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "parse" },
     { name = "parse-type" },
     { name = "six" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "win-unicode-console", marker = "python_full_version < '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/4b/d0a8c23b6c8985e5544ea96d27105a273ea22051317f850c2cdbf2029fe4/behave-1.2.6.tar.gz", hash = "sha256:b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86", size = 701696 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/51/f37442fe648b3e35ecf69bee803fa6db3f74c5b46d6c882d0bc5654185a2/behave-1.3.3.tar.gz", hash = "sha256:2b8f4b64ed2ea756a5a2a73e23defc1c4631e9e724c499e46661778453ebaf51", size = 892639, upload-time = "2025-09-04T12:12:02.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/6c/ec9169548b6c4cb877aaa6773408ca08ae2a282805b958dbc163cb19822d/behave-1.2.6-py2.py3-none-any.whl", hash = "sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c", size = 136779 },
+    { url = "https://files.pythonhosted.org/packages/63/71/06f74ffed6d74525c5cd6677c97bd2df0b7649e47a249cf6a0c2038083b2/behave-1.3.3-py2.py3-none-any.whl", hash = "sha256:89bdb62af8fb9f147ce245736a5de69f025e5edfb66f1fbe16c5007493f842c0", size = 223594, upload-time = "2025-09-04T12:12:00.3Z" },
 ]
 
 [[package]]
 name = "cachetools"
-version = "6.0.0"
+version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/b0/f539a1ddff36644c28a61490056e5bae43bd7386d9f9c69beae2d7e7d6d1/cachetools-6.0.0.tar.gz", hash = "sha256:f225782b84438f828328fc2ad74346522f27e5b1440f4e9fd18b20ebfd1aa2cf", size = 30160 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c3/8bb087c903c95a570015ce84e0c23ae1d79f528c349cbc141b5c4e250293/cachetools-6.0.0-py3-none-any.whl", hash = "sha256:82e73ba88f7b30228b5507dce1a1f878498fc669d972aef2dde4f3a3c24f103e", size = 10964 },
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024 },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188 },
-    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571 },
-    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687 },
-    { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211 },
-    { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325 },
-    { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784 },
-    { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564 },
-    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259 },
-    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200 },
-    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235 },
-    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721 },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242 },
-    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999 },
-    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242 },
-    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604 },
-    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
-    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
-    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
-    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
-    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
-    { url = "https://files.pythonhosted.org/packages/ed/65/25a8dc32c53bf5b7b6c2686b42ae2ad58743f7ff644844af7cdb29b49361/cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8", size = 424910 },
-    { url = "https://files.pythonhosted.org/packages/42/7a/9d086fab7c66bd7c4d0f27c57a1b6b068ced810afc498cc8c49e0088661c/cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576", size = 447200 },
-    { url = "https://files.pythonhosted.org/packages/da/63/1785ced118ce92a993b0ec9e0d0ac8dc3e5dbfbcaa81135be56c69cabbb6/cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87", size = 454565 },
-    { url = "https://files.pythonhosted.org/packages/74/06/90b8a44abf3556599cdec107f7290277ae8901a58f75e6fe8f970cd72418/cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0", size = 435635 },
-    { url = "https://files.pythonhosted.org/packages/bd/62/a1f468e5708a70b1d86ead5bab5520861d9c7eacce4a885ded9faa7729c3/cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3", size = 445218 },
-    { url = "https://files.pythonhosted.org/packages/5b/95/b34462f3ccb09c2594aa782d90a90b045de4ff1f70148ee79c69d37a0a5a/cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595", size = 460486 },
-    { url = "https://files.pythonhosted.org/packages/fc/fc/a1e4bebd8d680febd29cf6c8a40067182b64f00c7d105f8f26b5bc54317b/cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a", size = 437911 },
-    { url = "https://files.pythonhosted.org/packages/e6/c3/21cab7a6154b6a5ea330ae80de386e7665254835b9e98ecc1340b3a7de9a/cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e", size = 460632 },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+    { url = "https://files.pythonhosted.org/packages/88/a9/02cae418ec4beb282ace11958d9d4737793439d561fadc7e6d56f2e2b354/cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46", size = 211107, upload-time = "2026-07-06T21:32:12.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/30/c806937ed5e4c2c7ac30d9d6b76b5dc57ff8b75d83800d9bb11a8253cf2a/cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2", size = 218733, upload-time = "2026-07-06T21:32:13.67Z" },
+    { url = "https://files.pythonhosted.org/packages/38/66/04781a77b411f0bb5b234d62c1814754ab75ebe455ccff1b08e8d7aae98f/cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0", size = 218760, upload-time = "2026-07-06T21:32:17.98Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9a/bb1d5ed9c3fcae158e9f6391bf309c95d98c2ac37ed56573228471d0af5e/cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43", size = 221230, upload-time = "2026-07-06T21:32:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/3c1409cdd26094efacd1c36c66e0a6eb9d4296e4fd4f9901b8b2042f4323/cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c", size = 213524, upload-time = "2026-07-06T21:32:20.828Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/74dfb7c3fc6ebbd408038476bd4c1d7e925c62614e7b9c534ecc34218288/cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd", size = 220341, upload-time = "2026-07-06T21:32:21.9Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.2"
+version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367 }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/28/9901804da60055b406e1a1c5ba7aac1276fb77f1dde635aabfc7fd84b8ab/charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941", size = 201818 },
-    { url = "https://files.pythonhosted.org/packages/d9/9b/892a8c8af9110935e5adcbb06d9c6fe741b6bb02608c6513983048ba1a18/charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd", size = 144649 },
-    { url = "https://files.pythonhosted.org/packages/7b/a5/4179abd063ff6414223575e008593861d62abfc22455b5d1a44995b7c101/charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6", size = 155045 },
-    { url = "https://files.pythonhosted.org/packages/3b/95/bc08c7dfeddd26b4be8c8287b9bb055716f31077c8b0ea1cd09553794665/charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d", size = 147356 },
-    { url = "https://files.pythonhosted.org/packages/a8/2d/7a5b635aa65284bf3eab7653e8b4151ab420ecbae918d3e359d1947b4d61/charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86", size = 149471 },
-    { url = "https://files.pythonhosted.org/packages/ae/38/51fc6ac74251fd331a8cfdb7ec57beba8c23fd5493f1050f71c87ef77ed0/charset_normalizer-3.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c", size = 151317 },
-    { url = "https://files.pythonhosted.org/packages/b7/17/edee1e32215ee6e9e46c3e482645b46575a44a2d72c7dfd49e49f60ce6bf/charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0", size = 146368 },
-    { url = "https://files.pythonhosted.org/packages/26/2c/ea3e66f2b5f21fd00b2825c94cafb8c326ea6240cd80a91eb09e4a285830/charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef", size = 154491 },
-    { url = "https://files.pythonhosted.org/packages/52/47/7be7fa972422ad062e909fd62460d45c3ef4c141805b7078dbab15904ff7/charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6", size = 157695 },
-    { url = "https://files.pythonhosted.org/packages/2f/42/9f02c194da282b2b340f28e5fb60762de1151387a36842a92b533685c61e/charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366", size = 154849 },
-    { url = "https://files.pythonhosted.org/packages/67/44/89cacd6628f31fb0b63201a618049be4be2a7435a31b55b5eb1c3674547a/charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db", size = 150091 },
-    { url = "https://files.pythonhosted.org/packages/1f/79/4b8da9f712bc079c0f16b6d67b099b0b8d808c2292c937f267d816ec5ecc/charset_normalizer-3.4.2-cp310-cp310-win32.whl", hash = "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a", size = 98445 },
-    { url = "https://files.pythonhosted.org/packages/7d/d7/96970afb4fb66497a40761cdf7bd4f6fca0fc7bafde3a84f836c1f57a926/charset_normalizer-3.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509", size = 105782 },
-    { url = "https://files.pythonhosted.org/packages/05/85/4c40d00dcc6284a1c1ad5de5e0996b06f39d8232f1031cd23c2f5c07ee86/charset_normalizer-3.4.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2", size = 198794 },
-    { url = "https://files.pythonhosted.org/packages/41/d9/7a6c0b9db952598e97e93cbdfcb91bacd89b9b88c7c983250a77c008703c/charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645", size = 142846 },
-    { url = "https://files.pythonhosted.org/packages/66/82/a37989cda2ace7e37f36c1a8ed16c58cf48965a79c2142713244bf945c89/charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd", size = 153350 },
-    { url = "https://files.pythonhosted.org/packages/df/68/a576b31b694d07b53807269d05ec3f6f1093e9545e8607121995ba7a8313/charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8", size = 145657 },
-    { url = "https://files.pythonhosted.org/packages/92/9b/ad67f03d74554bed3aefd56fe836e1623a50780f7c998d00ca128924a499/charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f", size = 147260 },
-    { url = "https://files.pythonhosted.org/packages/a6/e6/8aebae25e328160b20e31a7e9929b1578bbdc7f42e66f46595a432f8539e/charset_normalizer-3.4.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7", size = 149164 },
-    { url = "https://files.pythonhosted.org/packages/8b/f2/b3c2f07dbcc248805f10e67a0262c93308cfa149a4cd3d1fe01f593e5fd2/charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9", size = 144571 },
-    { url = "https://files.pythonhosted.org/packages/60/5b/c3f3a94bc345bc211622ea59b4bed9ae63c00920e2e8f11824aa5708e8b7/charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544", size = 151952 },
-    { url = "https://files.pythonhosted.org/packages/e2/4d/ff460c8b474122334c2fa394a3f99a04cf11c646da895f81402ae54f5c42/charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82", size = 155959 },
-    { url = "https://files.pythonhosted.org/packages/a2/2b/b964c6a2fda88611a1fe3d4c400d39c66a42d6c169c924818c848f922415/charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0", size = 153030 },
-    { url = "https://files.pythonhosted.org/packages/59/2e/d3b9811db26a5ebf444bc0fa4f4be5aa6d76fc6e1c0fd537b16c14e849b6/charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5", size = 148015 },
-    { url = "https://files.pythonhosted.org/packages/90/07/c5fd7c11eafd561bb51220d600a788f1c8d77c5eef37ee49454cc5c35575/charset_normalizer-3.4.2-cp311-cp311-win32.whl", hash = "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a", size = 98106 },
-    { url = "https://files.pythonhosted.org/packages/a8/05/5e33dbef7e2f773d672b6d79f10ec633d4a71cd96db6673625838a4fd532/charset_normalizer-3.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28", size = 105402 },
-    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936 },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790 },
-    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924 },
-    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626 },
-    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567 },
-    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957 },
-    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408 },
-    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399 },
-    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815 },
-    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537 },
-    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565 },
-    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357 },
-    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776 },
-    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622 },
-    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435 },
-    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653 },
-    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231 },
-    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243 },
-    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442 },
-    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147 },
-    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057 },
-    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454 },
-    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174 },
-    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166 },
-    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064 },
-    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641 },
-    { url = "https://files.pythonhosted.org/packages/28/f8/dfb01ff6cc9af38552c69c9027501ff5a5117c4cc18dcd27cb5259fa1888/charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4", size = 201671 },
-    { url = "https://files.pythonhosted.org/packages/32/fb/74e26ee556a9dbfe3bd264289b67be1e6d616329403036f6507bb9f3f29c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7", size = 144744 },
-    { url = "https://files.pythonhosted.org/packages/ad/06/8499ee5aa7addc6f6d72e068691826ff093329fe59891e83b092ae4c851c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836", size = 154993 },
-    { url = "https://files.pythonhosted.org/packages/f1/a2/5e4c187680728219254ef107a6949c60ee0e9a916a5dadb148c7ae82459c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597", size = 147382 },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/56aca740dda674f0cc1ba1418c4d84534be51f639b5f98f538b332dc9a95/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7", size = 149536 },
-    { url = "https://files.pythonhosted.org/packages/53/13/db2e7779f892386b589173dd689c1b1e304621c5792046edd8a978cbf9e0/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f", size = 151349 },
-    { url = "https://files.pythonhosted.org/packages/69/35/e52ab9a276186f729bce7a0638585d2982f50402046e4b0faa5d2c3ef2da/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba", size = 146365 },
-    { url = "https://files.pythonhosted.org/packages/a6/d8/af7333f732fc2e7635867d56cb7c349c28c7094910c72267586947561b4b/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12", size = 154499 },
-    { url = "https://files.pythonhosted.org/packages/7a/3d/a5b2e48acef264d71e036ff30bcc49e51bde80219bb628ba3e00cf59baac/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518", size = 157735 },
-    { url = "https://files.pythonhosted.org/packages/85/d8/23e2c112532a29f3eef374375a8684a4f3b8e784f62b01da931186f43494/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5", size = 154786 },
-    { url = "https://files.pythonhosted.org/packages/c7/57/93e0169f08ecc20fe82d12254a200dfaceddc1c12a4077bf454ecc597e33/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3", size = 150203 },
-    { url = "https://files.pythonhosted.org/packages/2c/9d/9bf2b005138e7e060d7ebdec7503d0ef3240141587651f4b445bdf7286c2/charset_normalizer-3.4.2-cp39-cp39-win32.whl", hash = "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471", size = 98436 },
-    { url = "https://files.pythonhosted.org/packages/6d/24/5849d46cf4311bbf21b424c443b09b459f5b436b1558c04e45dbb7cc478b/charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e", size = 105772 },
-    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626 },
+    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
+    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ec/81e22253f4b7091eca6515bb3da5e45d05a663f7f567bb745695dc60f892/charset_normalizer-3.4.9-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:253a4a220747e8b5faf57ec320c4f5efb0cef05f647420bf267143ec15dba10a", size = 306122, upload-time = "2026-07-07T14:34:36.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/53/a8c042eb9eee4716f4d42a0f5a571eb32a09ec429be9fb0b8b9d765393ba/charset_normalizer-3.4.9-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68ce9f4d6b26d5ccbf7fd4459bf75f74a0a146677ebba80597df60cbdb20e6f4", size = 206284, upload-time = "2026-07-07T14:34:38.166Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cb/1db8b96547ee3186cd2dd7f2e59dd560a9b80748f3604171f3c153d62811/charset_normalizer-3.4.9-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:58150c9f9b9a552505912d182ccdf26f6396fb6094816ceebcbb20eecabaed94", size = 226837, upload-time = "2026-07-07T14:34:39.77Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/05/c94d5cd23396289c54c93b02e0273b4dd8921641d9968c4828caf9bbaad9/charset_normalizer-3.4.9-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df7276909358e5635ae203673ab7e509ddd224225a8d6b0790bf13eb2bde1cc5", size = 222199, upload-time = "2026-07-07T14:34:41.391Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/46/79847edd07244a4a2d443c6655a7b6ee94203c21539414b059f32713c357/charset_normalizer-3.4.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c09a49d6cde137258beb3d551994a2927fd35ad5cf96aed573f61bbd67c5f84", size = 214344, upload-time = "2026-07-07T14:34:42.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b4/ef5a49b2e77c00deb43bb3256592b115ba9e4346016e82c516b8d215bf68/charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:231ddcbb35e2ff8973e1365db41fe0572662893b99a05deb183b68ad4c0c8bd4", size = 199988, upload-time = "2026-07-07T14:34:44.685Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ca/ad1d7c7d3077dab873f539d3e1d083c0845a762cb0bafdfbe3ef93add598/charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:920079c3f7456fa213e0829ed2073aaa727fd39d889ead5b4f35d0de5460d04f", size = 211908, upload-time = "2026-07-07T14:34:46.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/61/710738687f90d01c06a04ed52d6ca1e62dd9b1d8cc2567098167c4691034/charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0fa1aec2d32bcc03c8fa0f6f1712caad1adc38509f31142112e5c9daf5b9c833", size = 209320, upload-time = "2026-07-07T14:34:47.753Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c0/6eec7bdabe6cbbcc274ec04596f6d93865751a0541d33d60d1ce179bd372/charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ad41ba96094304aa090f5a30cb6e4fb3b3f1c264c523394b4c39bbacc4dc92ba", size = 200980, upload-time = "2026-07-07T14:34:49.362Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/59344ff9a4a7b5f6530bf7bec2c980047cc42c3a616596cdbd8cb5c1a1af/charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:43b9e366a31fdd1c87d0eb08f579b4a82b723ea54338f040d6b4e518a026ea29", size = 216545, upload-time = "2026-07-07T14:34:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6d/bff78a4bacc4891bc63ec5bdc6776d8c85e47fab93d0d5f6223068fad0a4/charset_normalizer-3.4.9-cp39-cp39-win32.whl", hash = "sha256:93d59d504b230e83c7a843251681959a0b6a9cd76f6e146ce1b8a80eb8739af9", size = 146256, upload-time = "2026-07-07T14:34:52.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/55/86048bde1c9d0352940bd7b87d825091a52aef67d01cde6c6f7342c5b552/charset_normalizer-3.4.9-cp39-cp39-win_amd64.whl", hash = "sha256:ddf4af30b417d9fe16481e9b81c27ab2a7cde1ff7ba3e85653b02db7d145dc7b", size = 156413, upload-time = "2026-07-07T14:34:54.117Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e9/9fb6099b868c82a40698a748ae0fbd4f31ccc13844c176a07158ba2abbfd/charset_normalizer-3.4.9-cp39-cp39-win_arm64.whl", hash = "sha256:476743fe6dfe14a2da12e3ac79125dc84a3b2cf8094369a47a1529b0cd8549fe", size = 147887, upload-time = "2026-07-07T14:34:55.51Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "45.0.4"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/a2a376a8711c1e11708b9c9972e0c3223f5fc682552c82d8db844393d6ce/cryptography-45.0.4.tar.gz", hash = "sha256:7405ade85c83c37682c8fe65554759800a4a8c54b2d96e0f8ad114d31b808d57", size = 744890 }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/14/93b69f2af9ba832ad6618a03f8a034a5851dc9a3314336a3d71c252467e1/cryptography-45.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:680806cf63baa0039b920f4976f5f31b10e772de42f16310a6839d9f21a26b0d", size = 4205335 },
-    { url = "https://files.pythonhosted.org/packages/67/30/fae1000228634bf0b647fca80403db5ca9e3933b91dd060570689f0bd0f7/cryptography-45.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca0f52170e821bc8da6fc0cc565b7bb8ff8d90d36b5e9fdd68e8a86bdf72036", size = 4431487 },
-    { url = "https://files.pythonhosted.org/packages/6d/5a/7dffcf8cdf0cb3c2430de7404b327e3db64735747d641fc492539978caeb/cryptography-45.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f3fe7a5ae34d5a414957cc7f457e2b92076e72938423ac64d215722f6cf49a9e", size = 4208922 },
-    { url = "https://files.pythonhosted.org/packages/c6/f3/528729726eb6c3060fa3637253430547fbaaea95ab0535ea41baa4a6fbd8/cryptography-45.0.4-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:25eb4d4d3e54595dc8adebc6bbd5623588991d86591a78c2548ffb64797341e2", size = 3900433 },
-    { url = "https://files.pythonhosted.org/packages/d9/4a/67ba2e40f619e04d83c32f7e1d484c1538c0800a17c56a22ff07d092ccc1/cryptography-45.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ce1678a2ccbe696cf3af15a75bb72ee008d7ff183c9228592ede9db467e64f1b", size = 4464163 },
-    { url = "https://files.pythonhosted.org/packages/7e/9a/b4d5aa83661483ac372464809c4b49b5022dbfe36b12fe9e323ca8512420/cryptography-45.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:49fe9155ab32721b9122975e168a6760d8ce4cffe423bcd7ca269ba41b5dfac1", size = 4208687 },
-    { url = "https://files.pythonhosted.org/packages/db/b7/a84bdcd19d9c02ec5807f2ec2d1456fd8451592c5ee353816c09250e3561/cryptography-45.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2882338b2a6e0bd337052e8b9007ced85c637da19ef9ecaf437744495c8c2999", size = 4463623 },
-    { url = "https://files.pythonhosted.org/packages/d8/84/69707d502d4d905021cac3fb59a316344e9f078b1da7fb43ecde5e10840a/cryptography-45.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:23b9c3ea30c3ed4db59e7b9619272e94891f8a3a5591d0b656a7582631ccf750", size = 4332447 },
-    { url = "https://files.pythonhosted.org/packages/f3/ee/d4f2ab688e057e90ded24384e34838086a9b09963389a5ba6854b5876598/cryptography-45.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0a97c927497e3bc36b33987abb99bf17a9a175a19af38a892dc4bbb844d7ee2", size = 4572830 },
-    { url = "https://files.pythonhosted.org/packages/fe/51/8c584ed426093aac257462ae62d26ad61ef1cbf5b58d8b67e6e13c39960e/cryptography-45.0.4-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6a5bf57554e80f75a7db3d4b1dacaa2764611ae166ab42ea9a72bcdb5d577637", size = 4195746 },
-    { url = "https://files.pythonhosted.org/packages/5c/7d/4b0ca4d7af95a704eef2f8f80a8199ed236aaf185d55385ae1d1610c03c2/cryptography-45.0.4-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46cf7088bf91bdc9b26f9c55636492c1cce3e7aaf8041bbf0243f5e5325cfb2d", size = 4424456 },
-    { url = "https://files.pythonhosted.org/packages/1d/45/5fabacbc6e76ff056f84d9f60eeac18819badf0cefc1b6612ee03d4ab678/cryptography-45.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7bedbe4cc930fa4b100fc845ea1ea5788fcd7ae9562e669989c11618ae8d76ee", size = 4198495 },
-    { url = "https://files.pythonhosted.org/packages/55/b7/ffc9945b290eb0a5d4dab9b7636706e3b5b92f14ee5d9d4449409d010d54/cryptography-45.0.4-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:eaa3e28ea2235b33220b949c5a0d6cf79baa80eab2eb5607ca8ab7525331b9ff", size = 3885540 },
-    { url = "https://files.pythonhosted.org/packages/7f/e3/57b010282346980475e77d414080acdcb3dab9a0be63071efc2041a2c6bd/cryptography-45.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7ef2dde4fa9408475038fc9aadfc1fb2676b174e68356359632e980c661ec8f6", size = 4452052 },
-    { url = "https://files.pythonhosted.org/packages/37/e6/ddc4ac2558bf2ef517a358df26f45bc774a99bf4653e7ee34b5e749c03e3/cryptography-45.0.4-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6a3511ae33f09094185d111160fd192c67aa0a2a8d19b54d36e4c78f651dc5ad", size = 4198024 },
-    { url = "https://files.pythonhosted.org/packages/3a/c0/85fa358ddb063ec588aed4a6ea1df57dc3e3bc1712d87c8fa162d02a65fc/cryptography-45.0.4-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:06509dc70dd71fa56eaa138336244e2fbaf2ac164fc9b5e66828fccfd2b680d6", size = 4451442 },
-    { url = "https://files.pythonhosted.org/packages/33/67/362d6ec1492596e73da24e669a7fbbaeb1c428d6bf49a29f7a12acffd5dc/cryptography-45.0.4-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5f31e6b0a5a253f6aa49be67279be4a7e5a4ef259a9f33c69f7d1b1191939872", size = 4325038 },
-    { url = "https://files.pythonhosted.org/packages/53/75/82a14bf047a96a1b13ebb47fb9811c4f73096cfa2e2b17c86879687f9027/cryptography-45.0.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:944e9ccf67a9594137f942d5b52c8d238b1b4e46c7a0c2891b7ae6e01e7c80a4", size = 4560964 },
-    { url = "https://files.pythonhosted.org/packages/c4/b9/357f18064ec09d4807800d05a48f92f3b369056a12f995ff79549fbb31f1/cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7aad98a25ed8ac917fdd8a9c1e706e5a0956e06c498be1f713b61734333a4507", size = 4143732 },
-    { url = "https://files.pythonhosted.org/packages/c4/9c/7f7263b03d5db329093617648b9bd55c953de0b245e64e866e560f9aac07/cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3530382a43a0e524bc931f187fc69ef4c42828cf7d7f592f7f249f602b5a4ab0", size = 4385424 },
-    { url = "https://files.pythonhosted.org/packages/a6/5a/6aa9d8d5073d5acc0e04e95b2860ef2684b2bd2899d8795fc443013e263b/cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:6b613164cb8425e2f8db5849ffb84892e523bf6d26deb8f9bb76ae86181fa12b", size = 4142438 },
-    { url = "https://files.pythonhosted.org/packages/42/1c/71c638420f2cdd96d9c2b287fec515faf48679b33a2b583d0f1eda3a3375/cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:96d4819e25bf3b685199b304a0029ce4a3caf98947ce8a066c9137cc78ad2c58", size = 4384622 },
-    { url = "https://files.pythonhosted.org/packages/28/9a/a7d5bb87d149eb99a5abdc69a41e4e47b8001d767e5f403f78bfaafc7aa7/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:03dbff8411206713185b8cebe31bc5c0eb544799a50c09035733716b386e61a4", size = 4146899 },
-    { url = "https://files.pythonhosted.org/packages/17/11/9361c2c71c42cc5c465cf294c8030e72fb0c87752bacbd7a3675245e3db3/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:51dfbd4d26172d31150d84c19bbe06c68ea4b7f11bbc7b3a5e146b367c311349", size = 4388900 },
-    { url = "https://files.pythonhosted.org/packages/c0/76/f95b83359012ee0e670da3e41c164a0c256aeedd81886f878911581d852f/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8", size = 4146422 },
-    { url = "https://files.pythonhosted.org/packages/09/ad/5429fcc4def93e577a5407988f89cf15305e64920203d4ac14601a9dc876/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862", size = 4388475 },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
 ]
 
 [[package]]
 name = "cssselect"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870 }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870, upload-time = "2025-03-10T09:30:29.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786 },
+    { url = "https://files.pythonhosted.org/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786, upload-time = "2025-03-10T09:30:28.048Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/2e/cdfd8b01c37cbf4f9482eefd455853a3cf9c995029a46acd31dfaa9c1dd6/cssselect-1.4.0.tar.gz", hash = "sha256:fdaf0a1425e17dfe8c5cf66191d211b357cf7872ae8afc4c6762ddd8ac47fc92", size = 40589, upload-time = "2026-01-29T07:00:26.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/0c/7bb51e3acfafd16c48875bf3db03607674df16f5b6ef8d056586af7e2b8b/cssselect-1.4.0-py3-none-any.whl", hash = "sha256:c0ec5c0191c8ee39fcc8afc1540331d8b55b0183478c50e9c8a79d44dbceb1d8", size = 18540, upload-time = "2026-01-29T07:00:24.994Z" },
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "18.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/7d/f4e231167b23b3d7348aa1c90117ce8854fae186d6984ad66d705df24061/cucumber_expressions-18.0.1.tar.gz", hash = "sha256:86ce41bf28ee520408416f38022e5a083d815edf04a0bd1dae46d474ca597c60", size = 22232, upload-time = "2024-10-28T11:38:48.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/e0/31ce90dad5234c3d52432bfce7562aa11cda4848aea90936a4be6c67d7ab/cucumber_expressions-18.0.1-py3-none-any.whl", hash = "sha256:86230d503cdda7ef35a1f2072a882d7d57c740aa4c163c82b07f039b6bc60c42", size = 20211, upload-time = "2024-10-28T11:38:47.101Z" },
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "20.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/a6/eaac4ff3afdc776a4d3e0ef29c79db1c9faf11c423175771e225bcef9c84/cucumber_expressions-20.0.0.tar.gz", hash = "sha256:5cbd4012c66584aa82ada990a6e7cb131274796e132e905d27d95ae9a2ca0f48", size = 13738, upload-time = "2026-06-11T07:13:43.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/24/e403585f201d30ab561d8a971a1adc4de28123fb9bf2f9813650fda8ddb0/cucumber_expressions-20.0.0-py3-none-any.whl", hash = "sha256:8a0434529efd7ca6e2052934ec8d677c7e24edc0fad3b1d1b1bc4bbca5e521f3", size = 20236, upload-time = "2026-06-11T07:13:42.667Z" },
+]
+
+[[package]]
+name = "cucumber-tag-expressions"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/37/2e59554d623fcd899f9d3f8c8d41a9b88f847f48ba0c3ba64cc88d851b98/cucumber_tag_expressions-7.0.0.tar.gz", hash = "sha256:3acb919113eb361930519f4280b23e1df58a0201b9512d25470a2e9eea8868ed", size = 42173, upload-time = "2025-10-03T16:23:02.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/10/44a74996f3cc7f7c5c4a62ff2eb3c45c575be677e52acb062e4fcc22015b/cucumber_tag_expressions-7.0.0-py2.py3-none-any.whl", hash = "sha256:c95ee130c0f28b356f8a92495481383e1bf8ebcdb761e0ce72826f905fbd9c9f", size = 10248, upload-time = "2025-10-03T16:23:00.596Z" },
+]
+
+[[package]]
+name = "cucumber-tag-expressions"
+version = "10.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/8d/e2b978e7d42842ba974df1ae5613f451904765f155a019570744668963d3/cucumber_tag_expressions-10.0.0.tar.gz", hash = "sha256:b3ca4163660b247760031f88797ecde2c5384aac85f9d5908cb4750eddde89b7", size = 8448, upload-time = "2026-06-11T07:04:07.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ce/d7851b6433b1a156f4fc4e151e030bad6c00024e8c64de4f61c53d3da616/cucumber_tag_expressions-10.0.0-py3-none-any.whl", hash = "sha256:496f4a834e4e7ef9c1ae3f6f9c22f237a32f1916f96c32d8b8f900865f988f81", size = 9724, upload-time = "2026-06-11T07:04:06.07Z" },
 ]
 
 [[package]]
 name = "distlib"
-version = "0.3.9"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
 name = "docutils"
-version = "0.17.1"
+version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/17/559b4d020f4b46e0287a2eddf2d8ebf76318fd3bd495f1625414b052fdc9/docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125", size = 2016138 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/5e/6003a0d1f37725ec2ebd4046b657abb9372202655f96e76795dca8c0063c/docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61", size = 575533 },
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
 ]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.18.0"
+version = "3.29.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
 name = "id"
-version = "1.5.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/11/102da08f88412d875fa2f1a9a469ff7ad4c874b0ca6fed0048fe385bdb3d/id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d", size = 15237 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658", size = 13611 },
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
 name = "imagesize"
-version = "1.4.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769 },
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.0"
+version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -358,59 +476,59 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780 }
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777 },
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
 ]
 
 [[package]]
 name = "jaraco-context"
-version = "6.0.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825 },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]
 name = "jaraco-functools"
-version = "4.1.0"
+version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159 }
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649", size = 10187 },
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
 ]
 
 [[package]]
 name = "jeepney"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758 }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010 },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
 name = "jinja2"
-version = "2.11.3"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6", size = 257589 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419", size = 125699 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
 name = "keyring"
-version = "25.6.0"
+version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
@@ -421,304 +539,321 @@ dependencies = [
     { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
     { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085 },
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
 name = "lxml"
-version = "5.4.0"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/1f/a3b6b74a451ceb84b471caa75c934d2430a4d84395d38ef201d539f38cd1/lxml-5.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e7bc6df34d42322c5289e37e9971d6ed114e3776b45fa879f734bded9d1fea9c", size = 8076838 },
-    { url = "https://files.pythonhosted.org/packages/36/af/a567a55b3e47135b4d1f05a1118c24529104c003f95851374b3748139dc1/lxml-5.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6854f8bd8a1536f8a1d9a3655e6354faa6406621cf857dc27b681b69860645c7", size = 4381827 },
-    { url = "https://files.pythonhosted.org/packages/50/ba/4ee47d24c675932b3eb5b6de77d0f623c2db6dc466e7a1f199792c5e3e3a/lxml-5.4.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:696ea9e87442467819ac22394ca36cb3d01848dad1be6fac3fb612d3bd5a12cf", size = 5204098 },
-    { url = "https://files.pythonhosted.org/packages/f2/0f/b4db6dfebfefe3abafe360f42a3d471881687fd449a0b86b70f1f2683438/lxml-5.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ef80aeac414f33c24b3815ecd560cee272786c3adfa5f31316d8b349bfade28", size = 4930261 },
-    { url = "https://files.pythonhosted.org/packages/0b/1f/0bb1bae1ce056910f8db81c6aba80fec0e46c98d77c0f59298c70cd362a3/lxml-5.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b9c2754cef6963f3408ab381ea55f47dabc6f78f4b8ebb0f0b25cf1ac1f7609", size = 5529621 },
-    { url = "https://files.pythonhosted.org/packages/21/f5/e7b66a533fc4a1e7fa63dd22a1ab2ec4d10319b909211181e1ab3e539295/lxml-5.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a62cc23d754bb449d63ff35334acc9f5c02e6dae830d78dab4dd12b78a524f4", size = 4983231 },
-    { url = "https://files.pythonhosted.org/packages/11/39/a38244b669c2d95a6a101a84d3c85ba921fea827e9e5483e93168bf1ccb2/lxml-5.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f82125bc7203c5ae8633a7d5d20bcfdff0ba33e436e4ab0abc026a53a8960b7", size = 5084279 },
-    { url = "https://files.pythonhosted.org/packages/db/64/48cac242347a09a07740d6cee7b7fd4663d5c1abd65f2e3c60420e231b27/lxml-5.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b67319b4aef1a6c56576ff544b67a2a6fbd7eaee485b241cabf53115e8908b8f", size = 4927405 },
-    { url = "https://files.pythonhosted.org/packages/98/89/97442835fbb01d80b72374f9594fe44f01817d203fa056e9906128a5d896/lxml-5.4.0-cp310-cp310-manylinux_2_28_ppc64le.whl", hash = "sha256:a8ef956fce64c8551221f395ba21d0724fed6b9b6242ca4f2f7beb4ce2f41997", size = 5550169 },
-    { url = "https://files.pythonhosted.org/packages/f1/97/164ca398ee654eb21f29c6b582685c6c6b9d62d5213abc9b8380278e9c0a/lxml-5.4.0-cp310-cp310-manylinux_2_28_s390x.whl", hash = "sha256:0a01ce7d8479dce84fc03324e3b0c9c90b1ece9a9bb6a1b6c9025e7e4520e78c", size = 5062691 },
-    { url = "https://files.pythonhosted.org/packages/d0/bc/712b96823d7feb53482d2e4f59c090fb18ec7b0d0b476f353b3085893cda/lxml-5.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:91505d3ddebf268bb1588eb0f63821f738d20e1e7f05d3c647a5ca900288760b", size = 5133503 },
-    { url = "https://files.pythonhosted.org/packages/d4/55/a62a39e8f9da2a8b6002603475e3c57c870cd9c95fd4b94d4d9ac9036055/lxml-5.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a3bcdde35d82ff385f4ede021df801b5c4a5bcdfb61ea87caabcebfc4945dc1b", size = 4999346 },
-    { url = "https://files.pythonhosted.org/packages/ea/47/a393728ae001b92bb1a9e095e570bf71ec7f7fbae7688a4792222e56e5b9/lxml-5.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:aea7c06667b987787c7d1f5e1dfcd70419b711cdb47d6b4bb4ad4b76777a0563", size = 5627139 },
-    { url = "https://files.pythonhosted.org/packages/5e/5f/9dcaaad037c3e642a7ea64b479aa082968de46dd67a8293c541742b6c9db/lxml-5.4.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a7fb111eef4d05909b82152721a59c1b14d0f365e2be4c742a473c5d7372f4f5", size = 5465609 },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/ebcae89edf27e61c45023005171d0ba95cb414ee41c045ae4caf1b8487fd/lxml-5.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:43d549b876ce64aa18b2328faff70f5877f8c6dede415f80a2f799d31644d776", size = 5192285 },
-    { url = "https://files.pythonhosted.org/packages/42/ad/cc8140ca99add7d85c92db8b2354638ed6d5cc0e917b21d36039cb15a238/lxml-5.4.0-cp310-cp310-win32.whl", hash = "sha256:75133890e40d229d6c5837b0312abbe5bac1c342452cf0e12523477cd3aa21e7", size = 3477507 },
-    { url = "https://files.pythonhosted.org/packages/e9/39/597ce090da1097d2aabd2f9ef42187a6c9c8546d67c419ce61b88b336c85/lxml-5.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:de5b4e1088523e2b6f730d0509a9a813355b7f5659d70eb4f319c76beea2e250", size = 3805104 },
-    { url = "https://files.pythonhosted.org/packages/81/2d/67693cc8a605a12e5975380d7ff83020dcc759351b5a066e1cced04f797b/lxml-5.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:98a3912194c079ef37e716ed228ae0dcb960992100461b704aea4e93af6b0bb9", size = 8083240 },
-    { url = "https://files.pythonhosted.org/packages/73/53/b5a05ab300a808b72e848efd152fe9c022c0181b0a70b8bca1199f1bed26/lxml-5.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ea0252b51d296a75f6118ed0d8696888e7403408ad42345d7dfd0d1e93309a7", size = 4387685 },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/1a3879c5f512bdcd32995c301886fe082b2edd83c87d41b6d42d89b4ea4d/lxml-5.4.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b92b69441d1bd39f4940f9eadfa417a25862242ca2c396b406f9272ef09cdcaa", size = 4991164 },
-    { url = "https://files.pythonhosted.org/packages/f9/94/bbc66e42559f9d04857071e3b3d0c9abd88579367fd2588a4042f641f57e/lxml-5.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20e16c08254b9b6466526bc1828d9370ee6c0d60a4b64836bc3ac2917d1e16df", size = 4746206 },
-    { url = "https://files.pythonhosted.org/packages/66/95/34b0679bee435da2d7cae895731700e519a8dfcab499c21662ebe671603e/lxml-5.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7605c1c32c3d6e8c990dd28a0970a3cbbf1429d5b92279e37fda05fb0c92190e", size = 5342144 },
-    { url = "https://files.pythonhosted.org/packages/e0/5d/abfcc6ab2fa0be72b2ba938abdae1f7cad4c632f8d552683ea295d55adfb/lxml-5.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecf4c4b83f1ab3d5a7ace10bafcb6f11df6156857a3c418244cef41ca9fa3e44", size = 4825124 },
-    { url = "https://files.pythonhosted.org/packages/5a/78/6bd33186c8863b36e084f294fc0a5e5eefe77af95f0663ef33809cc1c8aa/lxml-5.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cef4feae82709eed352cd7e97ae062ef6ae9c7b5dbe3663f104cd2c0e8d94ba", size = 4876520 },
-    { url = "https://files.pythonhosted.org/packages/3b/74/4d7ad4839bd0fc64e3d12da74fc9a193febb0fae0ba6ebd5149d4c23176a/lxml-5.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:df53330a3bff250f10472ce96a9af28628ff1f4efc51ccba351a8820bca2a8ba", size = 4765016 },
-    { url = "https://files.pythonhosted.org/packages/24/0d/0a98ed1f2471911dadfc541003ac6dd6879fc87b15e1143743ca20f3e973/lxml-5.4.0-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:aefe1a7cb852fa61150fcb21a8c8fcea7b58c4cb11fbe59c97a0a4b31cae3c8c", size = 5362884 },
-    { url = "https://files.pythonhosted.org/packages/48/de/d4f7e4c39740a6610f0f6959052b547478107967362e8424e1163ec37ae8/lxml-5.4.0-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:ef5a7178fcc73b7d8c07229e89f8eb45b2908a9238eb90dcfc46571ccf0383b8", size = 4902690 },
-    { url = "https://files.pythonhosted.org/packages/07/8c/61763abd242af84f355ca4ef1ee096d3c1b7514819564cce70fd18c22e9a/lxml-5.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d2ed1b3cb9ff1c10e6e8b00941bb2e5bb568b307bfc6b17dffbbe8be5eecba86", size = 4944418 },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/6d7e3b63e7e282619193961a570c0a4c8a57fe820f07ca3fe2f6bd86608a/lxml-5.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:72ac9762a9f8ce74c9eed4a4e74306f2f18613a6b71fa065495a67ac227b3056", size = 4827092 },
-    { url = "https://files.pythonhosted.org/packages/71/4a/e60a306df54680b103348545706a98a7514a42c8b4fbfdcaa608567bb065/lxml-5.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f5cb182f6396706dc6cc1896dd02b1c889d644c081b0cdec38747573db88a7d7", size = 5418231 },
-    { url = "https://files.pythonhosted.org/packages/27/f2/9754aacd6016c930875854f08ac4b192a47fe19565f776a64004aa167521/lxml-5.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:3a3178b4873df8ef9457a4875703488eb1622632a9cee6d76464b60e90adbfcd", size = 5261798 },
-    { url = "https://files.pythonhosted.org/packages/38/a2/0c49ec6941428b1bd4f280650d7b11a0f91ace9db7de32eb7aa23bcb39ff/lxml-5.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e094ec83694b59d263802ed03a8384594fcce477ce484b0cbcd0008a211ca751", size = 4988195 },
-    { url = "https://files.pythonhosted.org/packages/7a/75/87a3963a08eafc46a86c1131c6e28a4de103ba30b5ae903114177352a3d7/lxml-5.4.0-cp311-cp311-win32.whl", hash = "sha256:4329422de653cdb2b72afa39b0aa04252fca9071550044904b2e7036d9d97fe4", size = 3474243 },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/1f0964c4f6c2be861c50db380c554fb8befbea98c6404744ce243a3c87ef/lxml-5.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd3be6481ef54b8cfd0e1e953323b7aa9d9789b94842d0e5b142ef4bb7999539", size = 3815197 },
-    { url = "https://files.pythonhosted.org/packages/f8/4c/d101ace719ca6a4ec043eb516fcfcb1b396a9fccc4fcd9ef593df34ba0d5/lxml-5.4.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b5aff6f3e818e6bdbbb38e5967520f174b18f539c2b9de867b1e7fde6f8d95a4", size = 8127392 },
-    { url = "https://files.pythonhosted.org/packages/11/84/beddae0cec4dd9ddf46abf156f0af451c13019a0fa25d7445b655ba5ccb7/lxml-5.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:942a5d73f739ad7c452bf739a62a0f83e2578afd6b8e5406308731f4ce78b16d", size = 4415103 },
-    { url = "https://files.pythonhosted.org/packages/d0/25/d0d93a4e763f0462cccd2b8a665bf1e4343dd788c76dcfefa289d46a38a9/lxml-5.4.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:460508a4b07364d6abf53acaa0a90b6d370fafde5693ef37602566613a9b0779", size = 5024224 },
-    { url = "https://files.pythonhosted.org/packages/31/ce/1df18fb8f7946e7f3388af378b1f34fcf253b94b9feedb2cec5969da8012/lxml-5.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:529024ab3a505fed78fe3cc5ddc079464e709f6c892733e3f5842007cec8ac6e", size = 4769913 },
-    { url = "https://files.pythonhosted.org/packages/4e/62/f4a6c60ae7c40d43657f552f3045df05118636be1165b906d3423790447f/lxml-5.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ca56ebc2c474e8f3d5761debfd9283b8b18c76c4fc0967b74aeafba1f5647f9", size = 5290441 },
-    { url = "https://files.pythonhosted.org/packages/9e/aa/04f00009e1e3a77838c7fc948f161b5d2d5de1136b2b81c712a263829ea4/lxml-5.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a81e1196f0a5b4167a8dafe3a66aa67c4addac1b22dc47947abd5d5c7a3f24b5", size = 4820165 },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/e0b2f61fa2404bf0f1fdf1898377e5bd1b74cc9b2cf2c6ba8509b8f27990/lxml-5.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00b8686694423ddae324cf614e1b9659c2edb754de617703c3d29ff568448df5", size = 4932580 },
-    { url = "https://files.pythonhosted.org/packages/24/a2/8263f351b4ffe0ed3e32ea7b7830f845c795349034f912f490180d88a877/lxml-5.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c5681160758d3f6ac5b4fea370495c48aac0989d6a0f01bb9a72ad8ef5ab75c4", size = 4759493 },
-    { url = "https://files.pythonhosted.org/packages/05/00/41db052f279995c0e35c79d0f0fc9f8122d5b5e9630139c592a0b58c71b4/lxml-5.4.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:2dc191e60425ad70e75a68c9fd90ab284df64d9cd410ba8d2b641c0c45bc006e", size = 5324679 },
-    { url = "https://files.pythonhosted.org/packages/1d/be/ee99e6314cdef4587617d3b3b745f9356d9b7dd12a9663c5f3b5734b64ba/lxml-5.4.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:67f779374c6b9753ae0a0195a892a1c234ce8416e4448fe1e9f34746482070a7", size = 4890691 },
-    { url = "https://files.pythonhosted.org/packages/ad/36/239820114bf1d71f38f12208b9c58dec033cbcf80101cde006b9bde5cffd/lxml-5.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:79d5bfa9c1b455336f52343130b2067164040604e41f6dc4d8313867ed540079", size = 4955075 },
-    { url = "https://files.pythonhosted.org/packages/d4/e1/1b795cc0b174efc9e13dbd078a9ff79a58728a033142bc6d70a1ee8fc34d/lxml-5.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3d3c30ba1c9b48c68489dc1829a6eede9873f52edca1dda900066542528d6b20", size = 4838680 },
-    { url = "https://files.pythonhosted.org/packages/72/48/3c198455ca108cec5ae3662ae8acd7fd99476812fd712bb17f1b39a0b589/lxml-5.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1af80c6316ae68aded77e91cd9d80648f7dd40406cef73df841aa3c36f6907c8", size = 5391253 },
-    { url = "https://files.pythonhosted.org/packages/d6/10/5bf51858971c51ec96cfc13e800a9951f3fd501686f4c18d7d84fe2d6352/lxml-5.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4d885698f5019abe0de3d352caf9466d5de2baded00a06ef3f1216c1a58ae78f", size = 5261651 },
-    { url = "https://files.pythonhosted.org/packages/2b/11/06710dd809205377da380546f91d2ac94bad9ff735a72b64ec029f706c85/lxml-5.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea53d51859b6c64e7c51d522c03cc2c48b9b5d6172126854cc7f01aa11f52bc", size = 5024315 },
-    { url = "https://files.pythonhosted.org/packages/f5/b0/15b6217834b5e3a59ebf7f53125e08e318030e8cc0d7310355e6edac98ef/lxml-5.4.0-cp312-cp312-win32.whl", hash = "sha256:d90b729fd2732df28130c064aac9bb8aff14ba20baa4aee7bd0795ff1187545f", size = 3486149 },
-    { url = "https://files.pythonhosted.org/packages/91/1e/05ddcb57ad2f3069101611bd5f5084157d90861a2ef460bf42f45cced944/lxml-5.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1dc4ca99e89c335a7ed47d38964abcb36c5910790f9bd106f2a8fa2ee0b909d2", size = 3817095 },
-    { url = "https://files.pythonhosted.org/packages/87/cb/2ba1e9dd953415f58548506fa5549a7f373ae55e80c61c9041b7fd09a38a/lxml-5.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:773e27b62920199c6197130632c18fb7ead3257fce1ffb7d286912e56ddb79e0", size = 8110086 },
-    { url = "https://files.pythonhosted.org/packages/b5/3e/6602a4dca3ae344e8609914d6ab22e52ce42e3e1638c10967568c5c1450d/lxml-5.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9c671845de9699904b1e9df95acfe8dfc183f2310f163cdaa91a3535af95de", size = 4404613 },
-    { url = "https://files.pythonhosted.org/packages/4c/72/bf00988477d3bb452bef9436e45aeea82bb40cdfb4684b83c967c53909c7/lxml-5.4.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9454b8d8200ec99a224df8854786262b1bd6461f4280064c807303c642c05e76", size = 5012008 },
-    { url = "https://files.pythonhosted.org/packages/92/1f/93e42d93e9e7a44b2d3354c462cd784dbaaf350f7976b5d7c3f85d68d1b1/lxml-5.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cccd007d5c95279e529c146d095f1d39ac05139de26c098166c4beb9374b0f4d", size = 4760915 },
-    { url = "https://files.pythonhosted.org/packages/45/0b/363009390d0b461cf9976a499e83b68f792e4c32ecef092f3f9ef9c4ba54/lxml-5.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fce1294a0497edb034cb416ad3e77ecc89b313cff7adbee5334e4dc0d11f422", size = 5283890 },
-    { url = "https://files.pythonhosted.org/packages/19/dc/6056c332f9378ab476c88e301e6549a0454dbee8f0ae16847414f0eccb74/lxml-5.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24974f774f3a78ac12b95e3a20ef0931795ff04dbb16db81a90c37f589819551", size = 4812644 },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/f8c66bbb23ecb9048a46a5ef9b495fd23f7543df642dabeebcb2eeb66592/lxml-5.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:497cab4d8254c2a90bf988f162ace2ddbfdd806fce3bda3f581b9d24c852e03c", size = 4921817 },
-    { url = "https://files.pythonhosted.org/packages/04/57/2e537083c3f381f83d05d9b176f0d838a9e8961f7ed8ddce3f0217179ce3/lxml-5.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e794f698ae4c5084414efea0f5cc9f4ac562ec02d66e1484ff822ef97c2cadff", size = 4753916 },
-    { url = "https://files.pythonhosted.org/packages/d8/80/ea8c4072109a350848f1157ce83ccd9439601274035cd045ac31f47f3417/lxml-5.4.0-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:2c62891b1ea3094bb12097822b3d44b93fc6c325f2043c4d2736a8ff09e65f60", size = 5289274 },
-    { url = "https://files.pythonhosted.org/packages/b3/47/c4be287c48cdc304483457878a3f22999098b9a95f455e3c4bda7ec7fc72/lxml-5.4.0-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:142accb3e4d1edae4b392bd165a9abdee8a3c432a2cca193df995bc3886249c8", size = 4874757 },
-    { url = "https://files.pythonhosted.org/packages/2f/04/6ef935dc74e729932e39478e44d8cfe6a83550552eaa072b7c05f6f22488/lxml-5.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1a42b3a19346e5601d1b8296ff6ef3d76038058f311902edd574461e9c036982", size = 4947028 },
-    { url = "https://files.pythonhosted.org/packages/cb/f9/c33fc8daa373ef8a7daddb53175289024512b6619bc9de36d77dca3df44b/lxml-5.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4291d3c409a17febf817259cb37bc62cb7eb398bcc95c1356947e2871911ae61", size = 4834487 },
-    { url = "https://files.pythonhosted.org/packages/8d/30/fc92bb595bcb878311e01b418b57d13900f84c2b94f6eca9e5073ea756e6/lxml-5.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4f5322cf38fe0e21c2d73901abf68e6329dc02a4994e483adbcf92b568a09a54", size = 5381688 },
-    { url = "https://files.pythonhosted.org/packages/43/d1/3ba7bd978ce28bba8e3da2c2e9d5ae3f8f521ad3f0ca6ea4788d086ba00d/lxml-5.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:0be91891bdb06ebe65122aa6bf3fc94489960cf7e03033c6f83a90863b23c58b", size = 5242043 },
-    { url = "https://files.pythonhosted.org/packages/ee/cd/95fa2201041a610c4d08ddaf31d43b98ecc4b1d74b1e7245b1abdab443cb/lxml-5.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:15a665ad90054a3d4f397bc40f73948d48e36e4c09f9bcffc7d90c87410e478a", size = 5021569 },
-    { url = "https://files.pythonhosted.org/packages/2d/a6/31da006fead660b9512d08d23d31e93ad3477dd47cc42e3285f143443176/lxml-5.4.0-cp313-cp313-win32.whl", hash = "sha256:d5663bc1b471c79f5c833cffbc9b87d7bf13f87e055a5c86c363ccd2348d7e82", size = 3485270 },
-    { url = "https://files.pythonhosted.org/packages/fc/14/c115516c62a7d2499781d2d3d7215218c0731b2c940753bf9f9b7b73924d/lxml-5.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:bcb7a1096b4b6b24ce1ac24d4942ad98f983cd3810f9711bcd0293f43a9d8b9f", size = 3814606 },
-    { url = "https://files.pythonhosted.org/packages/1e/04/acd238222ea25683e43ac7113facc380b3aaf77c53e7d88c4f544cef02ca/lxml-5.4.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bda3ea44c39eb74e2488297bb39d47186ed01342f0022c8ff407c250ac3f498e", size = 8082189 },
-    { url = "https://files.pythonhosted.org/packages/d6/4e/cc7fe9ccb9999cc648492ce970b63c657606aefc7d0fba46b17aa2ba93fb/lxml-5.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9ceaf423b50ecfc23ca00b7f50b64baba85fb3fb91c53e2c9d00bc86150c7e40", size = 4384950 },
-    { url = "https://files.pythonhosted.org/packages/56/bf/acd219c489346d0243a30769b9d446b71e5608581db49a18c8d91a669e19/lxml-5.4.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:664cdc733bc87449fe781dbb1f309090966c11cc0c0cd7b84af956a02a8a4729", size = 5209823 },
-    { url = "https://files.pythonhosted.org/packages/57/51/ec31cd33175c09aa7b93d101f56eed43d89e15504455d884d021df7166a7/lxml-5.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67ed8a40665b84d161bae3181aa2763beea3747f748bca5874b4af4d75998f87", size = 4931808 },
-    { url = "https://files.pythonhosted.org/packages/e5/68/865d229f191514da1777125598d028dc88a5ea300d68c30e1f120bfd01bd/lxml-5.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b4a3bd174cc9cdaa1afbc4620c049038b441d6ba07629d89a83b408e54c35cd", size = 5086067 },
-    { url = "https://files.pythonhosted.org/packages/82/01/4c958c5848b4e263cd9e83dff6b49f975a5a0854feb1070dfe0bdcdf70a0/lxml-5.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:b0989737a3ba6cf2a16efb857fb0dfa20bc5c542737fddb6d893fde48be45433", size = 4929026 },
-    { url = "https://files.pythonhosted.org/packages/55/31/5327d8af74d7f35e645b40ae6658761e1fee59ebecaa6a8d295e495c2ca9/lxml-5.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:dc0af80267edc68adf85f2a5d9be1cdf062f973db6790c1d065e45025fa26140", size = 5134245 },
-    { url = "https://files.pythonhosted.org/packages/6f/c9/204eba2400beb0016dacc2c5335ecb1e37f397796683ffdb7f471e86bddb/lxml-5.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:639978bccb04c42677db43c79bdaa23785dc7f9b83bfd87570da8207872f1ce5", size = 5001020 },
-    { url = "https://files.pythonhosted.org/packages/07/53/979165f50a853dab1cf3b9e53105032d55f85c5993f94afc4d9a61a22877/lxml-5.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5a99d86351f9c15e4a901fc56404b485b1462039db59288b203f8c629260a142", size = 5192346 },
-    { url = "https://files.pythonhosted.org/packages/17/2b/f37b5ae28949143f863ba3066b30eede6107fc9a503bd0d01677d4e2a1e0/lxml-5.4.0-cp39-cp39-win32.whl", hash = "sha256:3e6d5557989cdc3ebb5302bbdc42b439733a841891762ded9514e74f60319ad6", size = 3478275 },
-    { url = "https://files.pythonhosted.org/packages/9a/d5/b795a183680126147665a8eeda8e802c180f2f7661aa9a550bba5bcdae63/lxml-5.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:a8c9b7f16b63e65bbba889acb436a1034a82d34fa09752d754f88d708eca80e1", size = 3806275 },
-    { url = "https://files.pythonhosted.org/packages/c6/b0/e4d1cbb8c078bc4ae44de9c6a79fec4e2b4151b1b4d50af71d799e76b177/lxml-5.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1b717b00a71b901b4667226bba282dd462c42ccf618ade12f9ba3674e1fabc55", size = 3892319 },
-    { url = "https://files.pythonhosted.org/packages/5b/aa/e2bdefba40d815059bcb60b371a36fbfcce970a935370e1b367ba1cc8f74/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27a9ded0f0b52098ff89dd4c418325b987feed2ea5cc86e8860b0f844285d740", size = 4211614 },
-    { url = "https://files.pythonhosted.org/packages/3c/5f/91ff89d1e092e7cfdd8453a939436ac116db0a665e7f4be0cd8e65c7dc5a/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b7ce10634113651d6f383aa712a194179dcd496bd8c41e191cec2099fa09de5", size = 4306273 },
-    { url = "https://files.pythonhosted.org/packages/be/7c/8c3f15df2ca534589717bfd19d1e3482167801caedfa4d90a575facf68a6/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:53370c26500d22b45182f98847243efb518d268374a9570409d2e2276232fd37", size = 4208552 },
-    { url = "https://files.pythonhosted.org/packages/7d/d8/9567afb1665f64d73fc54eb904e418d1138d7f011ed00647121b4dd60b38/lxml-5.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c6364038c519dffdbe07e3cf42e6a7f8b90c275d4d1617a69bb59734c1a2d571", size = 4331091 },
-    { url = "https://files.pythonhosted.org/packages/f1/ab/fdbbd91d8d82bf1a723ba88ec3e3d76c022b53c391b0c13cad441cdb8f9e/lxml-5.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b12cb6527599808ada9eb2cd6e0e7d3d8f13fe7bbb01c6311255a15ded4c7ab4", size = 3487862 },
-    { url = "https://files.pythonhosted.org/packages/ad/fb/d19b67e4bb63adc20574ba3476cf763b3514df1a37551084b890254e4b15/lxml-5.4.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:9459e6892f59ecea2e2584ee1058f5d8f629446eab52ba2305ae13a32a059530", size = 3891034 },
-    { url = "https://files.pythonhosted.org/packages/c9/5d/6e1033ee0cdb2f9bc93164f9df14e42cb5bbf1bbed3bf67f687de2763104/lxml-5.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47fb24cc0f052f0576ea382872b3fc7e1f7e3028e53299ea751839418ade92a6", size = 4207420 },
-    { url = "https://files.pythonhosted.org/packages/f3/4b/23ac79efc32d913259d66672c5f93daac7750a3d97cdc1c1a9a5d1c1b46c/lxml-5.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50441c9de951a153c698b9b99992e806b71c1f36d14b154592580ff4a9d0d877", size = 4305106 },
-    { url = "https://files.pythonhosted.org/packages/a4/7a/fe558bee63a62f7a75a52111c0a94556c1c1bdcf558cd7d52861de558759/lxml-5.4.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ab339536aa798b1e17750733663d272038bf28069761d5be57cb4a9b0137b4f8", size = 4205587 },
-    { url = "https://files.pythonhosted.org/packages/ed/5b/3207e6bd8d67c952acfec6bac9d1fa0ee353202e7c40b335ebe00879ab7d/lxml-5.4.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:9776af1aad5a4b4a1317242ee2bea51da54b2a7b7b48674be736d463c999f37d", size = 4329077 },
-    { url = "https://files.pythonhosted.org/packages/a1/25/d381abcfd00102d3304aa191caab62f6e3bcbac93ee248771db6be153dfd/lxml-5.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:63e7968ff83da2eb6fdda967483a7a023aa497d85ad8f05c3ad9b1f2e8c84987", size = 3486416 },
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b5/0a0f61cc8c6aa61f439d276e62e70cbf4f32205f57b1fbd483b8d0cf514b/lxml-6.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c9f79d5325907f13e1be0b3e4dacc1049d1dffc4aeee3c995284bea5fe0fab7d", size = 8553821, upload-time = "2026-05-18T19:18:54.406Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/dc/66603d8f755d26f39c41cf29ed30e4a3bc93973d72a825cd12be91c5bd7b/lxml-6.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:83b6b30eb131da7a75b601f28c5d6971e6ed3e887919bf6b6a1ad3c2df289080", size = 4607623, upload-time = "2026-05-18T19:18:58.556Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ad/5ea70128e6b0d34a52d16e2386666f8f9529c17cfac46d5980fd22c35daa/lxml-6.1.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:441dd227fa0690eb9fc81edabc63cdcefc212bba99b906dcf6e32cc1a9d3e533", size = 5005993, upload-time = "2026-05-18T19:20:24.125Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c2/13a33e8659f95d59f28a293f31c31d61d858a1bd4294b82a662cfbae126b/lxml-6.1.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e07c65f443c887bbcf31cc1771d932ecc192a5273943589b3c7572b749f1ffb2", size = 5160240, upload-time = "2026-05-18T19:20:26.549Z" },
+    { url = "https://files.pythonhosted.org/packages/65/06/e850042d7b33cf47d2f1bc4accb31ab34478f56f46c376b7a67c6b1a84c5/lxml-6.1.1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bec7d03d78d853597d6107854c2310ce3f761fd218fe9fe91d5101fcf6c2efe", size = 5062940, upload-time = "2026-05-18T19:20:29.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5a/8d7a0b3e42b21a553f01e288e70283f4de37c015c9c2477a0c31dafa0408/lxml-6.1.1-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f76acfb5f68ba982635a53fd985a8044be98a35b43232c2a1ee235ffab3e1dd", size = 5292921, upload-time = "2026-05-18T19:20:31.463Z" },
+    { url = "https://files.pythonhosted.org/packages/03/7c/9238d52bc426c8737b427ce57ea48c8a5a91974c5dcc55a34260dd851763/lxml-6.1.1-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:8d43ca737b20e106e4aebc42b2f3ae19f00ba63d7eb731698ee083d72d15646f", size = 5416716, upload-time = "2026-05-18T19:20:34.059Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/be127e1f36410d8ec84964adf76694b72f7705593c16c838dc8b1061b0b8/lxml-6.1.1-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:32ab449a5486f6c758e849bb86710d0e45edc24a04e250c01555f8f5653958f8", size = 4773279, upload-time = "2026-05-18T19:20:36.555Z" },
+    { url = "https://files.pythonhosted.org/packages/77/42/5e3ca677b4d56ae189a454764d28d922d343750419548409974d913a9b65/lxml-6.1.1-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53c909b62a0532183542fed00c5a7218258c56292d409bc789886fe1cb04c438", size = 5361618, upload-time = "2026-05-18T19:20:39.044Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/816979635625f8b8f88b69b5f7d9a4ebdc3c0bab1bf70c824e4ffe239879/lxml-6.1.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:640f97d43d867bcb9c75b3af013b64850756b746cb6bce8ace83b70da3abba9d", size = 5111217, upload-time = "2026-05-18T19:19:42.123Z" },
+    { url = "https://files.pythonhosted.org/packages/25/86/a6ec97064d25959d4932f2e91b547ce6b8380daa27de08b103c7b50be323/lxml-6.1.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:469e3618338bd7ab5beb412d2439825479fcf0dab99e394ca563dbc4eaf6c834", size = 4808149, upload-time = "2026-05-18T19:19:45.317Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/85/dc6087d1ba06589202ee25cda29abb175443da2da70c9e6bcf92091ad272/lxml-6.1.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:aae97dfdb60715c164419ac2532a76d013c3918a665eb6cb7288098b5f349aaf", size = 5352761, upload-time = "2026-05-18T19:19:48.608Z" },
+    { url = "https://files.pythonhosted.org/packages/69/93/e89fcb55d12b8e1473ce9a62b8f6ee215c89532f7a75a7ce55830834373b/lxml-6.1.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c9a4b821dc7055bf9e05ff5719e18ec501f75c0f0bbfabd573b277559780833d", size = 5315355, upload-time = "2026-05-18T19:19:51.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/4f07e22d26e2e1ad741666f768df2d3b18ff1ddab3a99e2cb35d5b5df3a3/lxml-6.1.1-cp39-cp39-win32.whl", hash = "sha256:639f6c857d91d9be29bd7502348d6736dab168b54b5158cd899abf11684dc186", size = 3601121, upload-time = "2026-05-18T19:17:58.57Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/49/4bcb779b303876f1750eb37f534230ef4e7221341826cbd5e42388087393/lxml-6.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:34c2d737beabfe35baada43941ed519251e9a12e779031496bcd5d539fcfd730", size = 4024637, upload-time = "2026-05-18T19:18:32.806Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e6/0d1b437d0783874ff15fb94be03045bce6dcefbce1ea22e44a2dbd59a902/lxml-6.1.1-cp39-cp39-win_arm64.whl", hash = "sha256:07a4a68e286ee7a1ed7dfb8af83e615757c0ccfe9f18c6b4ea6771388d9ba8c9", size = 3670865, upload-time = "2026-05-19T19:23:01.555Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
 ]
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
 name = "markupsafe"
-version = "0.23"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/41/bae1254e0396c0cc8cf1751cb7d9afc90a602353695af5952530482c963f/MarkupSafe-0.23.tar.gz", hash = "sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3", size = 13416 }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
+]
 
 [[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
 name = "more-itertools"
-version = "10.7.0"
+version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278 },
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
 name = "nh3"
-version = "0.2.21"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/30/2f81466f250eb7f591d4d193930df661c8c23e9056bdc78e365b646054d8/nh3-0.2.21.tar.gz", hash = "sha256:4990e7ee6a55490dbf00d61a6f476c9a3258e31e711e13713b2ea7d6616f670e", size = 16581 }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7", size = 24684, upload-time = "2026-06-22T00:47:02.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/81/b83775687fcf00e08ade6d4605f0be9c4584cb44c4973d9f27b7456a31c9/nh3-0.2.21-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:fcff321bd60c6c5c9cb4ddf2554e22772bb41ebd93ad88171bbbb6f271255286", size = 1297678 },
-    { url = "https://files.pythonhosted.org/packages/22/ee/d0ad8fb4b5769f073b2df6807f69a5e57ca9cea504b78809921aef460d20/nh3-0.2.21-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31eedcd7d08b0eae28ba47f43fd33a653b4cdb271d64f1aeda47001618348fde", size = 733774 },
-    { url = "https://files.pythonhosted.org/packages/ea/76/b450141e2d384ede43fe53953552f1c6741a499a8c20955ad049555cabc8/nh3-0.2.21-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d426d7be1a2f3d896950fe263332ed1662f6c78525b4520c8e9861f8d7f0d243", size = 760012 },
-    { url = "https://files.pythonhosted.org/packages/97/90/1182275db76cd8fbb1f6bf84c770107fafee0cb7da3e66e416bcb9633da2/nh3-0.2.21-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9d67709bc0d7d1f5797b21db26e7a8b3d15d21c9c5f58ccfe48b5328483b685b", size = 923619 },
-    { url = "https://files.pythonhosted.org/packages/29/c7/269a7cfbec9693fad8d767c34a755c25ccb8d048fc1dfc7a7d86bc99375c/nh3-0.2.21-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:55823c5ea1f6b267a4fad5de39bc0524d49a47783e1fe094bcf9c537a37df251", size = 1000384 },
-    { url = "https://files.pythonhosted.org/packages/68/a9/48479dbf5f49ad93f0badd73fbb48b3d769189f04c6c69b0df261978b009/nh3-0.2.21-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:818f2b6df3763e058efa9e69677b5a92f9bc0acff3295af5ed013da544250d5b", size = 918908 },
-    { url = "https://files.pythonhosted.org/packages/d7/da/0279c118f8be2dc306e56819880b19a1cf2379472e3b79fc8eab44e267e3/nh3-0.2.21-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b3b5c58161e08549904ac4abd450dacd94ff648916f7c376ae4b2c0652b98ff9", size = 909180 },
-    { url = "https://files.pythonhosted.org/packages/26/16/93309693f8abcb1088ae143a9c8dbcece9c8f7fb297d492d3918340c41f1/nh3-0.2.21-cp313-cp313t-win32.whl", hash = "sha256:637d4a10c834e1b7d9548592c7aad760611415fcd5bd346f77fd8a064309ae6d", size = 532747 },
-    { url = "https://files.pythonhosted.org/packages/a2/3a/96eb26c56cbb733c0b4a6a907fab8408ddf3ead5d1b065830a8f6a9c3557/nh3-0.2.21-cp313-cp313t-win_amd64.whl", hash = "sha256:713d16686596e556b65e7f8c58328c2df63f1a7abe1277d87625dcbbc012ef82", size = 528908 },
-    { url = "https://files.pythonhosted.org/packages/ba/1d/b1ef74121fe325a69601270f276021908392081f4953d50b03cbb38b395f/nh3-0.2.21-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a772dec5b7b7325780922dd904709f0f5f3a79fbf756de5291c01370f6df0967", size = 1316133 },
-    { url = "https://files.pythonhosted.org/packages/b8/f2/2c7f79ce6de55b41e7715f7f59b159fd59f6cdb66223c05b42adaee2b645/nh3-0.2.21-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d002b648592bf3033adfd875a48f09b8ecc000abd7f6a8769ed86b6ccc70c759", size = 758328 },
-    { url = "https://files.pythonhosted.org/packages/6d/ad/07bd706fcf2b7979c51b83d8b8def28f413b090cf0cb0035ee6b425e9de5/nh3-0.2.21-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2a5174551f95f2836f2ad6a8074560f261cf9740a48437d6151fd2d4d7d617ab", size = 747020 },
-    { url = "https://files.pythonhosted.org/packages/75/99/06a6ba0b8a0d79c3d35496f19accc58199a1fb2dce5e711a31be7e2c1426/nh3-0.2.21-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b8d55ea1fc7ae3633d758a92aafa3505cd3cc5a6e40470c9164d54dff6f96d42", size = 944878 },
-    { url = "https://files.pythonhosted.org/packages/79/d4/dc76f5dc50018cdaf161d436449181557373869aacf38a826885192fc587/nh3-0.2.21-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ae319f17cd8960d0612f0f0ddff5a90700fa71926ca800e9028e7851ce44a6f", size = 903460 },
-    { url = "https://files.pythonhosted.org/packages/cd/c3/d4f8037b2ab02ebf5a2e8637bd54736ed3d0e6a2869e10341f8d9085f00e/nh3-0.2.21-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ca02ac6f27fc80f9894409eb61de2cb20ef0a23740c7e29f9ec827139fa578", size = 839369 },
-    { url = "https://files.pythonhosted.org/packages/11/a9/1cd3c6964ec51daed7b01ca4686a5c793581bf4492cbd7274b3f544c9abe/nh3-0.2.21-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5f77e62aed5c4acad635239ac1290404c7e940c81abe561fd2af011ff59f585", size = 739036 },
-    { url = "https://files.pythonhosted.org/packages/fd/04/bfb3ff08d17a8a96325010ae6c53ba41de6248e63cdb1b88ef6369a6cdfc/nh3-0.2.21-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:087ffadfdcd497658c3adc797258ce0f06be8a537786a7217649fc1c0c60c293", size = 768712 },
-    { url = "https://files.pythonhosted.org/packages/9e/aa/cfc0bf545d668b97d9adea4f8b4598667d2b21b725d83396c343ad12bba7/nh3-0.2.21-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ac7006c3abd097790e611fe4646ecb19a8d7f2184b882f6093293b8d9b887431", size = 930559 },
-    { url = "https://files.pythonhosted.org/packages/78/9d/6f5369a801d3a1b02e6a9a097d56bcc2f6ef98cffebf03c4bb3850d8e0f0/nh3-0.2.21-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:6141caabe00bbddc869665b35fc56a478eb774a8c1dfd6fba9fe1dfdf29e6efa", size = 1008591 },
-    { url = "https://files.pythonhosted.org/packages/a6/df/01b05299f68c69e480edff608248313cbb5dbd7595c5e048abe8972a57f9/nh3-0.2.21-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:20979783526641c81d2f5bfa6ca5ccca3d1e4472474b162c6256745fbfe31cd1", size = 925670 },
-    { url = "https://files.pythonhosted.org/packages/3d/79/bdba276f58d15386a3387fe8d54e980fb47557c915f5448d8c6ac6f7ea9b/nh3-0.2.21-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a7ea28cd49293749d67e4fcf326c554c83ec912cd09cd94aa7ec3ab1921c8283", size = 917093 },
-    { url = "https://files.pythonhosted.org/packages/e7/d8/c6f977a5cd4011c914fb58f5ae573b071d736187ccab31bfb1d539f4af9f/nh3-0.2.21-cp38-abi3-win32.whl", hash = "sha256:6c9c30b8b0d291a7c5ab0967ab200598ba33208f754f2f4920e9343bdd88f79a", size = 537623 },
-    { url = "https://files.pythonhosted.org/packages/23/fc/8ce756c032c70ae3dd1d48a3552577a325475af2a2f629604b44f571165c/nh3-0.2.21-cp38-abi3-win_amd64.whl", hash = "sha256:bb0014948f04d7976aabae43fcd4cb7f551f9f8ce785a4c9ef66e6c2590f8629", size = 535283 },
+    { url = "https://files.pythonhosted.org/packages/99/3e/6506aa4f23dc7b7993a2d0a45dca3ce864ec48380adfe15a173e643c63e8/nh3-0.3.6-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2", size = 1421679, upload-time = "2026-06-22T00:46:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/e96e7864a7a53bd6b6fab7e9632467382a2a2c1f3fed951918ad131542fb/nh3-0.3.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d", size = 792570, upload-time = "2026-06-22T00:46:22.179Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/5b6108bedaef2b2637fed04c87bdbcb5967b9961758b41f0e466ef22a022/nh3-0.3.6-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e", size = 842243, upload-time = "2026-06-22T00:46:23.801Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4a/526f199626bfcb496bc01a268051b44737962005553b158e985ed7e64865/nh3-0.3.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917", size = 1001468, upload-time = "2026-06-22T00:46:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/49/09/0d8e3101636d9ad88cdefb2914e764cb8e876ebdbb4286bfc251277d9c67/nh3-0.3.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4", size = 1082933, upload-time = "2026-06-22T00:46:27.15Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a1/ea83abe738a3fbaa203dfdb836ca7cbab0e7e9609faaee4fe1d4652599c0/nh3-0.3.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9", size = 1043120, upload-time = "2026-06-22T00:46:28.89Z" },
+    { url = "https://files.pythonhosted.org/packages/66/69/0654482b8635012fbae67826bd6c381abb05d841ac7388b9b4666300fdad/nh3-0.3.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6", size = 1023824, upload-time = "2026-06-22T00:46:30.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/1f7285ffadc8307c4dbeb08d21b920536d5117785056d1079e998c4dfa44/nh3-0.3.6-cp314-cp314t-win32.whl", hash = "sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796", size = 599253, upload-time = "2026-06-22T00:46:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/5542f3c45da4c00290d9d67a65e996702e23e613c4b627de3e09cb9fe357/nh3-0.3.6-cp314-cp314t-win_amd64.whl", hash = "sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6", size = 612553, upload-time = "2026-06-22T00:46:33.53Z" },
+    { url = "https://files.pythonhosted.org/packages/66/35/26bd47e6af5915a628281dccdac354ddf4e32f7397047894270acd8c9870/nh3-0.3.6-cp314-cp314t-win_arm64.whl", hash = "sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41", size = 595151, upload-time = "2026-06-22T00:46:34.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25", size = 1443564, upload-time = "2026-06-22T00:46:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69", size = 838002, upload-time = "2026-06-22T00:46:38.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/94/f48d08e6f72a406300fa11d8acd929fea1a80d4bf750fa292cb10785f126/nh3-0.3.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e", size = 823045, upload-time = "2026-06-22T00:46:39.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/431615ba1d1d3eb63cde0f974f2114edf863a8a3f6049a12fed23fc241d3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae", size = 1093171, upload-time = "2026-06-22T00:46:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/a0d80182a18919665fefd19c1c06f1d1df1c9a6455d0252de40c034a0bc3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d", size = 1049217, upload-time = "2026-06-22T00:46:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/6f1e302ca674ac74362e150848ad56a1be5145391204f74facdb8e94df12/nh3-0.3.6-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf", size = 917372, upload-time = "2026-06-22T00:46:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e", size = 806699, upload-time = "2026-06-22T00:46:45.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bfaa00046e58603507dcfc266c4778e3ab7adf68a5dedd73b6274b8d9314/nh3-0.3.6-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec", size = 835165, upload-time = "2026-06-22T00:46:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/fb2c38845efb703a9173bffdfc745fc64d2b0e55cfc73a3647d2f028250c/nh3-0.3.6-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0", size = 858282, upload-time = "2026-06-22T00:46:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/68/17/06e72a18ee9b572914447338237ca7eb164c0df901f141bc10d1282247a2/nh3-0.3.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78", size = 1014328, upload-time = "2026-06-22T00:46:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/3966c61455668c08853bf5e33b4bed93c421f3194ce4de896dc248d6f6ce/nh3-0.3.6-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438", size = 1098207, upload-time = "2026-06-22T00:46:52.674Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/479cb4ae440424825735d60525b53e3c77fd60fd6e6afc0e984f00eb0178/nh3-0.3.6-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56", size = 1056961, upload-time = "2026-06-22T00:46:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/6cdb5ee1e127be50dc8391e54bddc1f64e87bf4bfad0c55633320e2e02db/nh3-0.3.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f", size = 1033829, upload-time = "2026-06-22T00:46:56.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
 ]
 
 [[package]]
 name = "nodeenv"
-version = "1.9.1"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
-]
-
-[[package]]
-name = "parse"
-version = "1.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126 },
-]
-
-[[package]]
-name = "parse-type"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parse" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/17/e9/a3b2ae5f8a852542788ac1f1865dcea0c549cc40af243f42cabfa0acf24d/parse_type-0.6.4.tar.gz", hash = "sha256:5e1ec10440b000c3f818006033372939e693a9ec0176f446d9303e4db88489a6", size = 96480 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/b3/f6cc950042bfdbe98672e7c834d930f85920fb7d3359f59096e8d2799617/parse_type-0.6.4-py2.py3-none-any.whl", hash = "sha256:83d41144a82d6b8541127bf212dd76c7f01baff680b498ce8a4d052a7a5bce4c", size = 27442 },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567 },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
-]
-
-[[package]]
-name = "pycparser"
-version = "2.22"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
-]
-
-[[package]]
-name = "pygments"
-version = "2.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120 },
-]
-
-[[package]]
-name = "pyproject-api"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/fd/437901c891f58a7b9096511750247535e891d2d5a5a6eefbc9386a2b41d5/pyproject_api-1.9.1.tar.gz", hash = "sha256:43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335", size = 22710 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/e6/c293c06695d4a3ab0260ef124a74ebadba5f4c511ce3a4259e976902c00b/pyproject_api-1.9.1-py3-none-any.whl", hash = "sha256:7d6238d92f8962773dd75b5f0c4a6a27cce092a14b623b811dba656f3b628948", size = 13158 },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.401"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/9a/7ab2b333b921b2d6bfcffe05a0e0a0bbeff884bd6fb5ed50cd68e2898e53/pyright-1.1.401.tar.gz", hash = "sha256:788a82b6611fa5e34a326a921d86d898768cddf59edde8e93e56087d277cc6f1", size = 3894193 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e6/1f908fce68b0401d41580e0f9acc4c3d1b248adcff00dfaad75cd21a1370/pyright-1.1.401-py3-none-any.whl", hash = "sha256:6fde30492ba5b0d7667c16ecaf6c699fab8d7a1263f6a18549e0b00bf7724c06", size = 5629193 },
-]
-
-[[package]]
-name = "pytest"
-version = "8.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797 },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -731,17 +866,18 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "alabaster" },
+    { name = "alabaster", marker = "python_full_version >= '3.10'" },
     { name = "behave" },
-    { name = "jinja2" },
-    { name = "markupsafe" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "markupsafe", marker = "python_full_version >= '3.10'" },
     { name = "pyparsing" },
     { name = "pyright" },
-    { name = "pytest" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
-    { name = "sphinx" },
-    { name = "tox" },
-    { name = "twine" },
+    { name = "sphinx", marker = "python_full_version >= '3.10'" },
+    { name = "tox", marker = "python_full_version >= '3.10'" },
+    { name = "twine", marker = "python_full_version >= '3.10'" },
     { name = "types-lxml-multi-subclass" },
 ]
 
@@ -753,46 +889,194 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "alabaster", specifier = "<0.7.14" },
+    { name = "alabaster", marker = "python_full_version >= '3.10'", specifier = ">=0.7.14,<0.8" },
     { name = "behave", specifier = ">=1.2.6" },
-    { name = "jinja2", specifier = "==2.11.3" },
-    { name = "markupsafe", specifier = "==0.23" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'", specifier = ">=3.1.6,<4" },
+    { name = "markupsafe", marker = "python_full_version >= '3.10'", specifier = ">=2.1.3,<4" },
     { name = "pyparsing", specifier = ">=3.2.3" },
     { name = "pyright", specifier = ">=1.1.401" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "ruff", specifier = ">=0.11.13" },
-    { name = "sphinx", specifier = "==1.8.6" },
-    { name = "tox", specifier = ">=4.26.0" },
-    { name = "twine", specifier = ">=6.1.0" },
+    { name = "sphinx", marker = "python_full_version >= '3.10'", specifier = ">=7.4.7,<8" },
+    { name = "tox", marker = "python_full_version >= '3.10'", specifier = ">=4.26.0" },
+    { name = "twine", marker = "python_full_version >= '3.10'", specifier = ">=6.1.0" },
     { name = "types-lxml-multi-subclass", specifier = ">=2025.3.30" },
+]
+
+[[package]]
+name = "parse"
+version = "1.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f2/0b504486c2a5564798607d3860e48ed19c6443d5e9cc3ec61cc6b8b4ef58/parse-1.22.1.tar.gz", hash = "sha256:d3a4740ec3da338e2b258b2d69741b731eadfddca59e24a14bc4ee5fce38c911", size = 36970, upload-time = "2026-05-26T03:44:52.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/c5/7c16e99869e1f422629092cfd23e3b58e461988c3f9c36fd3624bb4142e6/parse-1.22.1-py2.py3-none-any.whl", hash = "sha256:20f0925a46f06602485ac90d751764d0697fd8455aaa97489ba8953a4b66de32", size = 20925, upload-time = "2026-05-26T03:44:51.156Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyproject-api"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d7/29e1e5e882f79133631f7bcace42d23db493f616463c157a1ab614bf69dd/pyproject_api-1.10.1-py3-none-any.whl", hash = "sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a", size = 12992, upload-time = "2026-05-28T14:22:12.711Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756 },
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
 name = "readme-renderer"
-version = "43.0"
+version = "45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "nh3" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b5/536c775084d239df6345dccf9b043419c7e3308bc31be4c7882196abc62e/readme_renderer-43.0.tar.gz", hash = "sha256:1818dd28140813509eeed8d62687f7cd4f7bad90d4db586001c5dc09d4fde311", size = 31768 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/51/d3a6ea424652c60f05600d8c2e01a55c913755e7cdad64afabbd1aa16f44/readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1", size = 36172, upload-time = "2026-06-09T21:05:17.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/be/3ea20dc38b9db08387cf97997a85a7d51527ea2057d71118feb0aa8afa55/readme_renderer-43.0-py3-none-any.whl", hash = "sha256:19db308d86ecd60e5affa3b2a98f017af384678c63c88e5d4556a380e674f3f9", size = 13301 },
+    { url = "https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f", size = 14134, upload-time = "2026-06-09T21:05:15.85Z" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -800,9 +1084,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258 }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847 },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -812,111 +1096,101 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]
 name = "rfc3986"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326 },
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
 ]
 
 [[package]]
 name = "rich"
-version = "14.0.0"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.11.13"
+version = "0.15.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", hash = "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514", size = 4282054 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46", size = 10292516 },
-    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48", size = 11106083 },
-    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b", size = 10436024 },
-    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a", size = 10646324 },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc", size = 10174416 },
-    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629", size = 11724197 },
-    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933", size = 12511615 },
-    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165", size = 12117080 },
-    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71", size = 11326315 },
-    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9", size = 11555640 },
-    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc", size = 10507364 },
-    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7", size = 10141462 },
-    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432", size = 11121028 },
-    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492", size = 11602992 },
-    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944 },
-    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669 },
-    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928 },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
 ]
 
 [[package]]
 name = "secretstorage"
-version = "3.3.3"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739 }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221 },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486 },
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
 name = "snowballstemmer"
-version = "3.0.1"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274 },
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
 ]
 
 [[package]]
 name = "soupsieve"
-version = "2.7"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418 }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677 },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
 name = "sphinx"
-version = "1.8.6"
+version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
@@ -928,105 +1202,166 @@ dependencies = [
     { name = "packaging" },
     { name = "pygments" },
     { name = "requests" },
-    { name = "setuptools" },
-    { name = "six" },
     { name = "snowballstemmer" },
-    { name = "sphinxcontrib-websupport" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/74/5cef400220b2f22a4c85540b9ba20234525571b8b851be8a9ac219326a11/Sphinx-1.8.6.tar.gz", hash = "sha256:e096b1b369dbb0fcb95a31ba8c9e1ae98c588e601f08eada032248e1696de4b1", size = 5816141 }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/da/e1b65da61267aeb92a76b6b6752430bcc076d98b723687929eb3d2e0d128/Sphinx-1.8.6-py2.py3-none-any.whl", hash = "sha256:5973adbb19a5de30e15ab394ec8bc05700317fa83f122c349dd01804d983720f", size = 3110177 },
+    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
 ]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080 }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072 },
-]
-
-[[package]]
-name = "sphinxcontrib-websupport"
-version = "1.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinxcontrib-serializinghtml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/aa/b03a3f569a52b6f21a579d168083a27036c1f606269e34abdf5b70fe3a2c/sphinxcontrib-websupport-1.2.4.tar.gz", hash = "sha256:4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232", size = 602360 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/e5/2a547830845e6e6e5d97b3246fc1e3ec74cba879c9adc5a8e27f1291bca3/sphinxcontrib_websupport-1.2.4-py2.py3-none-any.whl", hash = "sha256:6fc9287dfc823fe9aa432463edd6cea47fa9ebbf488d7f289b322ffcfca075c7", size = 39924 },
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
 name = "tomli"
-version = "2.2.1"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
-    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
-    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
-    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
-    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
-    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
-    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
-    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
-    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
-    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
 name = "tox"
-version = "4.26.0"
+version = "4.56.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
-    { name = "chardet" },
     { name = "colorama" },
     { name = "filelock" },
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "pluggy" },
     { name = "pyproject-api" },
+    { name = "python-discovery" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/dcec0c00321a107f7f697fd00754c5112572ea6dcacb40b16d8c3eea7c37/tox-4.26.0.tar.gz", hash = "sha256:a83b3b67b0159fa58e44e646505079e35a43317a62d2ae94725e0586266faeca", size = 197260 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/fc/903385f783a1d7b7670eb742654e8f6f109c7a5a65913f92dfee8d033ea7/tox-4.56.4.tar.gz", hash = "sha256:d49e371119ebfafb15054ad7ccff3d03027ccb65195fae3ac656b431b5524055", size = 286611, upload-time = "2026-07-08T23:59:07.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/14/f58b4087cf248b18c795b5c838c7a8d1428dfb07cb468dad3ec7f54041ab/tox-4.26.0-py3-none-any.whl", hash = "sha256:75f17aaf09face9b97bd41645028d9f722301e912be8b4c65a3f938024560224", size = 172761 },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/d2e2b6969203c319165860ba93272cf12c71d42acff5acd2c84d7543b460/tox-4.56.4-py3-none-any.whl", hash = "sha256:53bac88382b9638a5ce40fbaddd6076e1c8f638751af7bf8e759392c953df2f0", size = 217458, upload-time = "2026-07-08T23:59:05.21Z" },
 ]
 
 [[package]]
 name = "twine"
-version = "6.1.0"
+version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
     { name = "packaging" },
     { name = "readme-renderer" },
@@ -1036,72 +1371,127 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791 },
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
 ]
 
 [[package]]
 name = "types-html5lib"
-version = "1.1.11.20250516"
+version = "1.1.11.20251117"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ed/9f092ff479e2b5598941855f314a22953bb04b5fb38bcba3f880feb833ba/types_html5lib-1.1.11.20250516.tar.gz", hash = "sha256:65043a6718c97f7d52567cc0cdf41efbfc33b1f92c6c0c5e19f60a7ec69ae720", size = 16136 }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "types-webencodings", version = "0.5.0.20251108", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f3/d9a1bbba7b42b5558a3f9fe017d967f5338cf8108d35991d9b15fdea3e0d/types_html5lib-1.1.11.20251117.tar.gz", hash = "sha256:1a6a3ac5394aa12bf547fae5d5eff91dceec46b6d07c4367d9b39a37f42f201a", size = 18100, upload-time = "2025-11-17T03:08:00.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/3b/cb5b23c7b51bf48b8c9f175abb9dce2f1ecd2d2c25f92ea9f4e3720e9398/types_html5lib-1.1.11.20250516-py3-none-any.whl", hash = "sha256:5e407b14b1bd2b9b1107cbd1e2e19d4a0c46d60febd231c7ab7313d7405663c1", size = 21770 },
+    { url = "https://files.pythonhosted.org/packages/f0/ab/f5606db367c1f57f7400d3cb3bead6665ee2509621439af1b29c35ef6f9e/types_html5lib-1.1.11.20251117-py3-none-any.whl", hash = "sha256:2a3fc935de788a4d2659f4535002a421e05bea5e172b649d33232e99d4272d08", size = 24302, upload-time = "2025-11-17T03:07:59.996Z" },
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20260518"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "types-webencodings", version = "0.5.0.20260408", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/5a/0c708d1b0d35ad48b6a223c77c4a882fd016b40c25becb082a92e02a9c00/types_html5lib-1.1.11.20260518.tar.gz", hash = "sha256:4f33c087cb1119d65c4c80eca4323c2b501f9eaf8af9616b8b732ed4d8eae8fa", size = 18420, upload-time = "2026-05-18T06:07:23.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/d0/b088b9f11eb69637d6826843f06caaff60247156735a25512922d3dc2c13/types_html5lib-1.1.11.20260518-py3-none-any.whl", hash = "sha256:9baa7912224ebb37027c5ccb7e3768e43ea47b1dfdd977e7ddc4b0a4a550584d", size = 24339, upload-time = "2026-05-18T06:07:22.876Z" },
 ]
 
 [[package]]
 name = "types-lxml-multi-subclass"
-version = "2025.3.30"
+version = "2026.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "cssselect" },
-    { name = "types-html5lib" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "cssselect", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cssselect", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "types-html5lib", version = "1.1.11.20251117", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-html5lib", version = "1.1.11.20260518", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/3a/7f6d1d3b921404efef20ed1ddc2b6f1333e3f0bc5b91da37874e786ff835/types_lxml_multi_subclass-2025.3.30.tar.gz", hash = "sha256:7ac7a78e592fdba16951668968b21511adda49bbefbc0f130e55501b70e068b4", size = 153188 }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/bfffbead7eeefdb509834997e96f6f6d80692e6c13abe9cee00c6490655e/types_lxml_multi_subclass-2026.2.16.tar.gz", hash = "sha256:71150f126f518f336ce0a5e08ae76f5c996573d99dd6e1cb8cba95d3437ef03a", size = 161387, upload-time = "2026-02-17T02:38:19.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/8e/106b4c5a67e6d52475ef51008e6c27d4ad472690d619dc32e079d28a540b/types_lxml_multi_subclass-2025.3.30-py3-none-any.whl", hash = "sha256:b0563e4e49e66eb8093c44e74b262c59e3be6d3bb3437511e3a4843fd74044d1", size = 93475 },
+    { url = "https://files.pythonhosted.org/packages/c6/26/bdce67870d59176a2c8521c9519077ae5728241f026c252bbf3f1b8d280a/types_lxml_multi_subclass-2026.2.16-py3-none-any.whl", hash = "sha256:4301542698ce595caa6a8152823596f2ed9b58211786789d86993b0cfff56a58", size = 97301, upload-time = "2026-02-17T02:38:17.778Z" },
+]
+
+[[package]]
+name = "types-webencodings"
+version = "0.5.0.20251108"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/d6/75e381959a2706644f02f7527d264de3216cf6ed333f98eff95954d78e07/types_webencodings-0.5.0.20251108.tar.gz", hash = "sha256:2378e2ceccced3d41bb5e21387586e7b5305e11519fc6b0659c629f23b2e5de4", size = 7470, upload-time = "2025-11-08T02:56:00.132Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/4e/8fcf33e193ce4af03c19d0e08483cf5f0838e883f800909c6bc61cb361be/types_webencodings-0.5.0.20251108-py3-none-any.whl", hash = "sha256:e21f81ff750795faffddaffd70a3d8bfff77d006f22c27e393eb7812586249d8", size = 8715, upload-time = "2025-11-08T02:55:59.456Z" },
+]
+
+[[package]]
+name = "types-webencodings"
+version = "0.5.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/d2/21567fac142315580ce3ee37d08a4e8819921dae833bbcd27b9f8b373799/types_webencodings-0.5.0.20260408.tar.gz", hash = "sha256:28c596619f367e43eee393d85f63e8d2fdb6874c654a8d441c37f8afe29c6d0d", size = 7504, upload-time = "2026-04-08T04:28:51.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/e4/f13be8f6d9a561166f7d963012d0ccc833e13aee3044c4f1a8fb1fee462a/types_webencodings-0.5.0.20260408-py3-none-any.whl", hash = "sha256:19a2afe5c22d9b1e880b49ff823c7b531f473a390fe47ac903c0bdb5cd677dd9", size = 8717, upload-time = "2026-04-08T04:28:50.943Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
 name = "virtualenv"
-version = "20.31.2"
+version = "21.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316 }
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982 },
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]
-name = "zipp"
-version = "3.23.0"
+name = "win-unicode-console"
+version = "0.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
+sdist = { url = "https://files.pythonhosted.org/packages/89/8d/7aad74930380c8972ab282304a2ff45f3d4927108bb6693cabcc9fc6a099/win_unicode_console-0.5.zip", hash = "sha256:d4142d4d56d46f449d6f00536a73625a871cba040f0bc1a2e305a04578f07d1e", size = 31420, upload-time = "2016-06-25T19:48:54.05Z" }
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

This consolidates the unmerged `0.1.1` hardening PR (#9) with the practical contract work that followed it and prepares the combined result as `paper-docx 0.1.2`.

- retain all safety, rollback, compare, ZIP/OPC, distribution-identity, CI, and release hardening from #9
- make staged OPC writes validate the complete output before replacing a path or writing to a caller-owned stream
- strengthen stale-handle, field, comment, bookmark, content-control, scrub, and protection checks
- preserve and remap bookmark, style, numbering, relationship, and field dependencies during composition
- address merged and offset table cells through Word's visible layout grid
- advance the distribution and `docx.__paper_version__` sentinel to `0.1.2`
- include the scoped hardening proposal as the rationale and boundary for the added work

## Why

The combined changes harden the contract surface that matters in professional document work: a failed save or compound edit must not leave partial state; stale or ambiguous handles must not target the wrong content; review structures and package relationships must remain internally consistent; and unsupported structures must refuse before mutation.

This PR supersedes #9 so the unreleased `0.1.1` candidate does not need to be merged separately.

## Verification

- `2597 passed` in the complete local pytest suite using the same warning handling as CI
- focused proposal and affected regression suites passed
- `67` Behave features, `650` scenarios, and `1856` steps passed locally
- Sphinx 7.4 documentation build passed with `-W`
- changed source files passed Ruff; `uv lock --check` and `git diff --check` passed
- wheel and sdist built as `paper-docx 0.1.2` and passed `twine check --strict`
- clean virtual-environment smoke tests confirmed both artifacts report `paper-docx == docx.__paper_version__ == 0.1.2`
- GitHub Actions passed pytest and Behave on Python 3.9-3.13, the LibreOffice contract, strict docs, artifact inspection, the real-environment distribution collision matrix, and the aggregate required gate

## Review follow-up

Follow-up commits `9a4b451`, `072ccdc`, `d026a1f`, `e8a9f0b`, and `067102d` address the material review findings, including inherited comment authoring, Windows atomic saves, relationship parsing, final artifact validation, protection and compare, numbering traversal, bookmark and comment identity handling, complete comment scrubbing, doctor error handling, replacement-batch performance, Read the Docs runtime compatibility, case-insensitive OPC story matching, compare offsets around inline objects, single-snapshot compare inputs, append-stream safety, comment thread-state preservation, revision-stable bookmarks, non-mutating comment inspection, and scrub option isolation. The XML-ID claim was not reproducible; pre-year-1000 date formatting, byte-returning `PathLike` support for expanded package directories, and an unused private helper were deliberately left out because they do not affect correctness or practical professional-document workflows.

## Release

Merging this PR does not publish automatically. After it is merged, pushing tag `v0.1.2` from the merged `main` commit triggers the release workflow, which reruns quality gates, builds and verifies the artifacts, and publishes those exact artifacts to PyPI through OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to compare semantics, package I/O, and rollback behavior affect core document workflows; mis-refusals or incomplete rollback could block legitimate edits or leave inconsistent state.
> 
> **Overview**
> Prepares **`paper-docx 0.1.2`** by folding in the prior hardening work and tightening the public safety contract around editing, comparison, and packaging.
> 
> **`compare`** now validates raw package graphs up front, **refuses** differences it cannot express as tracked revisions (formatting, fields, hyperlinks, non-story parts, etc.) instead of reporting lossy findings, enforces sequence/pairing budgets, and **proves accept/reject** on private copies before returning a redline.
> 
> New infrastructure includes **`_zipguard`** (bounded, validated ZIP reads), **`PackageLimitError`**, **`_transaction`** rollback for multi-part mutations, **`assert_distribution_identity`** plus the **`paper-docx-doctor`** CLI, and ownership guards so spans/comments cannot mutate another document’s package.
> 
> **`patch_save`** and related package paths use guarded reads, staged output validation, deterministic ZIP metadata, and permission-preserving atomic writes; bookmarks, blocks, and text projection gain stricter revision/field/staleness checks.
> 
> **CI/release** reuses `test.yml` (pytest matrix, LibreOffice smoke, strict Sphinx, distribution collision matrix), splits release into build-then-publish with verified artifacts, and bumps docs/RTD tooling to Python 3.13 with **`fail_on_warning`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067102de850bca0fda14eba641688f448230eda8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



