### PR TITLE
feat: add Drawing.replace_picture

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -36,7 +36,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Delete one comment~~ **Done.** `delete_comment`.
 - ~~Modern comment identity parts~~ **Done.** New comments write `commentsIds.xml` and `commentsExtensible.xml`.
 - ~~Lock a file for the recipient~~ **Done.** `set_protection`.
-- Replace one existing picture
+- ~~Replace one existing picture~~ **Done.** `Drawing.replace_picture`. Picture form controls still refuse.
 - Create or retarget a hyperlink
 - Auto-number caption field
 - Add a footnote or endnote
@@ -87,7 +87,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Delete one comment and leave the rest~~ **Done.** | Review | Add, reply, or resolve. No single-comment delete. | `delete_comment` | **Not asked.** Original plan is add, reply, resolve only. |
 | ~~Add a comment that current Word will show and round-trip~~ **Done.** | Review | Only `comments.xml` and `commentsExtended.xml`. Current Word also wants `commentsIds.xml` and `commentsExtensible.xml`. | New comments write those two parts. | **Not asked.** Original plan is the older extra comments part only. |
 | ~~Lock a file for the recipient (read-only, comments only, or forms only)~~ **Done.** | Deliver | Could report Restrict Editing and refuse edits. Could not turn it on. | `set_protection` | **Not asked.** Plan: report it, never strip it, refuse edits while it is on. No setter. |
-| Replace one existing picture, keep size and position | Edit existing | Insert (stock) or copy on combine. No in-place swap that avoids sharing the image part. Picture form controls still refuse. | | **Later, if someone asks.** Image swap was parked until a real demand. |
+| ~~Replace one existing picture, keep size and position~~ **Done.** | Edit existing | Insert (stock) or copy on combine. No in-place swap that avoids sharing the image part. Picture form controls still refuse. | `Drawing.replace_picture` | **Later, if someone asks.** Image swap was parked until a real demand. |
 | Turn a phrase into a hyperlink, or change where an existing link goes | Edit existing, review | URL was read-only. Create/retarget was XML. | | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
 | Caption a figure or table so numbers update (Figure 1, Figure 2, …) | Structured | Bookmark plus REF is not a SEQ caption field. | | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
 | Add a footnote or endnote | Edit existing | Existing notes could be read and edited. New notes were not created. | | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |

--- a/src/docx/drawing/__init__.py
+++ b/src/docx/drawing/__init__.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
+from docx._transaction import rollback_on_error
+from docx.image.image import Image
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.drawing import CT_Drawing
+from docx.oxml.ns import qn
+from docx.protection import _refuse_if_protected
 from docx.shared import Parented
 
 if TYPE_CHECKING:
     import docx.types as t
-    from docx.image.image import Image
 
 
 class Drawing(Parented):
@@ -57,3 +61,20 @@ class Drawing(Parented):
         doc_part = self.part
         image_part = doc_part.related_parts[rId]
         return image_part.image
+
+    def replace_picture(self, image_descriptor: str | IO[bytes]) -> None:
+        """Swap this drawing's image bytes. Display size and position stay.
+
+        Always writes a new image part so other shapes that shared the old
+        part are unchanged.
+        """
+        if not self.has_picture:
+            raise ValueError("drawing does not contain a picture")
+        document = self.part.package.main_document_part.document
+        _refuse_if_protected(document, "replace a picture")
+        with rollback_on_error(document):
+            image = Image.from_file(image_descriptor)
+            image_part = self.part.package.image_parts._add_image_part(image)
+            r_id = self.part.relate_to(image_part, RT.IMAGE)
+            for blip in self._drawing.xpath(".//pic:blipFill/a:blip"):
+                blip.set(qn("r:embed"), r_id)

--- a/src/docx/drawing/__init__.py
+++ b/src/docx/drawing/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import IO, TYPE_CHECKING
 
 from docx._transaction import rollback_on_error
+from docx.errors import UnsupportedStructureError
 from docx.image.image import Image
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.drawing import CT_Drawing
@@ -70,6 +71,10 @@ class Drawing(Parented):
         """
         if not self.has_picture:
             raise ValueError("drawing does not contain a picture")
+        if self._drawing.xpath(".//pic:blipFill/a:blip/@r:link"):
+            raise UnsupportedStructureError(
+                "drawing is a linked picture; nothing was changed"
+            )
         document = self.part.package.main_document_part.document
         _refuse_if_protected(document, "replace a picture")
         with rollback_on_error(document):

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -206,6 +206,7 @@ APPROVED_SIGNATURES = [
         "(paragraph, *, bookmark, kind='text')",
     ),
     ("docx.fields", "insert_toc_after", "(document, anchor, *, levels=(1, 3))"),
+    ("docx.drawing", "Drawing.replace_picture", "(self, image_descriptor)"),
     ("docx.formatting", "format_of", "(target)"),
     ("docx.formatting", "surrounding_format", "(document, anchor)"),
 ]

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import io
+import struct
 from pathlib import Path
 
 import pytest
 
 import docx
+<<<<<<< HEAD
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
+from docx.drawing import Drawing
 from docx.errors import DocumentProtectedError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
@@ -22,6 +26,18 @@ MINIMAL = "generated/minimal-clean/minimal.docx"
 
 def _doc(relpath: str = MINIMAL):
     return docx.Document(str(fixture_path(relpath)))
+
+
+def _bmp(red: int, green: int, blue: int) -> bytes:
+    return (
+        struct.pack("<2sIHHI", b"BM", 58, 0, 0, 54)
+        + struct.pack("<IiiHHIIiiII", 40, 1, 1, 1, 24, 0, 4, 2835, 2835, 0, 0)
+        + bytes((blue, green, red, 0))
+    )
+
+
+def _blip_embed(drawing: Drawing) -> str:
+    return drawing._drawing.xpath(".//pic:blipFill/a:blip/@r:embed")[0]
 
 
 class DescribeCommentDeleteAndIdentity:
@@ -100,3 +116,27 @@ class DescribeProtectionSetter:
         set_protection(document, edit="readOnly")
         tags = [child.tag for child in settings]
         assert tags.index(qn("w:documentProtection")) < tags.index(qn("w:footnotePr"))
+
+
+class DescribePictureReplace:
+    def it_swaps_bytes_without_sharing_the_part(self):
+        document = _doc()
+        run = document.add_paragraph().add_run()
+        run.add_picture(io.BytesIO(_bmp(255, 0, 0)))
+        other = document.add_paragraph().add_run()
+        other.add_picture(io.BytesIO(_bmp(255, 0, 0)))
+        drawing = next(
+            item for item in run.iter_inner_content() if isinstance(item, Drawing)
+        )
+        other_drawing = next(
+            item for item in other.iter_inner_content() if isinstance(item, Drawing)
+        )
+        shared = _blip_embed(drawing)
+        assert _blip_embed(other_drawing) == shared
+        extent = drawing._drawing.xpath(".//wp:extent")[0]
+        cx, cy = extent.get("cx"), extent.get("cy")
+        drawing.replace_picture(io.BytesIO(_bmp(0, 0, 255)))
+        assert _blip_embed(drawing) != shared
+        assert _blip_embed(other_drawing) == shared
+        assert extent.get("cx") == cx
+        assert extent.get("cy") == cy

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -9,10 +9,9 @@ from pathlib import Path
 import pytest
 
 import docx
-<<<<<<< HEAD
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
 from docx.drawing import Drawing
-from docx.errors import DocumentProtectedError
+from docx.errors import DocumentProtectedError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.protection import acknowledge_protection, set_protection
@@ -140,3 +139,15 @@ class DescribePictureReplace:
         assert _blip_embed(other_drawing) == shared
         assert extent.get("cx") == cx
         assert extent.get("cy") == cy
+
+    def it_refuses_a_linked_picture(self):
+        document = _doc()
+        run = document.add_paragraph().add_run()
+        run.add_picture(io.BytesIO(_bmp(255, 0, 0)))
+        drawing = next(
+            item for item in run.iter_inner_content() if isinstance(item, Drawing)
+        )
+        blip = drawing._drawing.xpath(".//pic:blipFill/a:blip")[0]
+        blip.set(qn("r:link"), "rId99")
+        with pytest.raises(UnsupportedStructureError, match="linked picture"):
+            drawing.replace_picture(io.BytesIO(_bmp(0, 0, 255)))


### PR DESCRIPTION
## Summary
- Stacked on #16.
- `Drawing.replace_picture` swaps the image bytes on one drawing. Size and position stay.
- Always creates a new image part so other shapes that shared the old part are unchanged.

## Test plan
- [x] `tests/paper/test_missing_apis.py` picture case
- [x] `tests/paper/test_api_surface.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)