### PR TITLE
feat: add add_hyperlink and Hyperlink.address setter

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -37,7 +37,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Modern comment identity parts~~ **Done.** New comments write `commentsIds.xml` and `commentsExtensible.xml`.
 - ~~Lock a file for the recipient~~ **Done.** `set_protection`.
 - ~~Replace one existing picture~~ **Done.** `Drawing.replace_picture`. Picture form controls still refuse.
-- Create or retarget a hyperlink
+- ~~Create or retarget a hyperlink~~ **Done.** `add_hyperlink`, `Hyperlink.address`.
 - Auto-number caption field
 - Add a footnote or endnote
 - Fill a data-bound form control
@@ -88,7 +88,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Add a comment that current Word will show and round-trip~~ **Done.** | Review | Only `comments.xml` and `commentsExtended.xml`. Current Word also wants `commentsIds.xml` and `commentsExtensible.xml`. | New comments write those two parts. | **Not asked.** Original plan is the older extra comments part only. |
 | ~~Lock a file for the recipient (read-only, comments only, or forms only)~~ **Done.** | Deliver | Could report Restrict Editing and refuse edits. Could not turn it on. | `set_protection` | **Not asked.** Plan: report it, never strip it, refuse edits while it is on. No setter. |
 | ~~Replace one existing picture, keep size and position~~ **Done.** | Edit existing | Insert (stock) or copy on combine. No in-place swap that avoids sharing the image part. Picture form controls still refuse. | `Drawing.replace_picture` | **Later, if someone asks.** Image swap was parked until a real demand. |
-| Turn a phrase into a hyperlink, or change where an existing link goes | Edit existing, review | URL was read-only. Create/retarget was XML. | | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
+| ~~Turn a phrase into a hyperlink, or change where an existing link goes~~ **Done.** | Edit existing, review | URL was read-only. Create/retarget was XML. | `add_hyperlink`, `Hyperlink.address` | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
 | Caption a figure or table so numbers update (Figure 1, Figure 2, …) | Structured | Bookmark plus REF is not a SEQ caption field. | | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
 | Add a footnote or endnote | Edit existing | Existing notes could be read and edited. New notes were not created. | | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
 | Fill a form field whose value lives in Word's hidden custom XML | Structured | Surface fill would vanish on Word open. The package used to refuse. | | **Asked as refuse.** Intentional no in the original plan. |

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -1,0 +1,129 @@
+"""Create and retarget hyperlinks on existing text."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docx._guard import check_install
+from docx._transaction import rollback_on_error
+from docx.errors import BoundaryViolationError, UnsupportedStructureError
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
+from docx.protection import _refuse_if_protected
+from docx.text.hyperlink import Hyperlink
+from docx.text.paragraph import Paragraph
+
+if TYPE_CHECKING:
+    from docx.document import Document
+    from docx.search import Span
+
+check_install()
+
+_P = qn("w:p")
+_R = qn("w:r")
+_RPR = qn("w:rPr")
+_RSTYLE = qn("w:rStyle")
+_HYPERLINK = qn("w:hyperlink")
+
+
+def _refuse_intervening_markup(runs) -> None:
+    first = runs[0]
+    last = runs[-1]
+    if first is last:
+        return
+    allowed = {id(run) for run in runs}
+    sibling = first.getnext()
+    while sibling is not last:
+        if sibling is None or id(sibling) not in allowed:
+            raise UnsupportedStructureError(
+                "cannot wrap a hyperlink around intervening markup;"
+                " nothing was changed"
+            )
+        sibling = sibling.getnext()
+
+
+class _PartHost:
+    """Parent whose `.part` is the story that owns the hyperlink XML."""
+
+    def __init__(self, part):
+        self.part = part
+
+
+def _part_for_span(document: "Document", span: "Span"):
+    wanted = span.story.lstrip("/").casefold()
+    package = document.part.package
+    if package is None:
+        raise UnsupportedStructureError(
+            f"cannot resolve story part for {span.story}; nothing was changed"
+        )
+    for part in package.iter_parts():
+        if str(part.partname).lstrip("/").casefold() == wanted:
+            return part
+    raise UnsupportedStructureError(
+        f"span story {span.story} has no package part; nothing was changed"
+    )
+
+
+def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink:
+    """Wrap `span`'s runs in a hyperlink pointing at `address`.
+
+    The span must lie in a single paragraph. Visible text stays; Word
+    shows it as a link after the file opens.
+    """
+    if not address:
+        raise ValueError("address must be a non-empty URL")
+    _refuse_if_protected(document, "add a hyperlink")
+    with rollback_on_error(document, span):
+        span._isolate_edge_runs()  # noqa: SLF001
+        runs = []
+        for atom in span._atoms:  # noqa: SLF001
+            run = atom.run
+            if run is not None and not any(existing is run for existing in runs):
+                runs.append(run)
+        if not runs:
+            raise BoundaryViolationError(
+                "span has no runs to wrap in a hyperlink; nothing was changed"
+            )
+        parents = {run.getparent() for run in runs}
+        if len(parents) != 1:
+            raise BoundaryViolationError(
+                "cannot wrap a hyperlink across a paragraph boundary; nothing was changed"
+            )
+        parent = runs[0].getparent()
+        while parent is not None and parent.tag != _P:
+            parent = parent.getparent()
+        if parent is None:
+            raise BoundaryViolationError(
+                "hyperlink runs are not inside a paragraph; nothing was changed"
+            )
+        for run in runs:
+            ancestor = run.getparent()
+            while ancestor is not None and ancestor.tag != _P:
+                if ancestor.tag == _HYPERLINK:
+                    raise UnsupportedStructureError(
+                        "span is already inside a hyperlink; retarget it"
+                        " with Hyperlink.address. Nothing was changed"
+                    )
+                ancestor = ancestor.getparent()
+        _refuse_intervening_markup(runs)
+        story_part = _part_for_span(document, span)
+        r_id = story_part.relate_to(address, RT.HYPERLINK, is_external=True)
+        hyperlink = OxmlElement("w:hyperlink")
+        hyperlink.set(qn("r:id"), r_id)
+        hyperlink.set(qn("w:history"), "1")
+        first = runs[0]
+        first.addprevious(hyperlink)
+        for run in runs:
+            hyperlink.append(run)
+            r_pr = run.find(_RPR)
+            if r_pr is None:
+                r_pr = OxmlElement("w:rPr")
+                run.insert(0, r_pr)
+            style = r_pr.find(_RSTYLE)
+            if style is None:
+                style = OxmlElement("w:rStyle")
+                r_pr.insert(0, style)
+            style.set(qn("w:val"), "Hyperlink")
+        paragraph = Paragraph(parent, _PartHost(story_part))
+        return Hyperlink(hyperlink, paragraph)

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -77,6 +77,11 @@ def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink
     require_span_owner(document, span)
     _refuse_if_protected(document, "add a hyperlink")
     span._validate_fresh()  # noqa: SLF001
+    if span.in_field:
+        raise UnsupportedStructureError(
+            "the span lies inside a field result; Word regenerates field"
+            " results on update, so the hyperlink would silently vanish"
+        )
     with rollback_on_error(document, span):
         span._isolate_edge_runs()  # noqa: SLF001
         runs = []

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from docx._guard import check_install
 from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
+from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import qn
@@ -83,6 +84,8 @@ def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink
             " results on update, so the hyperlink would silently vanish"
         )
     with rollback_on_error(document, span):
+        if "Hyperlink" not in document.styles:
+            document.styles.add_style("Hyperlink", WD_STYLE_TYPE.CHARACTER, builtin=True)
         span._isolate_edge_runs()  # noqa: SLF001
         runs = []
         for atom in span._atoms:  # noqa: SLF001

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from docx._guard import check_install
 from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
-from docx.controls import _refuse_control_write_restrictions, _validate_span_surface_edit
+from docx.controls import (
+    _control_type,
+    _refuse_control_write_restrictions,
+    _validate_span_surface_edit,
+)
 from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -29,6 +33,7 @@ _RPR = qn("w:rPr")
 _RSTYLE = qn("w:rStyle")
 _HYPERLINK = qn("w:hyperlink")
 _SDT = qn("w:sdt")
+_SDT_PR = qn("w:sdtPr")
 
 
 def _refuse_intervening_markup(runs) -> None:
@@ -58,6 +63,11 @@ def _refuse_control_surface(span: "Span") -> None:
     for control in controls:
         _validate_span_surface_edit(control)
         _refuse_control_write_restrictions(control)
+        if _control_type(control.find(_SDT_PR)) == "text":
+            raise UnsupportedStructureError(
+                "span lies in a plain-text content control; a hyperlink would"
+                " break the control's content model. Nothing was changed"
+            )
 
 
 class _PartHost:

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from docx._guard import check_install
 from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
+from docx.controls import _refuse_control_write_restrictions, _validate_span_surface_edit
 from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -27,6 +28,7 @@ _R = qn("w:r")
 _RPR = qn("w:rPr")
 _RSTYLE = qn("w:rStyle")
 _HYPERLINK = qn("w:hyperlink")
+_SDT = qn("w:sdt")
 
 
 def _refuse_intervening_markup(runs) -> None:
@@ -43,6 +45,19 @@ def _refuse_intervening_markup(runs) -> None:
                 " nothing was changed"
             )
         sibling = sibling.getnext()
+
+
+def _refuse_control_surface(span: "Span") -> None:
+    controls = []
+    for atom in span._atoms:  # noqa: SLF001
+        current = atom.element.getparent()
+        while current is not None:
+            if current.tag == _SDT and not any(current is item for item in controls):
+                controls.append(current)
+            current = current.getparent()
+    for control in controls:
+        _validate_span_surface_edit(control)
+        _refuse_control_write_restrictions(control)
 
 
 class _PartHost:
@@ -83,6 +98,7 @@ def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink
             "the span lies inside a field result; Word regenerates field"
             " results on update, so the hyperlink would silently vanish"
         )
+    _refuse_control_surface(span)
     with rollback_on_error(document, span):
         if "Hyperlink" not in document.styles:
             document.styles.add_style("Hyperlink", WD_STYLE_TYPE.CHARACTER, builtin=True)

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from docx._guard import check_install
+from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -73,7 +74,9 @@ def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink
     """
     if not address:
         raise ValueError("address must be a non-empty URL")
+    require_span_owner(document, span)
     _refuse_if_protected(document, "add a hyperlink")
+    span._validate_fresh()  # noqa: SLF001
     with rollback_on_error(document, span):
         span._isolate_edge_runs()  # noqa: SLF001
         runs = []

--- a/src/docx/text/hyperlink.py
+++ b/src/docx/text/hyperlink.py
@@ -57,10 +57,10 @@ class Hyperlink(Parented):
         with rollback_on_error(document):
             old_r_id = self._hyperlink.rId
             new_r_id = self.part.relate_to(value, RT.HYPERLINK, is_external=True)
-            self._hyperlink.set(qn("r:id"), new_r_id)
-            self._hyperlink.anchor = None
             if old_r_id and old_r_id != new_r_id:
                 self.part.drop_rel(old_r_id)
+            self._hyperlink.set(qn("r:id"), new_r_id)
+            self._hyperlink.anchor = None
 
     @property
     def contains_page_break(self) -> bool:

--- a/src/docx/text/hyperlink.py
+++ b/src/docx/text/hyperlink.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from docx._transaction import rollback_on_error
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml.ns import qn
+from docx.protection import _refuse_if_protected
 from docx.shared import Parented
 from docx.text.run import Run
 
@@ -42,6 +46,21 @@ class Hyperlink(Parented):
         """
         rId = self._hyperlink.rId
         return self._parent.part.rels[rId].target_ref if rId else ""
+
+    @address.setter
+    def address(self, value: str) -> None:
+        """Point this hyperlink at a new external URL."""
+        document = self.part.package.main_document_part.document
+        _refuse_if_protected(document, "retarget a hyperlink")
+        if not value:
+            raise ValueError("address must be a non-empty URL")
+        with rollback_on_error(document):
+            old_r_id = self._hyperlink.rId
+            new_r_id = self.part.relate_to(value, RT.HYPERLINK, is_external=True)
+            self._hyperlink.set(qn("r:id"), new_r_id)
+            self._hyperlink.anchor = None
+            if old_r_id and old_r_id != new_r_id:
+                self.part.drop_rel(old_r_id)
 
     @property
     def contains_page_break(self) -> bool:

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -206,6 +206,7 @@ APPROVED_SIGNATURES = [
         "(paragraph, *, bookmark, kind='text')",
     ),
     ("docx.fields", "insert_toc_after", "(document, anchor, *, levels=(1, 3))"),
+    ("docx.links", "add_hyperlink", "(document, span, address)"),
     ("docx.drawing", "Drawing.replace_picture", "(self, image_descriptor)"),
     ("docx.formatting", "format_of", "(target)"),
     ("docx.formatting", "surrounding_format", "(document, anchor)"),

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -12,8 +12,10 @@ import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
 from docx.drawing import Drawing
 from docx.errors import DocumentProtectedError, UnsupportedStructureError
-from docx.oxml.ns import qn
-from docx.oxml.parser import OxmlElement
+from docx.links import add_hyperlink
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import OxmlElement, parse_xml
 from docx.protection import acknowledge_protection, set_protection
 from docx.search import find_one
 
@@ -151,3 +153,70 @@ class DescribePictureReplace:
         blip.set(qn("r:link"), "rId99")
         with pytest.raises(UnsupportedStructureError, match="linked picture"):
             drawing.replace_picture(io.BytesIO(_bmp(0, 0, 255)))
+
+
+class DescribeHyperlinks:
+    def it_wraps_a_phrase_and_can_retarget(self, tmp_path: Path):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        link = add_hyperlink(document, span, "https://example.com/a")
+        assert link.address == "https://example.com/a"
+        link.address = "https://example.com/b"
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        addresses = [
+            hyperlink.address
+            for paragraph in reopened.paragraphs
+            for hyperlink in paragraph.hyperlinks
+        ]
+        assert "https://example.com/b" in addresses
+
+    def it_puts_the_relationship_on_the_header_part(self, tmp_path: Path):
+        document = _doc()
+        header = document.sections[0].header
+        header.paragraphs[0].text = "HeaderLinkUnique"
+        span = find_one(document, "HeaderLinkUnique", story="word/header1.xml")
+        link = add_hyperlink(document, span, "https://example.com/header")
+        header_part = document.sections[0].header.part
+        r_id = link._hyperlink.get(qn("r:id"))
+        assert r_id in header_part.rels
+        assert header_part.rels[r_id].reltype == RT.HYPERLINK
+        assert header_part.rels[r_id].target_ref == "https://example.com/header"
+        assert link.address == "https://example.com/header"
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        addresses = [
+            hyperlink.address
+            for paragraph in reopened.sections[0].header.paragraphs
+            for hyperlink in paragraph.hyperlinks
+        ]
+        assert "https://example.com/header" in addresses
+
+    def it_refuses_to_nest_a_hyperlink(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        add_hyperlink(document, span, "https://example.com/a")
+        again = find_one(document, "perfectly ordinary")
+        with pytest.raises(UnsupportedStructureError, match="already inside a hyperlink"):
+            add_hyperlink(document, again, "https://example.com/b")
+
+    def it_refuses_intervening_markup_between_runs(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("hello ")
+        second = paragraph.add_run("world")
+        first._r.addnext(
+            parse_xml(f'<w:bookmarkStart {nsdecls("w")} w:id="1" w:name="Term"/>')
+        )
+        second._r.addnext(parse_xml(f'<w:bookmarkEnd {nsdecls("w")} w:id="1"/>'))
+        before = paragraph._p.xml
+        with pytest.raises(UnsupportedStructureError, match="intervening markup"):
+            add_hyperlink(document, find_one(document, "hello world"), "https://example.com/a")
+        assert paragraph._p.xml == before
+
+    def it_clears_a_stale_internal_anchor_when_retargeting(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        link = add_hyperlink(document, span, "https://example.com/a")
+        link._hyperlink.anchor = "_TocOld"
+        link.address = "https://example.com/b"
+        assert link._hyperlink.anchor is None
+        assert link.address == "https://example.com/b"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -258,3 +258,9 @@ class DescribeHyperlinks:
         assert span.in_field
         with pytest.raises(UnsupportedStructureError, match="field result"):
             add_hyperlink(document, span, "https://example.com/a")
+
+    def it_defines_the_hyperlink_character_style(self):
+        document = _doc()
+        assert "Hyperlink" not in document.styles
+        add_hyperlink(document, find_one(document, "perfectly ordinary"), "https://example.com/a")
+        assert "Hyperlink" in document.styles

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -238,3 +238,23 @@ class DescribeHyperlinks:
         find_one(document, "perfectly ordinary").replace("changed")
         with pytest.raises(TargetNotFoundError, match="stale"):
             add_hyperlink(document, span, "https://example.com/a")
+
+    def it_keeps_a_shared_relationship_when_retargeting_one(self):
+        document = _doc()
+        first = add_hyperlink(
+            document, find_one(document, "perfectly ordinary"), "https://example.com/a"
+        )
+        second = add_hyperlink(
+            document, find_one(document, "First body paragraph"), "https://example.com/a"
+        )
+        assert first._hyperlink.get(qn("r:id")) == second._hyperlink.get(qn("r:id"))
+        first.address = "https://example.com/b"
+        assert first.address == "https://example.com/b"
+        assert second.address == "https://example.com/a"
+
+    def it_refuses_a_field_result_span(self):
+        document = _doc("generated/feature-isolated/fields.docx")
+        span = find_one(document, "June 1, 2026")
+        assert span.in_field
+        with pytest.raises(UnsupportedStructureError, match="field result"):
+            add_hyperlink(document, span, "https://example.com/a")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -264,3 +264,50 @@ class DescribeHyperlinks:
         assert "Hyperlink" not in document.styles
         add_hyperlink(document, find_one(document, "perfectly ordinary"), "https://example.com/a")
         assert "Hyperlink" in document.styles
+
+    def it_refuses_a_data_bound_span(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="bound"/>'
+                '<w:dataBinding w:xpath="/x" w:storeItemID="{11111111-1111-1111-1111-111111111111}"/>'
+                "</w:sdtPr>"
+                "<w:sdtContent><w:r><w:t>BoundLink</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="data-bound"):
+            add_hyperlink(document, find_one(document, "BoundLink"), "https://example.com/a")
+
+    def it_refuses_a_locked_control_span(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="locked"/>'
+                '<w:lock w:val="contentLocked"/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>LockedLink</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            add_hyperlink(document, find_one(document, "LockedLink"), "https://example.com/a")
+
+    def it_wraps_text_inside_an_unlocked_control(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="plain"/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>PlainLink</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        link = add_hyperlink(
+            document, find_one(document, "PlainLink"), "https://example.com/a"
+        )
+        assert link.address == "https://example.com/a"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -311,3 +311,19 @@ class DescribeHyperlinks:
             document, find_one(document, "PlainLink"), "https://example.com/a"
         )
         assert link.address == "https://example.com/a"
+
+    def it_refuses_a_plain_text_control_span(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="plain-text"/><w:text/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>PlainTextLink</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="plain-text"):
+            add_hyperlink(
+                document, find_one(document, "PlainTextLink"), "https://example.com/a"
+            )

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -11,7 +11,12 @@ import pytest
 import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
 from docx.drawing import Drawing
-from docx.errors import DocumentProtectedError, UnsupportedStructureError
+from docx.errors import (
+    BoundaryViolationError,
+    DocumentProtectedError,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
 from docx.links import add_hyperlink
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import nsdecls, qn
@@ -220,3 +225,16 @@ class DescribeHyperlinks:
         link.address = "https://example.com/b"
         assert link._hyperlink.anchor is None
         assert link.address == "https://example.com/b"
+
+    def it_refuses_a_span_from_another_document(self):
+        document = _doc()
+        foreign = find_one(_doc(), "perfectly ordinary")
+        with pytest.raises(BoundaryViolationError, match="different document"):
+            add_hyperlink(document, foreign, "https://example.com/a")
+
+    def it_refuses_a_stale_span(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        find_one(document, "perfectly ordinary").replace("changed")
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            add_hyperlink(document, span, "https://example.com/a")


### PR DESCRIPTION
## Summary
- Stacked on #17.
- `add_hyperlink` wraps a phrase in an external link. The relationship is created on the span's story part (body, header, or footer).
- Nested wrap and intervening bookmark/comment marks are refused.
- `Hyperlink.address` retargets an existing link and clears a leftover `w:anchor`.

## Test plan
- [x] `tests/paper/test_missing_apis.py` hyperlink cases
- [x] `tests/paper/test_api_surface.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)