### PR TITLE
feat: add add_caption SEQ fields

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -38,7 +38,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Lock a file for the recipient~~ **Done.** `set_protection`.
 - ~~Replace one existing picture~~ **Done.** `Drawing.replace_picture`. Picture form controls still refuse.
 - ~~Create or retarget a hyperlink~~ **Done.** `add_hyperlink`, `Hyperlink.address`.
-- Auto-number caption field
+- ~~Auto-number caption field~~ **Done.** `add_caption`.
 - Add a footnote or endnote
 - Fill a data-bound form control
 - Append and keep the source letterhead
@@ -63,7 +63,7 @@ Read **What it does** first. The API column is only the name in the library.
 | Apply a real Word numbered or bulleted list, not fake Unicode bullets. Restart numbering when needed. | `docx.numbering` | Structured | Yes | Needed when inserting blocks into existing lists. |
 | Fill a form control: text, checkbox, dropdown, or date. | `docx.controls` | Structured | Yes | Stock cannot fill content controls safely. Data-bound controls were asked to refuse, not to fill. Picture controls also refuse (see Missing). |
 | Put a bookmark on a phrase, list bookmarks, or remove the markers (the text stays). | `docx.bookmarks` | Structured | Yes | Anchors for cross-references and TOC in existing files. |
-| Insert a page number, date, cross-reference, or table of contents. The displayed value is computed when Word opens the file, not here. | `docx.fields` | Structured | Yes | Stock is weak; agents otherwise hand-edit field XML. Page numbers, dates, cross-references, and TOC were asked for. Auto-number captions (Figure 1, 2, …) were not (see Missing). |
+| Insert a page number, date, cross-reference, table of contents, or auto-number caption. The displayed value is computed when Word opens the file, not here. | `docx.fields` | Structured | Yes | Stock is weak; agents otherwise hand-edit field XML. Captions use `add_caption` (SEQ). |
 | Copy a range, or a whole document, into another file, keeping styles, lists, and images. | `docx.composition` | Combine | Yes | Cross-file copy is where styles and relationships corrupt. Headers stay those of the destination file; keeping the source letterhead was left for later. Will not copy comments, pending revisions, or footnotes. |
 | Save an edited file without rewriting ZIP parts that did not change. | `docx.package.patch_save` | Package | Yes | Stock save rewrites the whole ZIP, which noisily diffs and can break unrelated parts. |
 | On open and save: refuse a broken ZIP with a typed error, write atomically, and roll back a failed edit instead of leaving a half-written file. | zipguard, atomic `save`, transactions, `PaperRefusal` | Package | Yes | Load/save plumbing. Keep. The zip-bomb *size caps* are gone (see Change order). A member that inflates past the size it declared still refuses. |
@@ -89,7 +89,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Lock a file for the recipient (read-only, comments only, or forms only)~~ **Done.** | Deliver | Could report Restrict Editing and refuse edits. Could not turn it on. | `set_protection` | **Not asked.** Plan: report it, never strip it, refuse edits while it is on. No setter. |
 | ~~Replace one existing picture, keep size and position~~ **Done.** | Edit existing | Insert (stock) or copy on combine. No in-place swap that avoids sharing the image part. Picture form controls still refuse. | `Drawing.replace_picture` | **Later, if someone asks.** Image swap was parked until a real demand. |
 | ~~Turn a phrase into a hyperlink, or change where an existing link goes~~ **Done.** | Edit existing, review | URL was read-only. Create/retarget was XML. | `add_hyperlink`, `Hyperlink.address` | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
-| Caption a figure or table so numbers update (Figure 1, Figure 2, …) | Structured | Bookmark plus REF is not a SEQ caption field. | | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
+| ~~Caption a figure or table so numbers update (Figure 1, Figure 2, …)~~ **Done.** | Structured | Bookmark plus REF is not a SEQ caption field. | `add_caption` | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
 | Add a footnote or endnote | Edit existing | Existing notes could be read and edited. New notes were not created. | | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
 | Fill a form field whose value lives in Word's hidden custom XML | Structured | Surface fill would vanish on Word open. The package used to refuse. | | **Asked as refuse.** Intentional no in the original plan. |
 | Append another document and keep *its* letterhead | Combine | Default append keeps destination headers. | | **Asked as future.** Destination headers on purpose; keeping the source letterhead was left for later. |

--- a/src/docx/fields.py
+++ b/src/docx/fields.py
@@ -147,6 +147,37 @@ def add_reference_field(
         _set_update_fields_on_open(document)
 
 
+def add_caption(
+    paragraph: "Paragraph",
+    *,
+    label: str = "Figure",
+    description: str = "",
+) -> None:
+    """Append a SEQ caption (`Figure 1`, `Table 1`, …) to `paragraph`.
+
+    Word recomputes the number on open. This package writes the field, not
+    the displayed integer.
+    """
+    if not label:
+        raise ValueError("label must be a non-empty caption name")
+    document = _document_of_paragraph(paragraph)
+    _refuse_if_protected(document, "insert a caption")
+    seq_name = "".join(character for character in label if character.isalnum()) or "Figure"
+    with rollback_on_error(document):
+        paragraph._p.style = "Caption"
+        prefix = OxmlElement("w:r")
+        prefix.add_t(f"{label} ")
+        paragraph._p.append(prefix)
+        paragraph._p.append(
+            _simple_field(f" SEQ {seq_name} \\* ARABIC ", "1")
+        )
+        if description:
+            suffix = OxmlElement("w:r")
+            suffix.add_t(f": {description}")
+            paragraph._p.append(suffix)
+        _set_update_fields_on_open(document)
+
+
 def insert_toc_after(
     document: "Document", anchor, *, levels: Tuple[int, int] = (1, 3)
 ) -> None:

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -206,6 +206,11 @@ APPROVED_SIGNATURES = [
         "(paragraph, *, bookmark, kind='text')",
     ),
     ("docx.fields", "insert_toc_after", "(document, anchor, *, levels=(1, 3))"),
+    (
+        "docx.fields",
+        "add_caption",
+        "(paragraph, *, label='Figure', description='')",
+    ),
     ("docx.links", "add_hyperlink", "(document, span, address)"),
     ("docx.drawing", "Drawing.replace_picture", "(self, image_descriptor)"),
     ("docx.formatting", "format_of", "(target)"),

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -17,6 +17,7 @@ from docx.errors import (
     TargetNotFoundError,
     UnsupportedStructureError,
 )
+from docx.fields import add_caption
 from docx.links import add_hyperlink
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import nsdecls, qn
@@ -327,3 +328,13 @@ class DescribeHyperlinks:
             add_hyperlink(
                 document, find_one(document, "PlainTextLink"), "https://example.com/a"
             )
+
+
+class DescribeCaptions:
+    def it_inserts_a_seq_field(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        add_caption(paragraph, label="Figure", description="Diagram")
+        xml = paragraph._p.xml
+        assert "SEQ Figure" in xml
+        assert paragraph._p.style == "Caption"


### PR DESCRIPTION
## Summary
- Stacked on #18.
- `add_caption` inserts a SEQ caption field (Figure 1, Figure 2, ...) whose number Word updates on open.

## Test plan
- [x] `tests/paper/test_missing_apis.py` caption case
- [x] `tests/paper/test_api_surface.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)