### PR TITLE
feat: add add_footnote and add_endnote

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -39,7 +39,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Replace one existing picture~~ **Done.** `Drawing.replace_picture`. Picture form controls still refuse.
 - ~~Create or retarget a hyperlink~~ **Done.** `add_hyperlink`, `Hyperlink.address`.
 - ~~Auto-number caption field~~ **Done.** `add_caption`.
-- Add a footnote or endnote
+- ~~Add a footnote or endnote~~ **Done.** `add_footnote`, `add_endnote`.
 - Fill a data-bound form control
 - Append and keep the source letterhead
 
@@ -53,7 +53,7 @@ Read **What it does** first. The API column is only the name in the library.
 
 | What it does | API | Use case | Place? | Why |
 | --- | --- | --- | --- | --- |
-| Read the whole file (body, headers, footers, footnotes, comments), including text that is still a tracked insertion or deletion. | `docx.story` | Edit existing, review | Yes | Stock only sees the main body and ignores pending revisions. Notes can be read, not created (see Missing). |
+| Read the whole file (body, headers, footers, footnotes, comments), including text that is still a tracked insertion or deletion. | `docx.story` | Edit existing, review | Yes | Stock only sees the main body and ignores pending revisions. Notes can be read; create with `add_footnote` / `add_endnote`. |
 | Find a quoted phrase even when Word split it across bold/italic runs, and replace it without wiping that formatting. Can stamp the edit as a tracked change. | `docx.search`, `Span.replace` | Edit existing, review | Yes | Stock `paragraph.text` wipes run formatting. Agents otherwise splice XML. |
 | Insert a heading and paragraphs, a real list, or a simple table after a known place. Mark whole paragraphs deleted or replaced as Word track-changes. | `docx.blocks` | Edit existing, review | Yes | Stock has no safe paragraph-level tracked edit. |
 | List every tracked change and accept or reject it (inserts, deletes, moves, some formatting). | `Document.revisions` | Review | Yes | Stock cannot list or resolve tracked changes. Rare types (table-property, cell, section, numbering, custom XML) can be listed but not resolved. |
@@ -90,7 +90,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Replace one existing picture, keep size and position~~ **Done.** | Edit existing | Insert (stock) or copy on combine. No in-place swap that avoids sharing the image part. Picture form controls still refuse. | `Drawing.replace_picture` | **Later, if someone asks.** Image swap was parked until a real demand. |
 | ~~Turn a phrase into a hyperlink, or change where an existing link goes~~ **Done.** | Edit existing, review | URL was read-only. Create/retarget was XML. | `add_hyperlink`, `Hyperlink.address` | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
 | ~~Caption a figure or table so numbers update (Figure 1, Figure 2, …)~~ **Done.** | Structured | Bookmark plus REF is not a SEQ caption field. | `add_caption` | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
-| Add a footnote or endnote | Edit existing | Existing notes could be read and edited. New notes were not created. | | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
+| ~~Add a footnote or endnote~~ **Done.** | Edit existing | Existing notes could be read and edited. New notes were not created. | `add_footnote`, `add_endnote` | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
 | Fill a form field whose value lives in Word's hidden custom XML | Structured | Surface fill would vanish on Word open. The package used to refuse. | | **Asked as refuse.** Intentional no in the original plan. |
 | Append another document and keep *its* letterhead | Combine | Default append keeps destination headers. | | **Asked as future.** Destination headers on purpose; keeping the source letterhead was left for later. |
 

--- a/src/docx/notes.py
+++ b/src/docx/notes.py
@@ -33,6 +33,9 @@ _TYPE = qn("w:type")
 _FOOTNOTE = qn("w:footnote")
 _ENDNOTE = qn("w:endnote")
 _P = qn("w:p")
+_R = qn("w:r")
+_FOOTNOTE_REFERENCE = qn("w:footnoteReference")
+_ENDNOTE_REFERENCE = qn("w:endnoteReference")
 
 _FOOTNOTES_TEMPLATE = (
     f"<w:footnotes {_W_DECL}>"
@@ -112,6 +115,15 @@ def _insert_note(
             "footnotes and endnotes attach in the main document body"
             f" (span is in {span.story})"
         )
+    if span.in_text_box:
+        raise UnsupportedStructureError(
+            "footnotes and endnotes cannot attach inside a text box"
+        )
+    if span.in_field:
+        raise UnsupportedStructureError(
+            "the span lies inside a field result; a note planted there"
+            " is destroyed the next time the field updates"
+        )
     with rollback_on_error(document, span):
         span._isolate_edge_runs()  # noqa: SLF001
         runs = []
@@ -146,8 +158,25 @@ def _insert_note(
         reference = OxmlElement(f"w:{kind}Reference")
         reference.set(_ID, str(note_id))
         mark.append(reference)
-        runs[-1].addnext(mark)
+        _insert_after_span(runs, mark)
         return note_id
+
+
+def _is_note_mark(element: "_Element") -> bool:
+    if element.tag != _R:
+        return False
+    return any(
+        child.tag in (_FOOTNOTE_REFERENCE, _ENDNOTE_REFERENCE) for child in element
+    )
+
+
+def _insert_after_span(runs, mark: "_Element") -> None:
+    anchor = runs[-1]
+    sibling = anchor.getnext()
+    while sibling is not None and _is_note_mark(sibling):
+        anchor = sibling
+        sibling = sibling.getnext()
+    anchor.addnext(mark)
 
 
 def add_footnote(document: "Document", span: "Span", text: str) -> int:

--- a/src/docx/notes.py
+++ b/src/docx/notes.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING
 from docx._guard import check_install
 from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
+from docx.controls import (
+    _control_type,
+    _refuse_control_write_restrictions,
+    _validate_span_surface_edit,
+)
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -36,6 +41,8 @@ _P = qn("w:p")
 _R = qn("w:r")
 _FOOTNOTE_REFERENCE = qn("w:footnoteReference")
 _ENDNOTE_REFERENCE = qn("w:endnoteReference")
+_SDT = qn("w:sdt")
+_SDT_PR = qn("w:sdtPr")
 
 _FOOTNOTES_TEMPLATE = (
     f"<w:footnotes {_W_DECL}>"
@@ -124,6 +131,7 @@ def _insert_note(
             "the span lies inside a field result; a note planted there"
             " is destroyed the next time the field updates"
         )
+    _refuse_control_surface(span)
     with rollback_on_error(document, span):
         span._isolate_edge_runs()  # noqa: SLF001
         runs = []
@@ -160,6 +168,24 @@ def _insert_note(
         mark.append(reference)
         _insert_after_span(runs, mark)
         return note_id
+
+
+def _refuse_control_surface(span: "Span") -> None:
+    controls = []
+    for atom in span._atoms:  # noqa: SLF001
+        current = atom.element.getparent()
+        while current is not None:
+            if current.tag == _SDT and not any(current is item for item in controls):
+                controls.append(current)
+            current = current.getparent()
+    for control in controls:
+        _validate_span_surface_edit(control)
+        _refuse_control_write_restrictions(control)
+        if _control_type(control.find(_SDT_PR)) == "text":
+            raise UnsupportedStructureError(
+                "span lies in a plain-text content control; a note mark would"
+                " break the control's content model. Nothing was changed"
+            )
 
 
 def _is_note_mark(element: "_Element") -> bool:

--- a/src/docx/notes.py
+++ b/src/docx/notes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from docx._guard import check_install
+from docx._ownership import require_span_owner
 from docx._transaction import rollback_on_error
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.opc.constants import CONTENT_TYPE as CT
@@ -95,10 +96,12 @@ def _insert_note(
     endnote: bool,
 ) -> int:
     operation = "add an endnote" if endnote else "add a footnote"
+    require_span_owner(document, span)
     _refuse_if_protected(document, operation)
     if not text:
         raise ValueError("note text must be non-empty")
     _validate_writable_text(text, argument="text")
+    span._validate_fresh()  # noqa: SLF001
     main_story = next(
         story
         for story, root in _story_elements(document)

--- a/src/docx/notes.py
+++ b/src/docx/notes.py
@@ -1,0 +1,157 @@
+"""Create footnotes and endnotes, including the note body and the mark."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docx._guard import check_install
+from docx._transaction import rollback_on_error
+from docx.errors import TargetNotFoundError, UnsupportedStructureError
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import OxmlElement, parse_xml
+from docx.parts.endnotes import EndnotesPart
+from docx.parts.footnotes import FootnotesPart
+from docx.protection import _refuse_if_protected
+from docx.search import _validate_writable_text
+from docx.story import _story_elements
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+    from docx.document import Document
+    from docx.search import Span
+
+check_install()
+
+_W_DECL = nsdecls("w")
+_ID = qn("w:id")
+_TYPE = qn("w:type")
+_FOOTNOTE = qn("w:footnote")
+_ENDNOTE = qn("w:endnote")
+_P = qn("w:p")
+
+_FOOTNOTES_TEMPLATE = (
+    f"<w:footnotes {_W_DECL}>"
+    '<w:footnote w:type="separator" w:id="-1">'
+    "<w:p><w:r><w:separator/></w:r></w:p></w:footnote>"
+    '<w:footnote w:type="continuationSeparator" w:id="0">'
+    "<w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>"
+    "</w:footnotes>"
+)
+_ENDNOTES_TEMPLATE = (
+    f"<w:endnotes {_W_DECL}>"
+    '<w:endnote w:type="separator" w:id="-1">'
+    "<w:p><w:r><w:separator/></w:r></w:p></w:endnote>"
+    '<w:endnote w:type="continuationSeparator" w:id="0">'
+    "<w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>"
+    "</w:endnotes>"
+)
+
+
+def _ensure_notes_part(document: "Document", *, endnote: bool):
+    reltype = RT.ENDNOTES if endnote else RT.FOOTNOTES
+    try:
+        return document.part.part_related_by(reltype)
+    except KeyError:
+        pass
+    if endnote:
+        part = EndnotesPart(
+            PackURI("/word/endnotes.xml"),
+            CT.WML_ENDNOTES,
+            parse_xml(_ENDNOTES_TEMPLATE),
+            document.part.package,
+        )
+    else:
+        part = FootnotesPart(
+            PackURI("/word/footnotes.xml"),
+            CT.WML_FOOTNOTES,
+            parse_xml(_FOOTNOTES_TEMPLATE),
+            document.part.package,
+        )
+    document.part.relate_to(part, reltype)
+    return part
+
+
+def _next_note_id(root: "_Element", tag) -> int:
+    used = []
+    for note in root.findall(tag):
+        if note.get(_TYPE) in ("separator", "continuationSeparator"):
+            continue
+        raw = note.get(_ID)
+        if raw is None:
+            continue
+        used.append(int(raw))
+    return (max(used) if used else 0) + 1
+
+
+def _insert_note(
+    document: "Document",
+    span: "Span",
+    text: str,
+    *,
+    endnote: bool,
+) -> int:
+    operation = "add an endnote" if endnote else "add a footnote"
+    _refuse_if_protected(document, operation)
+    if not text:
+        raise ValueError("note text must be non-empty")
+    _validate_writable_text(text, argument="text")
+    main_story = next(
+        story
+        for story, root in _story_elements(document)
+        if root is document.element
+    )
+    if span.story != main_story:
+        raise UnsupportedStructureError(
+            "footnotes and endnotes attach in the main document body"
+            f" (span is in {span.story})"
+        )
+    with rollback_on_error(document, span):
+        span._isolate_edge_runs()  # noqa: SLF001
+        runs = []
+        for atom in span._atoms:  # noqa: SLF001
+            run = atom.run
+            if run is not None and not any(existing is run for existing in runs):
+                runs.append(run)
+        if not runs:
+            raise TargetNotFoundError("span has no runs to attach a note to")
+        part = _ensure_notes_part(document, endnote=endnote)
+        root = part._element  # noqa: SLF001
+        tag = _ENDNOTE if endnote else _FOOTNOTE
+        note_id = _next_note_id(root, tag)
+        kind = "endnote" if endnote else "footnote"
+        note = OxmlElement(f"w:{kind}")
+        note.set(_ID, str(note_id))
+        paragraph = OxmlElement("w:p")
+        ref_run = OxmlElement("w:r")
+        ref_run.append(OxmlElement(f"w:{kind}Ref"))
+        text_run = OxmlElement("w:r")
+        text_run.add_t(" " + text)
+        paragraph.append(ref_run)
+        paragraph.append(text_run)
+        note.append(paragraph)
+        root.append(note)
+        mark = OxmlElement("w:r")
+        r_pr = OxmlElement("w:rPr")
+        align = OxmlElement("w:vertAlign")
+        align.set(qn("w:val"), "superscript")
+        r_pr.append(align)
+        mark.append(r_pr)
+        reference = OxmlElement(f"w:{kind}Reference")
+        reference.set(_ID, str(note_id))
+        mark.append(reference)
+        runs[-1].addnext(mark)
+        return note_id
+
+
+def add_footnote(document: "Document", span: "Span", text: str) -> int:
+    """Insert a footnote mark after `span` and create the note body."""
+    return _insert_note(document, span, text, endnote=False)
+
+
+def add_endnote(document: "Document", span: "Span", text: str) -> int:
+    """Insert an endnote mark after `span` and create the note body."""
+    return _insert_note(document, span, text, endnote=True)

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -212,6 +212,8 @@ APPROVED_SIGNATURES = [
         "(paragraph, *, label='Figure', description='')",
     ),
     ("docx.links", "add_hyperlink", "(document, span, address)"),
+    ("docx.notes", "add_footnote", "(document, span, text)"),
+    ("docx.notes", "add_endnote", "(document, span, text)"),
     ("docx.drawing", "Drawing.replace_picture", "(self, image_descriptor)"),
     ("docx.formatting", "format_of", "(target)"),
     ("docx.formatting", "surrounding_format", "(document, anchor)"),

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -19,6 +19,7 @@ from docx.errors import (
 )
 from docx.fields import add_caption
 from docx.links import add_hyperlink
+from docx.notes import add_endnote, add_footnote
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import nsdecls, qn
 from docx.oxml.parser import OxmlElement, parse_xml
@@ -338,3 +339,36 @@ class DescribeCaptions:
         xml = paragraph._p.xml
         assert "SEQ Figure" in xml
         assert paragraph._p.style == "Caption"
+
+
+class DescribeNotes:
+    def it_adds_a_footnote_and_endnote(self, tmp_path: Path):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        footnote_id = add_footnote(document, span, "A footnote.")
+        endnote_id = add_endnote(document, span, "An endnote.")
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        footnotes = reopened.part.part_related_by(RT.FOOTNOTES)._element
+        endnotes = reopened.part.part_related_by(RT.ENDNOTES)._element
+        assert str(footnote_id) in {
+            note.get(qn("w:id")) for note in footnotes.findall(qn("w:footnote"))
+        }
+        assert str(endnote_id) in {
+            note.get(qn("w:id")) for note in endnotes.findall(qn("w:endnote"))
+        }
+
+    def it_keeps_ampersands_and_angles_as_text(self, tmp_path: Path):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        add_footnote(document, span, "A & B <C>")
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        footnotes = reopened.part.part_related_by(RT.FOOTNOTES)._element
+        texts = [node.text or "" for node in footnotes.findall(".//" + qn("w:t"))]
+        assert any("A & B <C>" in text for text in texts)
+
+    def it_refuses_a_note_outside_the_body(self):
+        document = _doc()
+        document.sections[0].header.paragraphs[0].text = "HeaderNoteUnique"
+        span = find_one(document, "HeaderNoteUnique", story="word/header1.xml")
+        with pytest.raises(UnsupportedStructureError, match="main document body"):
+            add_footnote(document, span, "nope")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -411,27 +411,65 @@ class DescribeNotes:
         ]
         assert refs == [str(first), str(second)]
 
-    def it_refuses_a_note_inside_a_text_box(self):
-        document = _doc("generated/feature-isolated/textbox.docx")
-        span = find_one(document, "living inside the text box")
-        assert span.in_text_box
-        with pytest.raises(UnsupportedStructureError, match="text box"):
-            add_footnote(document, span, "nope")
-
-    def it_refuses_a_note_inside_a_field_result(self):
-        document = _doc("generated/feature-isolated/fields.docx")
-        span = find_one(document, "June 1, 2026")
-        assert span.in_field
-        with pytest.raises(UnsupportedStructureError, match="field result"):
-            add_footnote(document, span, "nope")
-
-    def it_keeps_stacked_note_marks_in_insertion_order(self):
+    def it_refuses_a_data_bound_span(self):
         document = _doc()
-        span = find_one(document, "perfectly ordinary")
-        first = add_footnote(document, span, "First")
-        second = add_footnote(document, span, "Second")
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="bound"/>'
+                '<w:dataBinding w:xpath="/x" w:storeItemID="{11111111-1111-1111-1111-111111111111}"/>'
+                "</w:sdtPr>"
+                "<w:sdtContent><w:r><w:t>BoundNote</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="data-bound"):
+            add_footnote(document, find_one(document, "BoundNote"), "nope")
+
+    def it_refuses_a_locked_control_span(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="locked"/>'
+                '<w:lock w:val="contentLocked"/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>LockedNote</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            add_footnote(document, find_one(document, "LockedNote"), "nope")
+
+    def it_adds_a_note_inside_an_unlocked_control(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="rich"/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>RichNote</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        note_id = add_footnote(document, find_one(document, "RichNote"), "ok")
         refs = [
             node.get(qn("w:id"))
             for node in document.element.iter(qn("w:footnoteReference"))
         ]
-        assert refs == [str(first), str(second)]
+        assert refs == [str(note_id)]
+
+    def it_refuses_a_plain_text_control_span(self):
+        document = _doc()
+        document.element.body.insert(
+            len(document.element.body) - 1,
+            parse_xml(
+                f'<w:p {nsdecls("w")}>'
+                '<w:sdt><w:sdtPr><w:tag w:val="plain-text"/><w:text/></w:sdtPr>'
+                "<w:sdtContent><w:r><w:t>PlainTextNote</w:t></w:r></w:sdtContent>"
+                "</w:sdt></w:p>"
+            ),
+        )
+        with pytest.raises(UnsupportedStructureError, match="plain-text"):
+            add_footnote(document, find_one(document, "PlainTextNote"), "nope")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -372,3 +372,16 @@ class DescribeNotes:
         span = find_one(document, "HeaderNoteUnique", story="word/header1.xml")
         with pytest.raises(UnsupportedStructureError, match="main document body"):
             add_footnote(document, span, "nope")
+
+    def it_refuses_a_span_from_another_document(self):
+        document = _doc()
+        foreign = find_one(_doc(), "perfectly ordinary")
+        with pytest.raises(BoundaryViolationError, match="different document"):
+            add_footnote(document, foreign, "nope")
+
+    def it_refuses_a_stale_span(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        find_one(document, "perfectly ordinary").replace("changed")
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            add_footnote(document, span, "nope")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -385,3 +385,53 @@ class DescribeNotes:
         find_one(document, "perfectly ordinary").replace("changed")
         with pytest.raises(TargetNotFoundError, match="stale"):
             add_footnote(document, span, "nope")
+
+    def it_refuses_a_note_inside_a_text_box(self):
+        document = _doc("generated/feature-isolated/textbox.docx")
+        span = find_one(document, "living inside the text box")
+        assert span.in_text_box
+        with pytest.raises(UnsupportedStructureError, match="text box"):
+            add_footnote(document, span, "nope")
+
+    def it_refuses_a_note_inside_a_field_result(self):
+        document = _doc("generated/feature-isolated/fields.docx")
+        span = find_one(document, "June 1, 2026")
+        assert span.in_field
+        with pytest.raises(UnsupportedStructureError, match="field result"):
+            add_footnote(document, span, "nope")
+
+    def it_keeps_stacked_note_marks_in_insertion_order(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        first = add_footnote(document, span, "First")
+        second = add_footnote(document, span, "Second")
+        refs = [
+            node.get(qn("w:id"))
+            for node in document.element.iter(qn("w:footnoteReference"))
+        ]
+        assert refs == [str(first), str(second)]
+
+    def it_refuses_a_note_inside_a_text_box(self):
+        document = _doc("generated/feature-isolated/textbox.docx")
+        span = find_one(document, "living inside the text box")
+        assert span.in_text_box
+        with pytest.raises(UnsupportedStructureError, match="text box"):
+            add_footnote(document, span, "nope")
+
+    def it_refuses_a_note_inside_a_field_result(self):
+        document = _doc("generated/feature-isolated/fields.docx")
+        span = find_one(document, "June 1, 2026")
+        assert span.in_field
+        with pytest.raises(UnsupportedStructureError, match="field result"):
+            add_footnote(document, span, "nope")
+
+    def it_keeps_stacked_note_marks_in_insertion_order(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        first = add_footnote(document, span, "First")
+        second = add_footnote(document, span, "Second")
+        refs = [
+            node.get(qn("w:id"))
+            for node in document.element.iter(qn("w:footnoteReference"))
+        ]
+        assert refs == [str(first), str(second)]


### PR DESCRIPTION
## Summary
- Stacked on #19.
- `add_footnote` / `add_endnote` insert the superscript mark after a phrase in the main body and create the note part and body.
- Note text is written as XML elements, not interpolated into a parse string.
- Notes outside the body are refused.

## Test plan
- [x] `tests/paper/test_missing_apis.py` note cases
- [x] `tests/paper/test_api_surface.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)