### PR TITLE
feat: write the custom XML store for data-bound controls

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -40,7 +40,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Create or retarget a hyperlink~~ **Done.** `add_hyperlink`, `Hyperlink.address`.
 - ~~Auto-number caption field~~ **Done.** `add_caption`.
 - ~~Add a footnote or endnote~~ **Done.** `add_footnote`, `add_endnote`.
-- Fill a data-bound form control
+- ~~Fill a data-bound form control~~ **Done.** `set_control_value` writes the custom XML store.
 - Append and keep the source letterhead
 
 **Parked**
@@ -61,7 +61,7 @@ Read **What it does** first. The API column is only the name in the library.
 | Diff two `.docx` files into a Word redline of the text. | `docx.package.compare` | Review | Yes | Review job, not every session: two files in, a redline a person opens in Word. Images, fields, controls, and formatting-only diffs refuse. |
 | Change one table cell, or insert/delete a row, without breaking a merged header. | `docx.tableops` | Structured | Yes | Stock cell/row edits scramble real tables. |
 | Apply a real Word numbered or bulleted list, not fake Unicode bullets. Restart numbering when needed. | `docx.numbering` | Structured | Yes | Needed when inserting blocks into existing lists. |
-| Fill a form control: text, checkbox, dropdown, or date. | `docx.controls` | Structured | Yes | Stock cannot fill content controls safely. Data-bound controls were asked to refuse, not to fill. Picture controls also refuse (see Missing). |
+| Fill a form control: text, checkbox, dropdown, or date. | `docx.controls` | Structured | Yes | Stock cannot fill content controls safely. Data-bound controls write the custom XML store. Picture controls still refuse. |
 | Put a bookmark on a phrase, list bookmarks, or remove the markers (the text stays). | `docx.bookmarks` | Structured | Yes | Anchors for cross-references and TOC in existing files. |
 | Insert a page number, date, cross-reference, table of contents, or auto-number caption. The displayed value is computed when Word opens the file, not here. | `docx.fields` | Structured | Yes | Stock is weak; agents otherwise hand-edit field XML. Captions use `add_caption` (SEQ). |
 | Copy a range, or a whole document, into another file, keeping styles, lists, and images. | `docx.composition` | Combine | Yes | Cross-file copy is where styles and relationships corrupt. Headers stay those of the destination file; keeping the source letterhead was left for later. Will not copy comments, pending revisions, or footnotes. |
@@ -91,7 +91,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Turn a phrase into a hyperlink, or change where an existing link goes~~ **Done.** | Edit existing, review | URL was read-only. Create/retarget was XML. | `add_hyperlink`, `Hyperlink.address` | **Later, if someone asks.** The plan asked to edit text *inside* an existing link, not to create or retarget one. |
 | ~~Caption a figure or table so numbers update (Figure 1, Figure 2, …)~~ **Done.** | Structured | Bookmark plus REF is not a SEQ caption field. | `add_caption` | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
 | ~~Add a footnote or endnote~~ **Done.** | Edit existing | Existing notes could be read and edited. New notes were not created. | `add_footnote`, `add_endnote` | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
-| Fill a form field whose value lives in Word's hidden custom XML | Structured | Surface fill would vanish on Word open. The package used to refuse. | | **Asked as refuse.** Intentional no in the original plan. |
+| ~~Fill a form field whose value lives in Word's hidden custom XML~~ **Done.** | Structured | Surface fill would vanish on Word open. The package used to refuse. | `set_control_value` writes the custom XML store. | **Asked as refuse.** Intentional no in the original plan; this follow-up fills the store. |
 | Append another document and keep *its* letterhead | Combine | Default append keeps destination headers. | | **Asked as future.** Destination headers on purpose; keeping the source letterhead was left for later. |
 
 Not a package hole (stock, QA outside the library, or a different product): insert image (`Run.add_picture`), edit header/footer text (stock + story/search), page/section breaks (stock `add_section`), fill existing non-bound form controls, visual PNG render, flatten-runs, redaction, a11y audit, watermarks, Google Docs title sanitizer, `.doc` conversion. Public document-QA was asked to stay out of this library.

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -71,6 +71,7 @@ _XPATH = qn("w:xpath")
 _PREFIX_MAPPINGS = qn("w:prefixMappings")
 _DS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/customXml"
 _DS_ITEM_ID = f"{{{_DS_NS}}}itemID"
+_XSI_NIL = "{http://www.w3.org/2001/XMLSchema-instance}nil"
 _LOCK = qn("w:lock")
 _DROPDOWN = qn("w:dropDownList")
 _COMBO = qn("w:comboBox")
@@ -702,7 +703,10 @@ def _write_bound_store(document: "Document", binding: "_Element", value: str) ->
         raise TargetNotFoundError(
             f"xpath {xpath!r} matched no node in the custom XML store"
         )
-    nodes[0].text = value
+    node = nodes[0]
+    if _XSI_NIL in node.attrib:
+        del node.attrib[_XSI_NIL]
+    node.text = value
     if getattr(item_part, "_element", None) is None:
         item_part._blob = etree.tostring(
             item_root, xml_declaration=True, encoding="UTF-8"

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -468,6 +468,12 @@ class Control:
         self._validate_ownership()
         _refuse_if_protected(self._document, "set a control value")
         if self.is_data_bound:
+            control_type = self.control_type
+            if control_type not in ("text", "rich_text"):
+                raise UnsupportedStructureError(
+                    f"data-bound {control_type} controls are not settable;"
+                    " nothing was changed"
+                )
             if not isinstance(value, str):
                 raise ValueError("data-bound controls take a string value")
             _validate_writable_text(value, argument="value")
@@ -654,6 +660,22 @@ def _part_root(part):
     return etree.fromstring(blob)
 
 
+def _write_bound_node(node, value: str) -> None:
+    if isinstance(node, etree._Element):
+        if _XSI_NIL in node.attrib:
+            del node.attrib[_XSI_NIL]
+        node.text = value
+        return
+    parent = node.getparent() if hasattr(node, "getparent") else None
+    attrname = getattr(node, "attrname", None)
+    if parent is not None and attrname and getattr(node, "is_attribute", False):
+        parent.set(attrname, value)
+        return
+    raise UnsupportedStructureError(
+        "xpath matched a non-element store target; nothing was changed"
+    )
+
+
 def _write_bound_store(document: "Document", binding: "_Element", value: str) -> None:
     store_id = binding.get(_STORE_ITEM_ID)
     xpath = binding.get(_XPATH)
@@ -703,10 +725,7 @@ def _write_bound_store(document: "Document", binding: "_Element", value: str) ->
         raise TargetNotFoundError(
             f"xpath {xpath!r} matched no node in the custom XML store"
         )
-    node = nodes[0]
-    if _XSI_NIL in node.attrib:
-        del node.attrib[_XSI_NIL]
-    node.text = value
+    _write_bound_node(nodes[0], value)
     if getattr(item_part, "_element", None) is None:
         item_part._blob = etree.tostring(
             item_root, xml_declaration=True, encoding="UTF-8"

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -6,23 +6,28 @@ them type-correctly: text controls get their runs replaced (placeholder
 state cleared), checkboxes flip `w14:checked` AND their
 glyph, dropdowns/combos validate against their `w:listItem` choices, dates
 set `w:fullDate` alongside the display text. Data-bound controls
-(`w:dataBinding`) refuse: their value lives in a custom XML part Word
-re-syncs on open, so editing the surface text would silently vanish.
+(`w:dataBinding`) write the custom XML store Word re-syncs on open, then
+update the visible surface.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Union
 
+from lxml import etree
+
 from docx._guard import check_install
+from docx._transaction import rollback_on_error
 from docx.errors import (
     AmbiguousTargetError,
     BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
+from docx.opc.constants import CONTENT_TYPE as CT
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.protection import _refuse_if_protected
@@ -61,6 +66,11 @@ _BLOCK_CONTROL_PARENTS = frozenset(
 )
 _SHOWING_PLC_HDR = qn("w:showingPlcHdr")
 _DATA_BINDING = qn("w:dataBinding")
+_STORE_ITEM_ID = qn("w:storeItemID")
+_XPATH = qn("w:xpath")
+_PREFIX_MAPPINGS = qn("w:prefixMappings")
+_DS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/customXml"
+_DS_ITEM_ID = f"{{{_DS_NS}}}itemID"
 _LOCK = qn("w:lock")
 _DROPDOWN = qn("w:dropDownList")
 _COMBO = qn("w:comboBox")
@@ -457,11 +467,15 @@ class Control:
         self._validate_ownership()
         _refuse_if_protected(self._document, "set a control value")
         if self.is_data_bound:
-            raise UnsupportedStructureError(
-                "control is data-bound (w:dataBinding): its value lives in a"
-                " custom XML part Word re-syncs on open; editing the surface"
-                " text would silently vanish"
-            )
+            if not isinstance(value, str):
+                raise ValueError("data-bound controls take a string value")
+            _validate_writable_text(value, argument="value")
+            _refuse_locked_control_content(self._sdt)
+            binding = self._sdt_pr.find(_DATA_BINDING)
+            with rollback_on_error(self._document):
+                _write_bound_store(self._document, binding, value)
+                self._set_text(value)
+            return
         _refuse_control_write_restrictions(self._sdt)
         control_type = self.control_type
         if control_type == "checkbox":
@@ -616,15 +630,89 @@ def _validate_span_surface_edit(sdt: "_Element") -> None:
         )
 
 
-def _refuse_control_write_restrictions(sdt: "_Element") -> None:
-    """Honor binding and content locks without rejecting typed controls."""
+def _prefix_map(raw: Optional[str]) -> dict:
+    if not raw:
+        return {}
+    return {
+        match.group(1): match.group(2)
+        for match in re.finditer(
+            r"xmlns:([A-Za-z0-9_]+)\s*=\s*['\"]([^'\"]+)['\"]", raw
+        )
+    }
+
+
+def _part_root(part):
+    element = getattr(part, "_element", None)
+    if element is not None:
+        return element
+    if "xml" not in (part.content_type or "").lower():
+        return None
+    blob = getattr(part, "blob", None)
+    if not blob:
+        return None
+    return etree.fromstring(blob)
+
+
+def _write_bound_store(document: "Document", binding: "_Element", value: str) -> None:
+    store_id = binding.get(_STORE_ITEM_ID)
+    xpath = binding.get(_XPATH)
+    if not store_id or not xpath:
+        raise UnsupportedStructureError(
+            "data-bound control is missing storeItemID or xpath; nothing was changed"
+        )
+    nsmap = _prefix_map(binding.get(_PREFIX_MAPPINGS))
+    props_part = None
+    for part in document.part.package.iter_parts():
+        if part.content_type != CT.OFC_CUSTOM_XML_PROPERTIES:
+            continue
+        root = _part_root(part)
+        if root is None:
+            continue
+        if root.get(_DS_ITEM_ID) == store_id:
+            props_part = part
+            break
+    if props_part is None:
+        raise TargetNotFoundError(
+            f"no custom XML store with itemID {store_id!r}; nothing was changed"
+        )
+    item_part = None
+    for owner in document.part.package.iter_parts():
+        rels = getattr(owner, "rels", None)
+        if not rels:
+            continue
+        for rel in rels.values():
+            if rel.is_external:
+                continue
+            if rel.target_part is props_part:
+                item_part = owner
+                break
+        if item_part is not None:
+            break
+    if item_part is None or item_part is props_part:
+        raise TargetNotFoundError(
+            "custom XML properties have no item payload; nothing was changed"
+        )
+    item_root = _part_root(item_part)
+    if item_root is None:
+        raise UnsupportedStructureError(
+            "custom XML item is not writable XML; nothing was changed"
+        )
+    nodes = item_root.xpath(xpath, namespaces=nsmap or None)
+    if not nodes:
+        raise TargetNotFoundError(
+            f"xpath {xpath!r} matched no node in the custom XML store"
+        )
+    nodes[0].text = value
+    if getattr(item_part, "_element", None) is None:
+        item_part._blob = etree.tostring(
+            item_root, xml_declaration=True, encoding="UTF-8"
+        )
+
+
+def _refuse_locked_control_content(sdt: "_Element") -> None:
     sdt_pr = sdt.find(_SDT_PR)
     if sdt_pr is None:
         return
-    if sdt_pr.find(_DATA_BINDING) is not None:
-        raise UnsupportedStructureError(
-            "control is data-bound; edits could be discarded on sync"
-        )
     locks = sdt_pr.findall(_LOCK)
     if len(locks) > 1:
         raise UnsupportedStructureError(
@@ -634,6 +722,18 @@ def _refuse_control_write_restrictions(sdt: "_Element") -> None:
         raise UnsupportedStructureError(
             "control content is locked; nothing was changed"
         )
+
+
+def _refuse_control_write_restrictions(sdt: "_Element") -> None:
+    """Honor binding and content locks without rejecting typed controls."""
+    sdt_pr = sdt.find(_SDT_PR)
+    if sdt_pr is None:
+        return
+    if sdt_pr.find(_DATA_BINDING) is not None:
+        raise UnsupportedStructureError(
+            "control is data-bound; edits could be discarded on sync"
+        )
+    _refuse_locked_control_content(sdt)
 
 
 def _iter_sdts(element: "_Element") -> "Iterator[_Element]":

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -29,7 +29,7 @@ from docx.errors import (
 )
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.oxml.ns import qn
-from docx.oxml.parser import OxmlElement
+from docx.oxml.parser import OxmlElement, parse_xml
 from docx.protection import _refuse_if_protected
 from docx.search import _validate_writable_text
 from docx.story import _first_choice_children, _story_elements
@@ -657,7 +657,7 @@ def _part_root(part):
     blob = getattr(part, "blob", None)
     if not blob:
         return None
-    return etree.fromstring(blob)
+    return parse_xml(blob)
 
 
 def _write_bound_node(node, value: str) -> None:

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -640,12 +640,38 @@ def _validate_span_surface_edit(sdt: "_Element") -> None:
 def _prefix_map(raw: Optional[str]) -> dict:
     if not raw:
         return {}
-    return {
-        match.group(1): match.group(2)
-        for match in re.finditer(
-            r"xmlns:([A-Za-z0-9_]+)\s*=\s*['\"]([^'\"]+)['\"]", raw
-        )
-    }
+    mapping = {}
+    for match in re.finditer(
+        r"xmlns(?::([A-Za-z_][\w.-]*))?\s*=\s*['\"]([^'\"]+)['\"]", raw
+    ):
+        mapping[match.group(1) or "_"] = match.group(2)
+    return mapping
+
+
+def _binding_namespaces(root, binding: "_Element") -> dict:
+    nsmap = _prefix_map(binding.get(_PREFIX_MAPPINGS))
+    if nsmap:
+        return nsmap
+    nsmap = {prefix: uri for prefix, uri in (root.nsmap or {}).items() if prefix}
+    default = (root.nsmap or {}).get(None)
+    if default is not None:
+        nsmap["_"] = default
+    return nsmap
+
+
+def _eval_store_xpath(root, xpath: str, nsmap: dict):
+    namespaces = nsmap or None
+    nodes = root.xpath(xpath, namespaces=namespaces)
+    if nodes:
+        return nodes
+    if "_" not in nsmap or re.search(r"(^|/)[A-Za-z_][\w.-]*:", xpath):
+        return nodes
+    qualified = re.sub(
+        r"(^|/)([A-Za-z_][\w.-]*)",
+        lambda match: f"{match.group(1)}_:{match.group(2)}",
+        xpath,
+    )
+    return root.xpath(qualified, namespaces=nsmap)
 
 
 def _part_root(part):
@@ -683,7 +709,6 @@ def _write_bound_store(document: "Document", binding: "_Element", value: str) ->
         raise UnsupportedStructureError(
             "data-bound control is missing storeItemID or xpath; nothing was changed"
         )
-    nsmap = _prefix_map(binding.get(_PREFIX_MAPPINGS))
     props_part = None
     for part in document.part.package.iter_parts():
         if part.content_type != CT.OFC_CUSTOM_XML_PROPERTIES:
@@ -720,7 +745,7 @@ def _write_bound_store(document: "Document", binding: "_Element", value: str) ->
         raise UnsupportedStructureError(
             "custom XML item is not writable XML; nothing was changed"
         )
-    nodes = item_root.xpath(xpath, namespaces=nsmap or None)
+    nodes = _eval_store_xpath(item_root, xpath, _binding_namespaces(item_root, binding))
     if not nodes:
         raise TargetNotFoundError(
             f"xpath {xpath!r} matched no node in the custom XML store"

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -659,9 +659,41 @@ def _binding_namespaces(root, binding: "_Element") -> dict:
     return nsmap
 
 
+def _evaluate_store_xpath(root, xpath: str, namespaces):
+    """Run one stored binding expression, refusing anything that cannot name a node.
+
+    The expression comes from `w:dataBinding/@w:xpath`, so it is document content rather than
+    a caller argument: a malformed or non-node-set expression is bad input and has to speak as
+    a typed refusal like every other defect this function rejects. Unguarded, lxml surfaced
+    `XPathEvalError` for bad syntax and `TypeError` for an expression returning a number or a
+    boolean, neither of which a caller catching |PaperRefusal| can handle.
+
+    Word treats a binding it cannot evaluate as an *unbound* control: it opens the document
+    without complaint and shows the body placeholder. So the message says the binding is
+    unusable, never that the document is damaged.
+    """
+    try:
+        result = root.xpath(xpath, namespaces=namespaces)
+    except etree.XPathError as exc:
+        raise UnsupportedStructureError(
+            f"the data-bound control's xpath {xpath!r} is not a valid XPath expression, so the"
+            " bound value cannot be located. The document itself is intact — Word treats such"
+            " a binding as unbound. Repair the w:dataBinding expression, or set the control's"
+            " value in a document whose binding resolves; nothing was changed"
+        ) from exc
+    if not isinstance(result, list):
+        raise UnsupportedStructureError(
+            f"the data-bound control's xpath {xpath!r} evaluates to"
+            f" {type(result).__name__}, not to a node, so there is nothing in the custom XML"
+            " store to write to. Point the binding at an element or attribute; nothing was"
+            " changed"
+        )
+    return result
+
+
 def _eval_store_xpath(root, xpath: str, nsmap: dict):
     namespaces = nsmap or None
-    nodes = root.xpath(xpath, namespaces=namespaces)
+    nodes = _evaluate_store_xpath(root, xpath, namespaces)
     if nodes:
         return nodes
     if "_" not in nsmap or re.search(r"(^|/)[A-Za-z_][\w.-]*:", xpath):
@@ -671,7 +703,7 @@ def _eval_store_xpath(root, xpath: str, nsmap: dict):
         lambda match: f"{match.group(1)}_:{match.group(2)}",
         xpath,
     )
-    return root.xpath(qualified, namespaces=nsmap)
+    return _evaluate_store_xpath(root, qualified, nsmap)
 
 
 def _part_root(part):

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -10,6 +10,7 @@ import pytest
 
 import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
+from docx.controls import get_control, set_control_value
 from docx.drawing import Drawing
 from docx.errors import (
     BoundaryViolationError,
@@ -20,7 +21,10 @@ from docx.errors import (
 from docx.fields import add_caption
 from docx.links import add_hyperlink
 from docx.notes import add_endnote, add_footnote
+from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.opc.part import XmlPart
 from docx.oxml.ns import nsdecls, qn
 from docx.oxml.parser import OxmlElement, parse_xml
 from docx.protection import acknowledge_protection, set_protection
@@ -30,6 +34,7 @@ from .harness.contract import save_and_reopen
 from .harness.paths import fixture_path
 
 MINIMAL = "generated/minimal-clean/minimal.docx"
+STORE_ID = "{11111111-1111-1111-1111-111111111111}"
 
 
 def _doc(relpath: str = MINIMAL):
@@ -46,6 +51,46 @@ def _bmp(red: int, green: int, blue: int) -> bytes:
 
 def _blip_embed(drawing: Drawing) -> str:
     return drawing._drawing.xpath(".//pic:blipFill/a:blip/@r:embed")[0]
+
+
+def _attach_bound_control(document, tag: str, *, locked: bool = False) -> None:
+    item = parse_xml(
+        '<ns0:root xmlns:ns0="http://example.com/form">'
+        "<ns0:name>old</ns0:name></ns0:root>"
+    )
+    item_part = XmlPart(
+        PackURI("/customXml/item2.xml"),
+        "application/xml",
+        item,
+        document.part.package,
+    )
+    props = parse_xml(
+        '<ds:datastoreItem xmlns:ds="http://schemas.openxmlformats.org/'
+        'officeDocument/2006/customXml"'
+        f' ds:itemID="{STORE_ID}"/>'
+    )
+    props_part = XmlPart(
+        PackURI("/customXml/itemProps2.xml"),
+        CT.OFC_CUSTOM_XML_PROPERTIES,
+        props,
+        document.part.package,
+    )
+    document.part.relate_to(item_part, RT.CUSTOM_XML)
+    item_part.relate_to(props_part, RT.CUSTOM_XML_PROPS)
+    lock = '<w:lock w:val="contentLocked"/>' if locked else ""
+    document.element.body.insert(
+        len(document.element.body) - 1,
+        parse_xml(
+            '<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+            f'<w:sdt><w:sdtPr><w:tag w:val="{tag}"/>{lock}'
+            "<w:dataBinding"
+            " w:prefixMappings=\"xmlns:ns0='http://example.com/form'\""
+            ' w:xpath="/ns0:root/ns0:name"'
+            f' w:storeItemID="{STORE_ID}"/></w:sdtPr>'
+            "<w:sdtContent><w:r><w:t>old</w:t></w:r></w:sdtContent>"
+            "</w:sdt></w:p>"
+        ),
+    )
 
 
 class DescribeCommentDeleteAndIdentity:
@@ -473,3 +518,43 @@ class DescribeNotes:
         )
         with pytest.raises(UnsupportedStructureError, match="plain-text"):
             add_footnote(document, find_one(document, "PlainTextNote"), "nope")
+
+
+class DescribeDataBoundControls:
+    def it_writes_the_custom_xml_store(self, tmp_path: Path):
+        document = _doc()
+        _attach_bound_control(document, "bound")
+        set_control_value(document, "new", tag="bound")
+        assert get_control(document, tag="bound").value == "new"
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        store = None
+        for part in reopened.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                element = getattr(part, "_element", None)
+                store = element if element is not None else parse_xml(part.blob)
+        assert store is not None
+        ns = {"ns0": "http://example.com/form"}
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+    def it_writes_the_store_when_the_package_has_binary_parts(self, tmp_path: Path):
+        document = _doc()
+        document.add_paragraph().add_run().add_picture(io.BytesIO(_bmp(255, 0, 0)))
+        _attach_bound_control(document, "bound")
+        set_control_value(document, "new", tag="bound")
+        assert get_control(document, tag="bound").value == "new"
+        reopened = save_and_reopen(document, tmp_path / "out.docx")
+        store = None
+        for part in reopened.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                element = getattr(part, "_element", None)
+                store = element if element is not None else parse_xml(part.blob)
+        assert store is not None
+        ns = {"ns0": "http://example.com/form"}
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+    def it_refuses_a_locked_data_bound_control(self):
+        document = _doc()
+        _attach_bound_control(document, "bound-locked", locked=True)
+        with pytest.raises(UnsupportedStructureError, match="locked"):
+            set_control_value(document, "new", tag="bound-locked")
+        assert get_control(document, tag="bound-locked").value == "old"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -53,11 +53,19 @@ def _blip_embed(drawing: Drawing) -> str:
     return drawing._drawing.xpath(".//pic:blipFill/a:blip/@r:embed")[0]
 
 
-def _attach_bound_control(document, tag: str, *, locked: bool = False) -> None:
-    item = parse_xml(
+def _attach_bound_control(
+    document,
+    tag: str,
+    *,
+    locked: bool = False,
+    extra_pr: str = "",
+    xpath: str = "/ns0:root/ns0:name",
+    item_xml: str = (
         '<ns0:root xmlns:ns0="http://example.com/form">'
         "<ns0:name>old</ns0:name></ns0:root>"
-    )
+    ),
+) -> None:
+    item = parse_xml(item_xml)
     item_part = XmlPart(
         PackURI("/customXml/item2.xml"),
         "application/xml",
@@ -81,11 +89,11 @@ def _attach_bound_control(document, tag: str, *, locked: bool = False) -> None:
     document.element.body.insert(
         len(document.element.body) - 1,
         parse_xml(
-            '<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
-            f'<w:sdt><w:sdtPr><w:tag w:val="{tag}"/>{lock}'
+            f'<w:p {nsdecls("w", "w14")}>'
+            f'<w:sdt><w:sdtPr><w:tag w:val="{tag}"/>{lock}{extra_pr}'
             "<w:dataBinding"
             " w:prefixMappings=\"xmlns:ns0='http://example.com/form'\""
-            ' w:xpath="/ns0:root/ns0:name"'
+            f' w:xpath="{xpath}"'
             f' w:storeItemID="{STORE_ID}"/></w:sdtPr>'
             "<w:sdtContent><w:r><w:t>old</w:t></w:r></w:sdtContent>"
             "</w:sdt></w:p>"
@@ -572,3 +580,79 @@ class DescribeDataBoundControls:
         set_control_value(document, "new", tag="bound")
         assert node.get("{http://www.w3.org/2001/XMLSchema-instance}nil") is None
         assert node.text == "new"
+
+    def it_refuses_a_data_bound_checkbox(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-box",
+            extra_pr='<w14:checkbox><w14:checked w14:val="0"/></w14:checkbox>',
+        )
+        with pytest.raises(UnsupportedStructureError, match="checkbox"):
+            set_control_value(document, "true", tag="bound-box")
+        assert get_control(document, tag="bound-box").value is False
+
+    def it_refuses_a_data_bound_picture(self):
+        document = _doc()
+        _attach_bound_control(document, "bound-pic", extra_pr="<w:picture/>")
+        with pytest.raises(UnsupportedStructureError, match="picture"):
+            set_control_value(document, "new", tag="bound-pic")
+
+    def it_writes_an_attribute_binding(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-attr",
+            xpath="/ns0:root/ns0:name/@status",
+            item_xml=(
+                '<ns0:root xmlns:ns0="http://example.com/form">'
+                '<ns0:name status="old">keep</ns0:name></ns0:root>'
+            ),
+        )
+        set_control_value(document, "new", tag="bound-attr")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        node = store.xpath("/ns0:root/ns0:name", namespaces=ns)[0]
+        assert node.get("status") == "new"
+        assert node.text == "keep"
+
+    def it_refuses_a_data_bound_checkbox(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-box",
+            extra_pr='<w14:checkbox><w14:checked w14:val="0"/></w14:checkbox>',
+        )
+        with pytest.raises(UnsupportedStructureError, match="checkbox"):
+            set_control_value(document, "true", tag="bound-box")
+        assert get_control(document, tag="bound-box").value is False
+
+    def it_refuses_a_data_bound_picture(self):
+        document = _doc()
+        _attach_bound_control(document, "bound-pic", extra_pr="<w:picture/>")
+        with pytest.raises(UnsupportedStructureError, match="picture"):
+            set_control_value(document, "new", tag="bound-pic")
+
+    def it_writes_an_attribute_binding(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-attr",
+            xpath="/ns0:root/ns0:name/@status",
+            item_xml=(
+                '<ns0:root xmlns:ns0="http://example.com/form">'
+                '<ns0:name status="old">keep</ns0:name></ns0:root>'
+            ),
+        )
+        set_control_value(document, "new", tag="bound-attr")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        node = store.xpath("/ns0:root/ns0:name", namespaces=ns)[0]
+        assert node.get("status") == "new"
+        assert node.text == "keep"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -10,7 +10,7 @@ import pytest
 
 import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
-from docx.controls import get_control, set_control_value
+from docx.controls import _part_root, get_control, set_control_value
 from docx.drawing import Drawing
 from docx.errors import (
     BoundaryViolationError,
@@ -619,40 +619,25 @@ class DescribeDataBoundControls:
         assert node.get("status") == "new"
         assert node.text == "keep"
 
-    def it_refuses_a_data_bound_checkbox(self):
+    def it_writes_the_store_after_reopen(self, tmp_path: Path):
         document = _doc()
-        _attach_bound_control(
-            document,
-            "bound-box",
-            extra_pr='<w14:checkbox><w14:checked w14:val="0"/></w14:checkbox>',
-        )
-        with pytest.raises(UnsupportedStructureError, match="checkbox"):
-            set_control_value(document, "true", tag="bound-box")
-        assert get_control(document, tag="bound-box").value is False
-
-    def it_refuses_a_data_bound_picture(self):
-        document = _doc()
-        _attach_bound_control(document, "bound-pic", extra_pr="<w:picture/>")
-        with pytest.raises(UnsupportedStructureError, match="picture"):
-            set_control_value(document, "new", tag="bound-pic")
-
-    def it_writes_an_attribute_binding(self):
-        document = _doc()
-        _attach_bound_control(
-            document,
-            "bound-attr",
-            xpath="/ns0:root/ns0:name/@status",
-            item_xml=(
-                '<ns0:root xmlns:ns0="http://example.com/form">'
-                '<ns0:name status="old">keep</ns0:name></ns0:root>'
-            ),
-        )
-        set_control_value(document, "new", tag="bound-attr")
+        _attach_bound_control(document, "bound")
+        reopened = save_and_reopen(document, tmp_path / "in.docx")
+        set_control_value(reopened, "new", tag="bound")
+        saved = save_and_reopen(reopened, tmp_path / "out.docx")
         store = None
-        for part in document.part.package.iter_parts():
+        for part in saved.part.package.iter_parts():
             if str(part.partname) == "/customXml/item2.xml":
-                store = part._element
+                element = getattr(part, "_element", None)
+                store = element if element is not None else parse_xml(part.blob)
+        assert store is not None
         ns = {"ns0": "http://example.com/form"}
-        node = store.xpath("/ns0:root/ns0:name", namespaces=ns)[0]
-        assert node.get("status") == "new"
-        assert node.text == "keep"
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+    def it_parses_blob_stores_without_resolving_entities(self):
+        class _BlobPart:
+            content_type = "application/xml"
+            blob = b'<!DOCTYPE root [<!ENTITY e "EXPANDED">]><root>&e;</root>'
+
+        root = _part_root(_BlobPart())
+        assert (root.text or "") != "EXPANDED"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -558,3 +558,17 @@ class DescribeDataBoundControls:
         with pytest.raises(UnsupportedStructureError, match="locked"):
             set_control_value(document, "new", tag="bound-locked")
         assert get_control(document, tag="bound-locked").value == "old"
+
+    def it_clears_xsi_nil_when_writing_the_store(self):
+        document = _doc()
+        _attach_bound_control(document, "bound")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        node = store.xpath("/ns0:root/ns0:name", namespaces=ns)[0]
+        node.set("{http://www.w3.org/2001/XMLSchema-instance}nil", "true")
+        set_control_value(document, "new", tag="bound")
+        assert node.get("{http://www.w3.org/2001/XMLSchema-instance}nil") is None
+        assert node.text == "new"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -7,6 +7,7 @@ import struct
 from pathlib import Path
 
 import pytest
+from lxml import etree
 
 import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
@@ -532,6 +533,46 @@ class DescribeNotes:
 
 
 class DescribeDataBoundControls:
+    # -- A binding's xpath is document content, not a caller argument, so every way it can be
+    # -- unusable has to speak as a typed refusal. Word treats a binding it cannot evaluate as
+    # -- an unbound control -- it opens the document and shows the body placeholder -- so these
+    # -- refusals must not claim the document is damaged.
+    @pytest.mark.parametrize(
+        "xpath",
+        [
+            "/ns0:root/[[[",                    # malformed syntax
+            "bogus-fn(/ns0:root)",              # unregistered function
+            "count(/ns0:root/ns0:name)",        # evaluates to a number
+            "string(/ns0:root/ns0:name)",       # evaluates to a string
+            "boolean(/ns0:root)",               # evaluates to a boolean
+        ],
+    )
+    def it_refuses_an_xpath_that_cannot_name_a_node(self, xpath: str):
+        document = _doc()
+        _attach_bound_control(document, "bound", xpath=xpath)
+        before = etree.tostring(document.element)
+
+        with pytest.raises(UnsupportedStructureError, match="nothing was changed"):
+            set_control_value(document, "new", tag="bound")
+
+        assert etree.tostring(document.element) == before
+        assert get_control(document, tag="bound").value == "old"
+
+    def it_says_the_binding_is_unusable_without_calling_the_document_damaged(self):
+        document = _doc()
+        _attach_bound_control(document, "bound", xpath="/ns0:root/[[[")
+
+        with pytest.raises(UnsupportedStructureError) as exc:
+            set_control_value(document, "new", tag="bound")
+
+        message = str(exc.value)
+        assert "not a valid XPath expression" in message
+        assert "/ns0:root/[[[" in message
+        # -- Word opens these documents without complaint, so the message must not imply
+        # -- corruption or send the caller to repair the file
+        assert "corrupt" not in message.lower()
+        assert "w:dataBinding expression" in message
+
     def it_writes_the_custom_xml_store(self, tmp_path: Path):
         document = _doc()
         _attach_bound_control(document, "bound")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -60,6 +60,7 @@ def _attach_bound_control(
     locked: bool = False,
     extra_pr: str = "",
     xpath: str = "/ns0:root/ns0:name",
+    prefix_mappings: str | None = "xmlns:ns0='http://example.com/form'",
     item_xml: str = (
         '<ns0:root xmlns:ns0="http://example.com/form">'
         "<ns0:name>old</ns0:name></ns0:root>"
@@ -86,13 +87,15 @@ def _attach_bound_control(
     document.part.relate_to(item_part, RT.CUSTOM_XML)
     item_part.relate_to(props_part, RT.CUSTOM_XML_PROPS)
     lock = '<w:lock w:val="contentLocked"/>' if locked else ""
+    mapping_attr = (
+        f" w:prefixMappings=\"{prefix_mappings}\"" if prefix_mappings is not None else ""
+    )
     document.element.body.insert(
         len(document.element.body) - 1,
         parse_xml(
             f'<w:p {nsdecls("w", "w14")}>'
             f'<w:sdt><w:sdtPr><w:tag w:val="{tag}"/>{lock}{extra_pr}'
-            "<w:dataBinding"
-            " w:prefixMappings=\"xmlns:ns0='http://example.com/form'\""
+            f"<w:dataBinding{mapping_attr}"
             f' w:xpath="{xpath}"'
             f' w:storeItemID="{STORE_ID}"/></w:sdtPr>'
             "<w:sdtContent><w:r><w:t>old</w:t></w:r></w:sdtContent>"
@@ -641,3 +644,52 @@ class DescribeDataBoundControls:
 
         root = _part_root(_BlobPart())
         assert (root.text or "") != "EXPANDED"
+
+    def it_writes_the_store_using_the_item_namespaces(self):
+        document = _doc()
+        _attach_bound_control(document, "bound", prefix_mappings=None)
+        set_control_value(document, "new", tag="bound")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+    def it_writes_the_store_using_the_default_namespace(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-default",
+            prefix_mappings=None,
+            xpath="/root/name",
+            item_xml=(
+                '<root xmlns="http://example.com/form"><name>old</name></root>'
+            ),
+        )
+        set_control_value(document, "new", tag="bound-default")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+    def it_writes_the_store_when_prefix_mappings_declare_a_default_ns(self):
+        document = _doc()
+        _attach_bound_control(
+            document,
+            "bound-default-map",
+            prefix_mappings="xmlns='http://example.com/form'",
+            xpath="/root/name",
+            item_xml=(
+                '<root xmlns="http://example.com/form"><name>old</name></root>'
+            ),
+        )
+        set_control_value(document, "new", tag="bound-default-map")
+        store = None
+        for part in document.part.package.iter_parts():
+            if str(part.partname) == "/customXml/item2.xml":
+                store = part._element
+        ns = {"ns0": "http://example.com/form"}
+        assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"


### PR DESCRIPTION
## Summary
- Stacked on #20.
- Data-bound `set_control_value` writes the custom XML store (`w:storeItemID` + `w:xpath`) and then the visible text.
- Looks up the store by custom XML properties content type, so images and thumbnails are not parsed as XML.
- Locked controls still refuse.

## Test plan
- [x] `tests/paper/test_missing_apis.py` bound-control cases
- [x] `tests/paper/test_verbs.py` still covers incomplete bindings
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)