### PR TITLE
feat: copy source letterhead on append_document

### DIFF
--- a/docs/proposals/paper-docx-pre-oss-review.md
+++ b/docs/proposals/paper-docx-pre-oss-review.md
@@ -41,7 +41,7 @@ Drop the zip-bomb caps and the two bundled deliver verbs. Keep `PackageLimitErro
 - ~~Auto-number caption field~~ **Done.** `add_caption`.
 - ~~Add a footnote or endnote~~ **Done.** `add_footnote`, `add_endnote`.
 - ~~Fill a data-bound form control~~ **Done.** `set_control_value` writes the custom XML store.
-- Append and keep the source letterhead
+- ~~Append and keep the source letterhead~~ **Done.** `append_document(..., headers="source")`.
 
 **Parked**
 
@@ -64,7 +64,7 @@ Read **What it does** first. The API column is only the name in the library.
 | Fill a form control: text, checkbox, dropdown, or date. | `docx.controls` | Structured | Yes | Stock cannot fill content controls safely. Data-bound controls write the custom XML store. Picture controls still refuse. |
 | Put a bookmark on a phrase, list bookmarks, or remove the markers (the text stays). | `docx.bookmarks` | Structured | Yes | Anchors for cross-references and TOC in existing files. |
 | Insert a page number, date, cross-reference, table of contents, or auto-number caption. The displayed value is computed when Word opens the file, not here. | `docx.fields` | Structured | Yes | Stock is weak; agents otherwise hand-edit field XML. Captions use `add_caption` (SEQ). |
-| Copy a range, or a whole document, into another file, keeping styles, lists, and images. | `docx.composition` | Combine | Yes | Cross-file copy is where styles and relationships corrupt. Headers stay those of the destination file; keeping the source letterhead was left for later. Will not copy comments, pending revisions, or footnotes. |
+| Copy a range, or a whole document, into another file, keeping styles, lists, and images. | `docx.composition` | Combine | Yes | Cross-file copy is where styles and relationships corrupt. Default append keeps destination headers; `headers="source"` copies the source letterhead. Will not copy comments, pending revisions, or footnotes. |
 | Save an edited file without rewriting ZIP parts that did not change. | `docx.package.patch_save` | Package | Yes | Stock save rewrites the whole ZIP, which noisily diffs and can break unrelated parts. |
 | On open and save: refuse a broken ZIP with a typed error, write atomically, and roll back a failed edit instead of leaving a half-written file. | zipguard, atomic `save`, transactions, `PaperRefusal` | Package | Yes | Load/save plumbing. Keep. The zip-bomb *size caps* are gone (see Change order). A member that inflates past the size it declared still refuses. |
 | Say why a file will not open: encrypted, template, macros, not Word, damaged ZIP. | `docx.package.diagnose` | Package | Yes | Stock raises untyped errors on bad input. |
@@ -80,7 +80,7 @@ Read **What it does** first. The API column is only the name in the library.
 
 ## Missing
 
-Jobs the agent could not do through the package. Stacked follow-ups add these APIs. **Plans** is vs `paper-original-plans-and-specs-2026-08-13/paper-docx` and is unchanged.
+Jobs the agent could not do through the package. This follow-up adds the APIs. **Plans** is vs `paper-original-plans-and-specs-2026-08-13/paper-docx` and is unchanged.
 
 | What the agent needs to do | Use case | Why it was a hole | API | Plans |
 | --- | --- | --- | --- | --- |
@@ -92,7 +92,7 @@ Jobs the agent could not do through the package. Stacked follow-ups add these AP
 | ~~Caption a figure or table so numbers update (Figure 1, Figure 2, …)~~ **Done.** | Structured | Bookmark plus REF is not a SEQ caption field. | `add_caption` | **Not asked.** Fields in the plan are page numbers, date, cross-references, and TOC. |
 | ~~Add a footnote or endnote~~ **Done.** | Edit existing | Existing notes could be read and edited. New notes were not created. | `add_footnote`, `add_endnote` | **Explicitly out.** Read is in. Creating notes was deferred until a legal or academic customer asked. |
 | ~~Fill a form field whose value lives in Word's hidden custom XML~~ **Done.** | Structured | Surface fill would vanish on Word open. The package used to refuse. | `set_control_value` writes the custom XML store. | **Asked as refuse.** Intentional no in the original plan; this follow-up fills the store. |
-| Append another document and keep *its* letterhead | Combine | Default append keeps destination headers. | | **Asked as future.** Destination headers on purpose; keeping the source letterhead was left for later. |
+| ~~Append another document and keep *its* letterhead~~ **Done.** | Combine | Default append keeps destination headers. | `append_document(..., headers="source")` | **Asked as future.** Destination headers on purpose; keeping the source letterhead was left for later. |
 
 Not a package hole (stock, QA outside the library, or a different product): insert image (`Run.add_picture`), edit header/footer text (stock + story/search), page/section breaks (stock `add_section`), fill existing non-bound form controls, visual PNG render, flatten-runs, redaction, a11y audit, watermarks, Google Docs title sanitizer, `.doc` conversion. Public document-QA was asked to stay out of this library.
 

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -197,6 +197,7 @@ def append_document(
     destination_blocks = [child for child in document.element.body if child.tag in _BODY_BLOCK_TAGS]
     if not destination_blocks:
         raise TargetNotFoundError("the destination document body has no blocks")
+    dest_section_count = len(document.sections)
     with rollback_on_error(document):
         report = _compose(
             document,
@@ -215,7 +216,7 @@ def append_document(
             break_paragraph.append(run)
             destination_blocks[-1].addnext(break_paragraph)
         if headers == "source":
-            _copy_letterhead(document, source, report)
+            _copy_letterhead(document, source, report, dest_section_count)
         return report
 
 
@@ -225,7 +226,10 @@ def _validate_styles_mode(styles: str) -> None:
 
 
 def _copy_letterhead(
-    document: "Document", source: "Document", report: CompositionReport
+    document: "Document",
+    source: "Document",
+    report: CompositionReport,
+    dest_section_count: int,
 ) -> None:
     dest_section = document.sections[-1]
     src_section = source.sections[-1]
@@ -234,7 +238,7 @@ def _copy_letterhead(
     )
     source_even = source.settings.odd_and_even_pages_header_footer
     dest_even = document.settings.odd_and_even_pages_header_footer
-    if source_even != dest_even and len(document.sections) > 1:
+    if source_even != dest_even and dest_section_count > 1:
         raise UnsupportedStructureError(
             "even/odd headers are a document-wide setting; destination has"
             " more than one section. Nothing was changed"

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -184,6 +184,9 @@ def append_document(
     `w:sectPr`: `section="new_page"` prefixes the appended content with a
     page break; `"continuous"` appends flush. Pass `headers="source"` to
     copy the source letterhead onto the destination's last section.
+    First-page headers cannot target the appended content (they apply to
+    that section's first page, which already holds destination body) and
+    are skipped.
     """
     _validate_styles_mode(styles)
     if section not in ("new_page", "continuous"):
@@ -234,9 +237,6 @@ def _copy_letterhead(
 ) -> None:
     dest_section = document.sections[-1]
     src_section = source.sections[-1]
-    dest_section.different_first_page_header_footer = (
-        src_section.different_first_page_header_footer
-    )
     source_even = source.settings.odd_and_even_pages_header_footer
     dest_even = document.settings.odd_and_even_pages_header_footer
     if source_even != dest_even and dest_section_count > 1:
@@ -245,11 +245,21 @@ def _copy_letterhead(
             " more than one section. Nothing was changed"
         )
     document.settings.odd_and_even_pages_header_footer = source_even
+    if src_section.different_first_page_header_footer:
+        report.findings.append(
+            CompositionFinding(
+                kind="letterhead_first_page_skipped",
+                detail=(
+                    "first-page headers apply to the destination section's"
+                    " first page, not the appended content; the source"
+                    " first-page letterhead was not copied"
+                ),
+            )
+        )
+    dest_section.different_first_page_header_footer = False
     pairs = (
         (src_section.header, dest_section.header),
         (src_section.footer, dest_section.footer),
-        (src_section.first_page_header, dest_section.first_page_header),
-        (src_section.first_page_footer, dest_section.first_page_footer),
         (src_section.even_page_header, dest_section.even_page_header),
         (src_section.even_page_footer, dest_section.even_page_footer),
     )

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -30,6 +30,7 @@ from docx._guard import check_install
 from docx._ownership import require_anchor_owner
 from docx._transaction import rollback_on_error
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
+from docx.fields import _set_update_fields_on_open
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.protection import _refuse_if_protected
@@ -54,6 +55,7 @@ _NAME = qn("w:name")
 _VAL = qn("w:val")
 _INSTR_TEXT = qn("w:instrText")
 _FLD_SIMPLE = qn("w:fldSimple")
+_FLD_CHAR = qn("w:fldChar")
 _INSTR = qn("w:instr")
 _BLIP = qn("a:blip")
 # VML (legacy image markup); its prefix is not in the upstream nsmap
@@ -85,6 +87,14 @@ _REFUSED_TAGS = {
     qn("w:commentReference"): "a comment anchor (composition cannot carry comments)",
     qn("w:subDoc"): "a subdocument reference",
 }
+
+
+def _contains_fields(elements) -> bool:
+    return any(
+        True
+        for element in elements
+        for _node in element.iter(_FLD_SIMPLE, _FLD_CHAR)
+    )
 
 
 @dataclass(frozen=True)
@@ -263,6 +273,7 @@ def _copy_letterhead(
         (src_section.even_page_header, dest_section.even_page_header),
         (src_section.even_page_footer, dest_section.even_page_footer),
     )
+    letterhead_has_fields = False
     for src_hf, dest_hf in pairs:
         src_defined = _defined_header_footer(src_hf)
         if src_defined is None:
@@ -281,6 +292,8 @@ def _copy_letterhead(
         for child in list(dest_root):
             dest_root.remove(child)
         clones = [copy.deepcopy(child) for child in source_children]
+        if _contains_fields(clones):
+            letterhead_has_fields = True
         imported_definitions = _reconcile_styles(
             document, source, clones, styles_mode, report
         )
@@ -293,6 +306,8 @@ def _copy_letterhead(
         _reallocate_sdt_ids(document, clones)
         for clone in clones:
             dest_root.append(clone)
+    if letterhead_has_fields:
+        _set_update_fields_on_open(document)
 
 
 def _defined_header_footer(hf):
@@ -389,9 +404,7 @@ def _compose(
     )
 
     report = CompositionReport()
-    has_fields = any(
-        True for element in range_elements for _node in element.iter(_FLD_SIMPLE, qn("w:fldChar"))
-    )
+    has_fields = _contains_fields(range_elements)
     # ALL refusal conditions run before any mutation (refusal atomicity):
     # importing styles/numbering/media first would leave orphaned
     # definitions behind when the destination anchor turns out invalid
@@ -432,8 +445,6 @@ def _compose(
     _pad_adjacent_tables(anchor_p, clones)
     _insert_after(anchor_p, clones)
     if has_fields:
-        from docx.fields import _set_update_fields_on_open
-
         _set_update_fields_on_open(document)
     report.inserted_blocks = len(clones)
     report.declared_parts = [

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -744,6 +744,9 @@ def _reconcile_styles(
     to_import: "List[Tuple[str, _Element]]" = []
     taken_ids = set(destination_by_id)  # incl. ids allocated THIS batch
     for style_id in wanted:
+        if style_id in report.style_map:
+            style_map[style_id] = report.style_map[style_id]
+            continue
         definition = source_by_id[style_id]
         name_element = definition.find(qn("w:name"))
         name = name_element.get(_VAL) if name_element is not None else style_id
@@ -1216,9 +1219,9 @@ def _reconcile_bookmarks(
                         ),
                     )
                 )
-    if renames:
-        _remap_field_refs(clones, renames)
     report.bookmarks_renamed.update(renames)
+    if report.bookmarks_renamed:
+        _remap_field_refs(clones, report.bookmarks_renamed)
 
 
 def _fresh_bookmark_name(existing_folded: set, base: str) -> str:

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -259,6 +259,8 @@ def _copy_letterhead(
             continue
         dest_hf.is_linked_to_previous = False
         source_children = list(src_defined._element)  # noqa: SLF001
+        _refuse_unsupported_content(source_children)
+        _refuse_malformed_numeric_ids(document, source_children)
         _preflight_relationships(src_defined.part, source_children)
         _refuse_unloadable_media(src_defined.part, source_children)
         chained = _chained_source_definitions(source, source_children)
@@ -268,11 +270,7 @@ def _copy_letterhead(
         dest_root = dest_hf._element  # noqa: SLF001
         for child in list(dest_root):
             dest_root.remove(child)
-        clones = []
-        for child in source_children:
-            clone = copy.deepcopy(child)
-            dest_root.append(clone)
-            clones.append(clone)
+        clones = [copy.deepcopy(child) for child in source_children]
         imported_definitions = _reconcile_styles(
             document, source, clones, styles_mode, report
         )
@@ -281,6 +279,10 @@ def _copy_letterhead(
         )
         _copy_media(dest_hf.part, src_defined.part, clones, report)
         _recreate_hyperlinks(dest_hf.part, src_defined.part, clones, report)
+        _reconcile_bookmarks(document, clones, report)
+        _reallocate_sdt_ids(document, clones)
+        for clone in clones:
+            dest_root.append(clone)
 
 
 def _defined_header_footer(hf):
@@ -1046,6 +1048,11 @@ def _remap_numbering(
     for remap in plan.remaps:
         if remap.source_num_id not in referenced:
             continue
+        if remap.source_num_id in report.numbering_map:
+            numbering_map[remap.source_num_id] = report.numbering_map[
+                remap.source_num_id
+            ]
+            continue
         abstract_clone = copy.deepcopy(remap.source_abstract)
         abstract_clone.set(qn("w:abstractNumId"), str(remap.destination_abstract_id))
         # nsid/tmpl uniqueness is advisory; leaving them is Word-tolerated
@@ -1211,7 +1218,7 @@ def _reconcile_bookmarks(
                 )
     if renames:
         _remap_field_refs(clones, renames)
-    report.bookmarks_renamed = renames
+    report.bookmarks_renamed.update(renames)
 
 
 def _fresh_bookmark_name(existing_folded: set, base: str) -> str:

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -176,17 +176,20 @@ def append_document(
     *,
     section: str = "new_page",
     styles: str = "match_by_name",
+    headers: str = "destination",
 ) -> CompositionReport:
     """Append `source`'s whole body to `document`.
 
-    Keeps the destination's headers/footers and authors no new
+    Keeps the destination's headers/footers by default and authors no new
     `w:sectPr`: `section="new_page"` prefixes the appended content with a
-    page break; `"continuous"` appends flush. (Keeping the source's headers
-    is a declared future mode.)
+    page break; `"continuous"` appends flush. Pass `headers="source"` to
+    copy the source letterhead onto the destination's last section.
     """
     _validate_styles_mode(styles)
     if section not in ("new_page", "continuous"):
         raise ValueError(f"section must be 'new_page' or 'continuous', got {section!r}")
+    if headers not in ("destination", "source"):
+        raise ValueError(f"headers must be 'destination' or 'source', got {headers!r}")
     _refuse_if_protected(document, "append a document")
     range_elements = [child for child in source.element.body if child.tag != _SECT_PR]
     if not range_elements:
@@ -211,12 +214,72 @@ def append_document(
             run.append(page_break)
             break_paragraph.append(run)
             destination_blocks[-1].addnext(break_paragraph)
+        if headers == "source":
+            _copy_letterhead(document, source, report)
         return report
 
 
 def _validate_styles_mode(styles: str) -> None:
     if styles not in ("match_by_name", "import_renamed"):
         raise ValueError(f"styles must be 'match_by_name' or 'import_renamed', got {styles!r}")
+
+
+def _copy_letterhead(
+    document: "Document", source: "Document", report: CompositionReport
+) -> None:
+    dest_section = document.sections[-1]
+    src_section = source.sections[-1]
+    dest_section.different_first_page_header_footer = (
+        src_section.different_first_page_header_footer
+    )
+    source_even = source.settings.odd_and_even_pages_header_footer
+    dest_even = document.settings.odd_and_even_pages_header_footer
+    if source_even != dest_even and len(document.sections) > 1:
+        raise UnsupportedStructureError(
+            "even/odd headers are a document-wide setting; destination has"
+            " more than one section. Nothing was changed"
+        )
+    document.settings.odd_and_even_pages_header_footer = source_even
+    pairs = (
+        (src_section.header, dest_section.header),
+        (src_section.footer, dest_section.footer),
+        (src_section.first_page_header, dest_section.first_page_header),
+        (src_section.first_page_footer, dest_section.first_page_footer),
+        (src_section.even_page_header, dest_section.even_page_header),
+        (src_section.even_page_footer, dest_section.even_page_footer),
+    )
+    for src_hf, dest_hf in pairs:
+        src_defined = _defined_header_footer(src_hf)
+        if src_defined is None:
+            continue
+        dest_hf.is_linked_to_previous = False
+        source_children = list(src_defined._element)  # noqa: SLF001
+        _preflight_relationships(src_defined.part, source_children)
+        _refuse_unloadable_media(src_defined.part, source_children)
+        dest_root = dest_hf._element  # noqa: SLF001
+        for child in list(dest_root):
+            dest_root.remove(child)
+        clones = []
+        for child in source_children:
+            clone = copy.deepcopy(child)
+            dest_root.append(clone)
+            clones.append(clone)
+        _copy_media(dest_hf.part, src_defined.part, clones, report)
+        _recreate_hyperlinks(dest_hf.part, src_defined.part, clones, report)
+
+
+def _defined_header_footer(hf):
+    """The header/footer that Word actually shows for this slot.
+
+    Walk `is_linked_to_previous` without touching `_element`, which would
+    create a part on the source document.
+    """
+    current = hf
+    while current is not None:
+        if not current.is_linked_to_previous:
+            return current
+        current = current._prior_headerfooter  # noqa: SLF001
+    return None
 
 
 def _source_range(source: "Document", start_anchor, end_anchor, count: int) -> "List[_Element]":
@@ -319,10 +382,10 @@ def _compose(
         _refuse_paragraph_in_open_field(story, root, anchor_p, for_insertion=True)
     _refuse_malformed_numeric_ids(document, range_elements)
     _preflight_bookmark_references(source, range_elements)
-    _preflight_relationships(source, range_elements)
+    _preflight_relationships(source.part, range_elements)
     chained_definitions = _chained_source_definitions(source, range_elements)
     numbering_plan = _preflight_numbering(document, source, range_elements + chained_definitions)
-    _refuse_unloadable_media(source, range_elements)
+    _refuse_unloadable_media(source.part, range_elements)
 
     clones = [copy.deepcopy(element) for element in range_elements]
     imported_definitions = _reconcile_styles(document, source, clones, styles_mode, report)
@@ -334,8 +397,8 @@ def _compose(
         numbering_plan,
         report,
     )
-    _copy_media(document, source, clones, report)
-    _recreate_hyperlinks(document, source, clones, report)
+    _copy_media(document.part, source.part, clones, report)
+    _recreate_hyperlinks(document.part, source.part, clones, report)
     _reconcile_bookmarks(document, clones, report)
     _reallocate_sdt_ids(document, clones)
 
@@ -373,7 +436,7 @@ def _chained_source_definitions(source: "Document", elements: "List[_Element]") 
     ]
 
 
-def _preflight_relationships(source: "Document", range_elements: "List[_Element]") -> None:
+def _preflight_relationships(source_part, range_elements: "List[_Element]") -> None:
     """Refuse every relationship the composition pipeline cannot remap."""
     from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
@@ -385,7 +448,7 @@ def _preflight_relationships(source: "Document", range_elements: "List[_Element]
                     or attribute == _OFFICE_REL_ID
                 ):
                     continue
-                rel = source.part.rels.get(r_id)
+                rel = source_part.rels.get(r_id)
                 if node.tag == _BLIP and attribute == _R_EMBED:
                     if rel is not None and rel.reltype == RT.IMAGE and not rel.is_external:
                         continue
@@ -470,7 +533,7 @@ def _refuse_relationship(node, attribute, r_id, rel, expected=None) -> None:
     )
 
 
-def _refuse_unloadable_media(source: "Document", range_elements: "List[_Element]") -> None:
+def _refuse_unloadable_media(source_part, range_elements: "List[_Element]") -> None:
     """Pre-mutation check: every image in the range must be re-embeddable,
     or _copy_media would raise AFTER styles/numbering were already imported
     (refusal atomicity)."""
@@ -483,7 +546,7 @@ def _refuse_unloadable_media(source: "Document", range_elements: "List[_Element]
             r_id = node.get(attr)
             if not r_id:
                 continue
-            rel = source.part.rels.get(r_id)
+            rel = source_part.rels.get(r_id)
             if rel is None or rel.is_external:
                 raise UnsupportedStructureError(
                     f"image relationship {r_id!r} changed after composition"
@@ -1000,8 +1063,8 @@ def _remap_numbering(
 
 
 def _copy_media(
-    document: "Document",
-    source: "Document",
+    dest_part,
+    source_part,
     clones: "List[_Element]",
     report: CompositionReport,
 ) -> None:
@@ -1015,24 +1078,24 @@ def _copy_media(
             if not r_id:
                 continue
             if r_id not in rel_map:
-                rel = source.part.rels.get(r_id)
+                rel = source_part.rels.get(r_id)
                 if rel is None or rel.is_external or rel.reltype != RT.IMAGE:
                     raise UnsupportedStructureError(
                         f"image relationship {r_id!r} changed after composition"
                         " preflight. Nothing was changed"
                     )
                 blob = rel.target_part.blob
-                new_r_id, _image = document.part.get_or_add_image(io.BytesIO(blob))
+                new_r_id, _image = dest_part.get_or_add_image(io.BytesIO(blob))
                 rel_map[r_id] = new_r_id
                 report.media_copied.append(
-                    str(document.part.rels[new_r_id].target_part.partname).lstrip("/")
+                    str(dest_part.rels[new_r_id].target_part.partname).lstrip("/")
                 )
             node.set(attr, rel_map[r_id])
 
 
 def _recreate_hyperlinks(
-    document: "Document",
-    source: "Document",
+    dest_part,
+    source_part,
     clones: "List[_Element]",
     report: CompositionReport,
 ) -> None:
@@ -1043,13 +1106,13 @@ def _recreate_hyperlinks(
             r_id = hyperlink.get(_R_ID)
             if not r_id:
                 continue  # internal anchor link: carried as-is
-            rel = source.part.rels.get(r_id)
+            rel = source_part.rels.get(r_id)
             if rel is None or not rel.is_external or rel.reltype != RT.HYPERLINK:
                 raise UnsupportedStructureError(
                     f"hyperlink relationship {r_id!r} changed after composition"
                     " preflight. Nothing was changed"
                 )
-            new_r_id = document.part.relate_to(rel.target_ref, RT.HYPERLINK, is_external=True)
+            new_r_id = dest_part.relate_to(rel.target_ref, RT.HYPERLINK, is_external=True)
             hyperlink.set(_R_ID, new_r_id)
 
 

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -216,7 +216,7 @@ def append_document(
             break_paragraph.append(run)
             destination_blocks[-1].addnext(break_paragraph)
         if headers == "source":
-            _copy_letterhead(document, source, report, dest_section_count)
+            _copy_letterhead(document, source, report, dest_section_count, styles)
         return report
 
 
@@ -230,6 +230,7 @@ def _copy_letterhead(
     source: "Document",
     report: CompositionReport,
     dest_section_count: int,
+    styles_mode: str = "match_by_name",
 ) -> None:
     dest_section = document.sections[-1]
     src_section = source.sections[-1]
@@ -260,6 +261,10 @@ def _copy_letterhead(
         source_children = list(src_defined._element)  # noqa: SLF001
         _preflight_relationships(src_defined.part, source_children)
         _refuse_unloadable_media(src_defined.part, source_children)
+        chained = _chained_source_definitions(source, source_children)
+        numbering_plan = _preflight_numbering(
+            document, source, source_children + chained
+        )
         dest_root = dest_hf._element  # noqa: SLF001
         for child in list(dest_root):
             dest_root.remove(child)
@@ -268,6 +273,12 @@ def _copy_letterhead(
             clone = copy.deepcopy(child)
             dest_root.append(clone)
             clones.append(clone)
+        imported_definitions = _reconcile_styles(
+            document, source, clones, styles_mode, report
+        )
+        _remap_numbering(
+            document, clones + imported_definitions, numbering_plan, report
+        )
         _copy_media(dest_hf.part, src_defined.part, clones, report)
         _recreate_hyperlinks(dest_hf.part, src_defined.part, clones, report)
 
@@ -772,7 +783,7 @@ def _reconcile_styles(
                 value = node.get(_VAL)
                 if value in style_map and style_map[value] != value:
                     node.set(_VAL, style_map[value])
-    report.style_map = style_map
+    report.style_map.update(style_map)
     if report.renamed_styles:
         _remap_styleref_fields(clones, report.renamed_styles)
     return [definition for _new_id, definition in to_import]
@@ -1058,7 +1069,7 @@ def _remap_numbering(
             value = num_id_element.get(_VAL)
             if value and int(value) in numbering_map:
                 num_id_element.set(_VAL, str(numbering_map[int(value)]))
-    report.numbering_map = numbering_map
+    report.numbering_map.update(numbering_map)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -192,7 +192,8 @@ APPROVED_SIGNATURES = [
     (
         "docx.composition",
         "append_document",
-        "(document, source, *, section='new_page', styles='match_by_name')",
+        "(document, source, *, section='new_page', styles='match_by_name',"
+        " headers='destination')",
     ),
     ("docx.bookmarks", "list_bookmarks", "(document)"),
     ("docx.bookmarks", "create_bookmark", "(document, span, name)"),

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -21,8 +21,10 @@ from docx.errors import (
     UnsupportedStructureError,
 )
 from docx.fields import add_caption
+from docx.enum.style import WD_STYLE_TYPE
 from docx.links import add_hyperlink
 from docx.notes import add_endnote, add_footnote
+from docx.numbering import apply_numbering, ensure_decimal_definition, list_numbering
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.packuri import PackURI
@@ -827,3 +829,35 @@ class DescribeSourceLetterhead:
         append_document(destination, source, headers="source")
         reopened = save_and_reopen(destination, tmp_path / "out.docx")
         assert reopened.settings.odd_and_even_pages_header_footer
+
+    def it_imports_a_custom_header_style(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        style = source.styles.add_style("LetterheadBrand", WD_STYLE_TYPE.PARAGRAPH)
+        style.font.italic = True
+        header = source.sections[0].header.paragraphs[0]
+        header.style = style
+        header.text = "Source letterhead"
+        report = append_document(destination, source, headers="source")
+        assert "LetterheadBrand" in report.imported_styles
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert reopened.sections[-1].header.paragraphs[0].style.name == "LetterheadBrand"
+
+    def it_remaps_header_numbering(self, tmp_path: Path):
+        destination = _doc()
+        ensure_decimal_definition(destination)
+        source = _doc()
+        source_num_id = ensure_decimal_definition(source)
+        header = source.sections[0].header.paragraphs[0]
+        header.text = "Header item"
+        apply_numbering(header, num_id=source_num_id)
+        report = append_document(destination, source, headers="source")
+        assert source_num_id in report.numbering_map
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        copied = [
+            item
+            for item in list_numbering(reopened).numbered_paragraphs
+            if item.text == "Header item"
+        ]
+        assert copied
+        assert copied[0].num_id == report.numbering_map[source_num_id]

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -902,3 +902,54 @@ class DescribeSourceLetterhead:
         )
         report = append_document(destination, source, headers="source")
         assert report.bookmarks_renamed["SharedMark"] != "SharedMark"
+
+    def it_reuses_a_body_style_remap_in_the_header(self, tmp_path: Path):
+        destination = _doc()
+        dest_style = destination.styles.add_style("HouseTerm", WD_STYLE_TYPE.PARAGRAPH)
+        dest_style.font.bold = True
+        source = _doc()
+        source_style = source.styles.add_style("HouseTerm", WD_STYLE_TYPE.PARAGRAPH)
+        source_style.font.italic = True
+        source.add_paragraph("Body branded", style="HouseTerm")
+        header = source.sections[0].header.paragraphs[0]
+        header.style = source_style
+        header.text = "Header branded"
+        report = append_document(
+            destination, source, headers="source", styles="import_renamed"
+        )
+        assert report.renamed_styles == {"HouseTerm": "HouseTerm (imported)"}
+        assert [style.name for style in destination.styles].count(
+            "HouseTerm (imported)"
+        ) == 1
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        body = next(p for p in reopened.paragraphs if "Body branded" in p.text)
+        copied_header = reopened.sections[-1].header.paragraphs[0]
+        assert body.style.name == copied_header.style.name == "HouseTerm (imported)"
+
+    def it_remaps_header_refs_to_body_bookmark_renames(self):
+        destination = _doc()
+        create_bookmark(
+            destination, find_one(destination, "perfectly ordinary"), "SharedMark"
+        )
+        source = _doc()
+        source.add_paragraph("Source body mark")
+        create_bookmark(source, find_one(source, "Source body mark"), "SharedMark")
+        header = source.sections[0].header.paragraphs[0]
+        header._p.append(
+            parse_xml(
+                f'<w:fldSimple {nsdecls("w")} w:instr=" REF SharedMark \\h ">'
+                "<w:r><w:t>see mark</w:t></w:r></w:fldSimple>"
+            )
+        )
+        header._p.append(
+            parse_xml(
+                f'<w:hyperlink {nsdecls("w")} w:anchor="SharedMark">'
+                "<w:r><w:t>jump</w:t></w:r></w:hyperlink>"
+            )
+        )
+        report = append_document(destination, source, headers="source")
+        renamed = report.bookmarks_renamed["SharedMark"]
+        assert renamed != "SharedMark"
+        header_xml = destination.sections[-1].header._element.xml
+        assert f" REF {renamed} " in header_xml
+        assert f'w:anchor="{renamed}"' in header_xml

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -800,7 +800,9 @@ class DescribeSourceLetterhead:
         source.sections[0].even_page_header.paragraphs[0].text = "Inherited even"
         source.add_section()
         assert source.sections[-1].even_page_header.is_linked_to_previous
-        _copy_letterhead(destination, source, CompositionReport())
+        _copy_letterhead(
+            destination, source, CompositionReport(), len(destination.sections)
+        )
         reopened = save_and_reopen(destination, tmp_path / "out.docx")
         assert "Inherited even" in reopened.sections[-1].even_page_header.paragraphs[0].text
 
@@ -812,3 +814,16 @@ class DescribeSourceLetterhead:
         source.sections[0].even_page_header.paragraphs[0].text = "Even letterhead"
         with pytest.raises(UnsupportedStructureError, match="document-wide"):
             append_document(destination, source, headers="source")
+
+    def it_allows_even_odd_when_only_the_source_gained_sections(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.settings.odd_and_even_pages_header_footer = True
+        source.sections[0].even_page_header.paragraphs[0].text = "Even letterhead"
+        source.add_section()
+        for child in list(source.sections[0]._sectPr):
+            if child.tag in (qn("w:headerReference"), qn("w:footerReference")):
+                source.sections[0]._sectPr.remove(child)
+        append_document(destination, source, headers="source")
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert reopened.settings.odd_and_even_pages_header_footer

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -953,3 +953,23 @@ class DescribeSourceLetterhead:
         header_xml = destination.sections[-1].header._element.xml
         assert f" REF {renamed} " in header_xml
         assert f'w:anchor="{renamed}"' in header_xml
+
+    def it_does_not_apply_source_first_page_headers_to_destination_pages(
+        self, tmp_path: Path
+    ):
+        destination = _doc()
+        destination.sections[0].header.paragraphs[0].text = "Dest running"
+        source = _doc()
+        source.sections[0].header.paragraphs[0].text = "Source running"
+        source.sections[0].different_first_page_header_footer = True
+        source.sections[0].first_page_header.paragraphs[0].text = "Source first page"
+        report = append_document(destination, source, headers="source")
+        assert any(
+            finding.kind == "letterhead_first_page_skipped"
+            for finding in report.findings
+        )
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert not reopened.sections[-1].different_first_page_header_footer
+        header_text = reopened.sections[-1].header.paragraphs[0].text
+        assert "Source running" in header_text
+        assert "Source first page" not in header_text

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -973,3 +973,17 @@ class DescribeSourceLetterhead:
         header_text = reopened.sections[-1].header.paragraphs[0].text
         assert "Source running" in header_text
         assert "Source first page" not in header_text
+
+    def it_arms_letterhead_fields_for_update(self):
+        destination = _doc()
+        source = _doc()
+        source.sections[0].header.paragraphs[0]._p.append(
+            parse_xml(
+                f'<w:fldSimple {nsdecls("w")} w:instr=" PAGE ">'
+                "<w:r><w:t>1</w:t></w:r></w:fldSimple>"
+            )
+        )
+        append_document(destination, source, headers="source")
+        update = destination.settings.element.find(qn("w:updateFields"))
+        assert update is not None
+        assert update.get(qn("w:val")) == "true"

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -11,6 +11,7 @@ from lxml import etree
 
 import docx
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
+from docx.composition import CompositionReport, _copy_letterhead, append_document
 from docx.controls import _part_root, get_control, set_control_value
 from docx.drawing import Drawing
 from docx.errors import (
@@ -734,3 +735,80 @@ class DescribeDataBoundControls:
                 store = part._element
         ns = {"ns0": "http://example.com/form"}
         assert store.xpath("/ns0:root/ns0:name", namespaces=ns)[0].text == "new"
+
+
+class DescribeSourceLetterhead:
+    def it_copies_source_headers_when_requested(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.sections[0].header.paragraphs[0].text = "Source letterhead"
+        append_document(destination, source, headers="source")
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert "Source letterhead" in reopened.sections[-1].header.paragraphs[0].text
+
+    def it_copies_header_images_onto_the_header_part(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.sections[0].header.paragraphs[0].add_run().add_picture(io.BytesIO(_bmp(0, 128, 0)))
+        append_document(destination, source, headers="source")
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        header = reopened.sections[-1].header
+        blips = header._element.findall(".//" + qn("a:blip"))
+        assert blips
+        r_id = blips[0].get(qn("r:embed"))
+        assert r_id in header.part.rels
+        assert header.part.rels[r_id].reltype == RT.IMAGE
+
+    def it_copies_header_hyperlinks_onto_the_header_part(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.sections[0].header.paragraphs[0].text = "SourceHeaderLink"
+        span = find_one(source, "SourceHeaderLink", story="word/header1.xml")
+        add_hyperlink(source, span, "https://example.com/letterhead")
+        append_document(destination, source, headers="source")
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        header = reopened.sections[-1].header
+        addresses = [
+            hyperlink.address
+            for paragraph in header.paragraphs
+            for hyperlink in paragraph.hyperlinks
+        ]
+        assert "https://example.com/letterhead" in addresses
+        r_ids = [
+            node.get(qn("r:id"))
+            for node in header._element.findall(".//" + qn("w:hyperlink"))
+        ]
+        assert r_ids and r_ids[0]
+        assert r_ids[0] in header.part.rels
+        assert header.part.rels[r_ids[0]].reltype == RT.HYPERLINK
+        assert header.part.rels[r_ids[0]].target_ref == "https://example.com/letterhead"
+
+    def it_turns_on_even_page_headers_when_the_source_uses_them(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.settings.odd_and_even_pages_header_footer = True
+        source.sections[0].even_page_header.paragraphs[0].text = "Even letterhead"
+        append_document(destination, source, headers="source")
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert reopened.settings.odd_and_even_pages_header_footer
+        assert "Even letterhead" in reopened.sections[-1].even_page_header.paragraphs[0].text
+
+    def it_copies_an_even_header_the_last_source_section_inherits(self, tmp_path: Path):
+        destination = _doc()
+        source = _doc()
+        source.settings.odd_and_even_pages_header_footer = True
+        source.sections[0].even_page_header.paragraphs[0].text = "Inherited even"
+        source.add_section()
+        assert source.sections[-1].even_page_header.is_linked_to_previous
+        _copy_letterhead(destination, source, CompositionReport())
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        assert "Inherited even" in reopened.sections[-1].even_page_header.paragraphs[0].text
+
+    def it_refuses_even_odd_when_the_destination_has_more_sections(self):
+        destination = _doc()
+        destination.add_section()
+        source = _doc()
+        source.settings.odd_and_even_pages_header_footer = True
+        source.sections[0].even_page_header.paragraphs[0].text = "Even letterhead"
+        with pytest.raises(UnsupportedStructureError, match="document-wide"):
+            append_document(destination, source, headers="source")

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -10,6 +10,7 @@ import pytest
 from lxml import etree
 
 import docx
+from docx.bookmarks import create_bookmark
 from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
 from docx.composition import CompositionReport, _copy_letterhead, append_document
 from docx.controls import _part_root, get_control, set_control_value
@@ -861,3 +862,43 @@ class DescribeSourceLetterhead:
         ]
         assert copied
         assert copied[0].num_id == report.numbering_map[source_num_id]
+
+    def it_reuses_a_body_numbering_remap_in_the_header(self, tmp_path: Path):
+        destination = _doc()
+        ensure_decimal_definition(destination)
+        source = _doc()
+        source_num_id = ensure_decimal_definition(source)
+        apply_numbering(source.add_paragraph("Body item"), num_id=source_num_id)
+        header = source.sections[0].header.paragraphs[0]
+        header.text = "Header item"
+        apply_numbering(header, num_id=source_num_id)
+        report = append_document(destination, source, headers="source")
+        new_id = report.numbering_map[source_num_id]
+        reopened = save_and_reopen(destination, tmp_path / "out.docx")
+        numbered = list_numbering(reopened).numbered_paragraphs
+        body_item = next(item for item in numbered if "Body item" in item.text)
+        header_item = next(item for item in numbered if item.text == "Header item")
+        assert body_item.num_id == header_item.num_id == new_id
+
+    def it_refuses_a_note_mark_in_the_source_letterhead(self):
+        destination = _doc()
+        source = _doc()
+        source.sections[0].header.paragraphs[0].text = "Source letterhead"
+        source.sections[0].header.paragraphs[0].add_run()._r.append(
+            parse_xml(f'<w:footnoteReference {nsdecls("w")} w:id="1"/>')
+        )
+        with pytest.raises(UnsupportedStructureError, match="footnote"):
+            append_document(destination, source, headers="source")
+
+    def it_renames_a_header_bookmark_that_collides_with_the_destination(self):
+        destination = _doc()
+        create_bookmark(destination, find_one(destination, "perfectly ordinary"), "SharedMark")
+        source = _doc()
+        source.sections[0].header.paragraphs[0].text = "HeaderMark"
+        create_bookmark(
+            source,
+            find_one(source, "HeaderMark", story="word/header1.xml"),
+            "SharedMark",
+        )
+        report = append_document(destination, source, headers="source")
+        assert report.bookmarks_renamed["SharedMark"] != "SharedMark"


### PR DESCRIPTION
## Summary
- Last PR in the Missing-API chain. Stacked on #21.
- `append_document(..., headers="source")` copies the source letterhead onto the destination's last section.
- Images and hyperlinks are related on the header/footer parts.
- Walks `is_linked_to_previous` so an inherited even header still copies.
- Refuses an even/odd flip when the destination already has more than one section.
- Default remains destination headers.

## Test plan
- [x] `tests/paper/test_missing_apis.py` letterhead cases
- [x] `tests/paper/test_composition.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)