### PR TITLE
fix: refuse packages Word cannot open, on both the read and the write side

### DIFF
--- a/docs/proposals/word-openable-packages/build-sequence.md
+++ b/docs/proposals/word-openable-packages/build-sequence.md
@@ -1,0 +1,214 @@
+# Build Sequence: Refuse packages Word cannot open
+
+**Created:** 2026-08-18
+**Status:** Ready
+
+## Dependency Graph
+
+<!-- Machine-readable DAG. /execute-plan parses this block. -->
+```yaml
+phases:
+  - id: 1
+    name: Load byte-zero check
+    depends_on: []
+  - id: 2
+    name: Refuse nonzero-offset stream writes
+    depends_on: [1]
+  - id: 3
+    name: diagnose() label accuracy
+    depends_on: [1]
+  - id: 4
+    name: Documentation hygiene
+    depends_on: [1, 2, 3]
+```
+
+## Context
+
+### What exists today
+
+`_zipguard._preflight_zip_stream` validates that a package's central directory is *internally
+consistent* — `central_offset + central_size == central_end` — which a prefixed archive with
+rebased offsets satisfies exactly. Nothing checks where the archive starts. Word refuses such a
+file; every Python reader opens it and reports the correct content.
+
+`preflight_zip` has exactly two callers, and between them they cover every read entry point:
+
+- `src/docx/opc/phys_pkg.py:127` — `Document()`, `PackageReader`
+- `src/docx/_paperpkg.py:226` (`_read_zip`) — `patch_save` (original at `:566`, its own output at
+  `:604`), `diff_package` (`:291-292`), `diagnose` (`:481`), `compare` (`_compare.py:314`)
+
+`opc/package._atomic_stream_write` permits a seekable destination at any position. The
+write-only branch (`_write_staged_to_unrestorable_stream`) already refuses a nonzero start with
+`OSError`; only the seekable branch allows it. A bare `stream.truncate()` at
+`opc/package.py:339` then destroys everything after the package.
+
+`_paperpkg.diagnose` returns `readable=True, kind="docx"` for a prefixed archive whose prefix
+begins with the bytes `PK`, and `kind="not-a-zip"` when it does not.
+
+### What this feature requires
+
+- A package must begin at byte 0 — a local file header signature, or an end-of-central-directory
+  signature for a legal empty archive.
+- Saving to a seekable stream positioned past 0 must refuse before staging anything, leaving the
+  destination byte-for-byte unchanged.
+- `diagnose()` must not label a prefixed archive `not-a-zip`.
+
+### What this feature explicitly excludes
+
+- **Part-name character rules, prefix-collision detection, image relationship content types, the
+  protection gate, and message rewording.** Owned by `word-oracle-alignment` and
+  `word-oracle-fixes`.
+- **Embedding support.** No output of a nonzero-offset write is openable by either route, so
+  supporting it needs offset rebasing plus an explicit statement that the container file is not
+  itself openable. Separate design, separate Word round.
+- **The reachability gap** (`undeclared_orphan_part`, `ds_store`, `macosx_sidecar`). No Word
+  verdict yet.
+- **Prefix-length reporting in the refusal message.** `_scan_central_directory` returns nothing
+  and tracks no offsets; threading a value through it buys wording, not correctness.
+- **A `patch_save` verbatim-copy gate.** Phase 1 makes it unreachable — `patch_save` reads the
+  original through `_read_zip` at `:566`, long before the verbatim decision at `:577` — and
+  testing it would require bypassing the loader. Replaced by a coupling test in Phase 1.
+
+### Cross-cutting rules
+
+- **Exception vocabulary.** Load-path refusals raise `PackageLimitError`; its contract is "a
+  package archive is corrupt, encrypted, or malformed", which a prefixed archive is. Destination
+  refusals raise `OSError`, matching append-mode and every other destination refusal in
+  `opc/package.py`. A stream's cursor position is a property of the argument, not of the archive.
+- **Refusal messages** name what was found, why it cannot be interpreted, and what to do.
+- **No public signature changes**, and no new `PackageDiagnosis.kind` value — see Phase 3.
+- **Smallest diff.** No drive-by refactors. `_zipguard.py` is also being edited by the two
+  parallel specs; touch only `_preflight_zip_stream`.
+
+### Reference files
+
+- `src/docx/_zipguard.py` — `_preflight_zip_stream`, `_find_end_record`,
+  `_scan_central_directory`, `_LOCAL_HEADER_SIGNATURE`, `_END_RECORD_SIGNATURE`
+- `src/docx/opc/package.py` — `_atomic_stream_write`, `_stream_position`,
+  `_has_stream_rollback_surface`, `_copy_stream_prefix`
+- `src/docx/_paperpkg.py` — `_read_zip`, `diagnose`, `patch_save`
+- `src/docx/errors.py` — `PaperRefusal` hierarchy and each subclass's contract
+- `tests/paper/test_practical_opc_hardening.py` — save-path guard tests; the two that must be
+  rewritten live here
+- `tests/paper/test_audit_zip_preflight.py` — preflight guard tests; these are what a
+  badly-placed check shadows
+
+### Verification baseline
+
+At the stack tip: **suite green, plus 9 collection errors** in `tests/opc/test_phys_pkg.py` from
+a pytest deprecation about class-scoped fixtures declared as instance methods — pre-existing and
+unrelated. Do not pin a passing count: this work adds tests and rewrites two. The gate is
+"green, the 9 known collection errors, and every test-count delta attributable to a test this
+plan intends".
+
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q
+```
+
+### Fixture-verdict replay gate
+
+Phases 1 and 2 both change load or save behaviour for *every* entry point, so per-fix tests
+cannot prove nothing else moved. At the end of each, replay the recorded-verdict fixture sets
+and assert every fixture lands on its recorded accept/refuse status. Use the replay harness from
+the `word-oracle-alignment` branch when available, or regenerate with
+`verifying-against-word/scripts/build_review.sh` and compare. Sets `4-followups/` and
+`5-encoding/` were built by other sessions and are not produced by `build_review.sh`; take them
+from the existing review tree rather than regenerating.
+
+The only status changes this plan intends, across all five sets — verified against the fork at
+the stack tip:
+
+| fixture | before | after | phase |
+|---|---|---|---|
+| `4-followups/06-prefix-data.docx` | accepted | refused | 1 |
+| `3-fork-output/07-container-WHOLE-FILE.docx` | accepted | refused | 1 |
+
+Any other movement is a regression.
+
+**Two fixtures are easy to mistake for these and must NOT change status.** `06-` collides across
+four sets, so check the set name, not the number:
+
+| fixture | status today | why it must not move |
+|---|---|---|
+| `1-refused-inputs/06-concatenated.docx` | already refused | not `prefix_data`; refused for an ambiguous central-directory region |
+| `3-fork-output/08-container-extracted-package.docx` | already refused | offsets skewed by the prefix length; refused by existing logic, not by this work |
+
+## Phases
+
+### Phase 1: Load byte-zero check
+
+The keystone. Adds the byte-zero requirement to `_preflight_zip_stream`, which closes the
+prefixed-archive hole at every read entry point at once, and — because both read back through
+`preflight_zip` — also closes `patch_save` prefix propagation and makes a nonzero-offset save
+fail with the destination intact.
+
+**Steps:**
+- Step 1 — add the check at the end of `_preflight_zip_stream`
+- Step 2 — rewrite the two tests that encode the disproved assumption
+- Step 3 — add guard tests, including the `patch_save` coupling test
+
+**Touches:** `src/docx/_zipguard.py`, `tests/paper/test_practical_opc_hardening.py`,
+`tests/paper/test_audit_zip_preflight.py`
+**Done when:** a prefixed archive is refused through `Document()`, `patch_save` and
+`diff_package`; the clean control still opens; suite green per the baseline rule; replay gate
+shows only the two intended status changes
+**Depends on:** nothing (foundation)
+
+### Phase 2: Refuse nonzero-offset stream writes
+
+Turns the diagnosis for a nonzero-offset save from a complaint about a malformed archive —
+raised from the staged-output validator after Phase 1 — into an early, accurate statement that
+the destination cursor is wrong, and removes the dead prefix-copying helper.
+
+**Steps:**
+- Step 1 — refuse a nonzero start in `_atomic_stream_write` before staging
+- Step 2 — gate `truncate()` on `start == 0` and delete `_copy_stream_prefix`
+- Step 3 — guard test for the refusal and the untouched destination
+
+**Touches:** `src/docx/opc/package.py`, `tests/paper/test_practical_opc_hardening.py`
+**Done when:** a nonzero-offset save raises `OSError` naming the position and leaves the
+destination byte-identical; offset-0 saves over a longer document still truncate; suite green;
+replay gate clean
+**Depends on:** Phase 1
+
+### Phase 3: diagnose() label accuracy
+
+**Polish, not safety.** The dangerous half of the `diagnose()` bug — `readable=True, kind="docx"`
+for a file Word refuses — is fixed for free by Phase 1, because `diagnose` reads through
+`_read_zip` and already maps `PackageLimitError` to `kind="unsafe-archive"`. What remains is the
+`not-a-zip` mislabel on a prefixed file whose prefix does not begin with `PK`.
+
+**Steps:**
+- Step 1 — distinguish "no ZIP structure at all" from "ZIP structure not at byte 0" in the early
+  return, reusing `unsafe-archive` rather than adding a `kind` value
+- Step 2 — guard test for both prefix shapes and for a genuine non-zip
+
+**Touches:** `src/docx/_paperpkg.py`, `tests/paper/`
+**Done when:** both prefix shapes report `readable=False, kind="unsafe-archive"` with a problem
+string naming the defect; a genuine non-zip still reports `not-a-zip`; the clean control still
+reports `docx`
+**Depends on:** Phase 1
+
+### Phase 4: Documentation hygiene (ALWAYS the final phase)
+
+**Steps:**
+- Update `verifying-against-word/WORD-VERDICTS.md`: move `prefix_data` and
+  `3-fork-output/07` out of "fork too lenient" into shipped — **`08` was never in that framing;
+  it is already refused** — and strike the save-path decisions this plan closes from "Rows that
+  still need a human"
+- Update `verifying-against-word/scripts/make_save_variants.py` — its README text for files 07
+  and 08 states measured verdicts; add that the fork now refuses the write outright
+- Update `docs/proposals/word-openable-packages/spec.md` — `status: planned` → `status: shipped`,
+  and fold the Phase 3 `kind` decision and the truncate-gate resolution into it
+- Note the byte-zero rule in whichever doc surface describes package validation, if one exists
+- Grep-sweep for `_copy_stream_prefix` and for prose asserting that a nonzero-offset save
+  preserves a prefix
+
+**Verification:**
+- `grep -rn "_copy_stream_prefix" .` returns nothing outside git history
+- No path referenced in the skill or the proposals tree points at something that does not exist
+- `WORD-VERDICTS.md` contains no row claiming the fork accepts a prefixed archive
+
+**Done when:** a reviewer can read the ledger and the spec cold and see that the prefixed-archive
+hole is closed on both the read and the write side, without reading the phase plans.
+**Depends on:** Phases 1, 2, 3

--- a/docs/proposals/word-openable-packages/phases/phase-01-load-byte-zero-check.md
+++ b/docs/proposals/word-openable-packages/phases/phase-01-load-byte-zero-check.md
@@ -1,0 +1,181 @@
+# Phase 1 — Load byte-zero check
+
+**Created:** 2026-08-18
+**Status:** Ready
+
+## Motivation
+
+Word refuses a package that does not begin at byte 0; paper-docx opens it and reports the
+correct content, so nothing downstream can tell the document is unusable. This is the only
+shape in the ledger where the fork is unsafely permissive. Adding one check to the shared
+preflight closes it at every read entry point, and because `patch_save` and the save-path
+validator both read back through the same preflight, it also closes prefix propagation and makes
+a nonzero-offset save fail with the destination intact — which is what Phases 2 and 3 build on.
+
+## Context
+
+**What exists today:**
+- `src/docx/_zipguard.py` `_preflight_zip_stream` validates the central directory is *internally
+  consistent* (`central_offset + central_size == central_end`). A prefixed archive with rebased
+  offsets satisfies that exactly, so it passes.
+- `_LOCAL_HEADER_SIGNATURE` (`PK\x03\x04`) and `_END_RECORD_SIGNATURE` (`PK\x05\x06`) are already
+  module constants.
+- `preflight_zip` has two callers, covering every read path: `opc/phys_pkg.py:127` and
+  `_paperpkg._read_zip` (`:226`), the latter reached by `patch_save` (original `:566`, own output
+  `:604`), `diff_package` (`:291-292`), `diagnose` (`:481`) and `compare` (`_compare.py:314`).
+- Two tests assert the behaviour Word disproved — see Step 2.
+
+**What this phase delivers:**
+- A prefixed archive is refused with `PackageLimitError` through every read entry point.
+- The two disproved tests express the measured behaviour instead.
+- Guard tests pinning the refusal, the adjacent legal shape, and the `patch_save` coupling.
+
+**Reference files to study before starting:**
+- `src/docx/_zipguard.py` — the function being changed and the constants to reuse
+- `tests/paper/test_audit_zip_preflight.py` — the preflight guard tests a badly-placed check
+  shadows; read `_zip64_count_only_archive` and the two tests asserting "too small for its member
+  count"
+- `tests/paper/test_practical_opc_hardening.py` — the two tests to rewrite
+- `src/docx/errors.py` — `PackageLimitError`'s contract
+
+## Steps
+
+### Step 1 — Add the byte-zero requirement to the preflight
+
+**Goal:** `_preflight_zip_stream` refuses any archive whose first four bytes are neither a local
+file header signature nor an end-of-central-directory signature.
+
+**Work:**
+After the central directory has been fully validated, seek to position 0 and read four bytes.
+Accept a local file header signature. Also accept an end-of-central-directory signature, so a
+legal empty archive gets its own specific downstream error rather than a byte-zero message it
+cannot act on. Anything else is a refusal.
+
+The message must name what was found, why it cannot be interpreted, and what to do: that the
+file does not begin with a ZIP local file header, that Word cannot open a `.docx` with bytes
+ahead of the archive, and that the archive must be extracted to its own file. Do not report the
+number of leading bytes — `_scan_central_directory` returns nothing and tracks no offsets, and
+threading a value through it buys wording, not correctness.
+
+**Constraints:**
+- **Placement is load-bearing.** The check must run at the *end* of `_preflight_zip_stream`,
+  after `_scan_central_directory`, inside the existing `try`. Placed immediately after the
+  multi-disk check it shadows more specific diagnoses: measured, it turned two preflight
+  refusals that correctly say "central directory is too small for its member count" into the
+  generic byte-zero message, failing
+  `tests/paper/test_audit_zip_preflight.py::DescribeCentralDirectoryPreflight::it_refuses_a_zip64_count_that_cannot_fit_in_the_central_directory`
+  and `::it_preflights_an_ordinary_document_open_before_constructing_zipfile`.
+- Reuse `_LOCAL_HEADER_SIGNATURE` and `_END_RECORD_SIGNATURE`. Do not introduce new constants.
+- Raise `PackageLimitError`. Its contract covers a malformed archive; a prefixed archive is one.
+- The existing `finally` restores the stream position — do not add a second restore.
+- Touch only `_preflight_zip_stream`. `_zipguard.py` is being edited concurrently by two other
+  specs; keep the diff to one function so the merge stays trivial.
+- Do not alter `_find_end_record`, `_scan_central_directory`, or any existing refusal.
+
+**Verification:**
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q tests/paper/test_audit_zip_preflight.py
+```
+must pass in full — that is the shadowing check. Then confirm the intended refusal fires and the
+control does not, through all three entry points (`Document()`, `patch_save`, `diff_package`).
+
+### Step 2 — Rewrite the two tests that encode the disproved assumption
+
+**Goal:** neither test asserts behaviour Word has refuted, and both still test what they were for.
+
+**Work:**
+`tests/paper/test_practical_opc_hardening.py::it_validates_the_real_prefix_of_a_nonzero_position_stream`
+asserts that a nonzero-offset save succeeds, that the prefix survives, and that the whole stream
+reopens as a `Document`. All three are now wrong. Invert it: the save refuses, and the
+destination is byte-for-byte unchanged. Keep its name meaningful — it is now about refusing a
+nonzero-position stream, so rename accordingly.
+
+`::it_restores_a_seekable_stream_after_commit_error` seeks to offset 7 only incidentally; its
+subject is commit-failure rollback. Move it to offset 0 so it still exercises the snapshot and
+restore path, and adjust the trailing position assertion.
+
+**Constraints:**
+- Do not delete either test. Both cover real behaviour; only their assumptions changed.
+- The rollback test must still fail if rollback regresses — verify by confirming it exercises
+  `_snapshot_stream_tail` and `_restore_stream_tail`, which stay live at offset 0.
+- Do not weaken either test into a smoke test.
+
+**Verification:**
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q tests/paper/test_practical_opc_hardening.py
+```
+
+### Step 3 — Guard tests for the new refusal
+
+**Goal:** the refusal, its adjacent legal shape, and the `patch_save` coupling are pinned.
+
+**Work:**
+Add tests in `tests/paper/`, following the existing `it_...` function-level convention in
+`test_audit_zip_preflight.py`:
+
+- A self-consistent prefixed archive — rebased offsets, clean CRCs, internally correct central
+  directory — is refused. Build it by prepending bytes to a real saved document and rebasing
+  every central-directory local-header offset plus the end record's central-directory offset, so
+  the fixture is refused for the prefix and not for inconsistency.
+- The same document without a prefix still opens. This is the pair that makes the verdict
+  attributable.
+- A ZIP archive comment (bytes *after* the archive, declared correctly) still opens — it proves
+  the new check is about the start of the file, not the end, and does not overlap the footer rule.
+- `patch_save` refuses a prefixed original. This replaces the verbatim-copy gate that Phase 1
+  makes unreachable: it asserts the coupling holds rather than guarding a dead branch.
+
+**Constraints:**
+- Name each test so the Word verdict it encodes is traceable.
+- The prefixed fixture must be built in-test, not committed as a binary.
+- Do not assert on message text beyond one substring that would change if the refusal were
+  re-aimed at a different property.
+
+**Verification:**
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q tests/paper/
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q
+```
+Then run the fixture-verdict replay gate from the build sequence.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Edit | `src/docx/_zipguard.py` — byte-zero check at the end of `_preflight_zip_stream` |
+| Edit | `tests/paper/test_practical_opc_hardening.py` — invert the prefix test, move the rollback test to offset 0 |
+| Edit | `tests/paper/test_audit_zip_preflight.py` — add the refusal/control/comment guard tests |
+| Edit | `tests/paper/` — `patch_save` prefixed-original coupling test, in whichever module already covers `patch_save` |
+
+## What this phase does NOT include
+
+- Any change to `opc/package.py` — that is Phase 2.
+- Any change to `diagnose()` — that is Phase 3.
+- Prefix-length reporting in the message.
+- A `patch_save` verbatim-copy gate. Unreachable after this phase, and testing it would need a
+  loader bypass; the coupling test in Step 3 covers the real behaviour instead.
+- Part-name rules, prefix-collision detection, content-type or protection changes — other specs.
+
+## Tests this phase must include
+
+- Prefixed archive refused; identical document without the prefix accepted (the attributable pair).
+- Declared ZIP archive comment still accepted — separates this rule from the footer rule.
+- `patch_save` refuses a prefixed original.
+- The full `test_audit_zip_preflight.py` module still passes, which is the placement/shadowing
+  guard.
+
+**Does NOT need tests:** the constants reused, and the exact refusal wording beyond one
+substring.
+
+## Done when
+
+1. A self-consistent prefixed archive raises `PackageLimitError` through `Document()`,
+   `patch_save`, and `diff_package`.
+2. The same document without a prefix opens through all three.
+3. `tests/paper/test_audit_zip_preflight.py` passes in full — no shadowed diagnoses.
+4. The two rewritten tests pass and still cover refusal and rollback respectively.
+5. Full suite green with the 9 known `tests/opc/test_phys_pkg.py` collection errors and every
+   count delta attributable to a test this phase adds or rewrites.
+6. Replay gate shows exactly two status changes: `4-followups/06-prefix-data.docx` and
+   `3-fork-output/07-container-WHOLE-FILE.docx`, both accepted → refused. Note the set names:
+   `1-refused-inputs/06-` is `06-concatenated.docx`, a different shape that is already refused,
+   and `3-fork-output/08` is already refused too — neither may move.

--- a/docs/proposals/word-openable-packages/phases/phase-02-refuse-nonzero-offset-writes.md
+++ b/docs/proposals/word-openable-packages/phases/phase-02-refuse-nonzero-offset-writes.md
@@ -1,0 +1,160 @@
+# Phase 2 — Refuse nonzero-offset stream writes
+
+**Created:** 2026-08-18
+**Status:** Ready
+
+## Motivation
+
+After Phase 1 a nonzero-offset save already fails, but with the wrong diagnosis: the caller gets
+`PackageLimitError: package does not begin with a ZIP local file header`, raised from the
+staged-output validator, describing a malformed *archive* when the actual fault is a bad
+*destination argument*. An agent cannot act on that. This phase moves the refusal to the front of
+the write path, where it can name the real cause, and removes the prefix-copying machinery that
+only existed to support the capability being refused.
+
+## Context
+
+**What exists today:**
+- `opc/package._atomic_stream_write` computes `start = _stream_position(stream)` and proceeds for
+  any value. The write-only branch, `_write_staged_to_unrestorable_stream`, already refuses
+  `start not in (None, 0)` with `OSError` — only the seekable branch permits it.
+- `_copy_stream_prefix(stream, staged, start)` copies the caller's existing prefix into the
+  staged buffer. One call site, at `opc/package.py:332`.
+- A bare `stream.truncate()` at `opc/package.py:339` truncates after the package regardless of
+  where the write began. Measured: a 312,000-byte tail is reduced to 0, where upstream
+  python-docx preserves 274,992.
+- Word refuses both artifacts of a nonzero-offset write: the whole container file (a prefixed
+  archive) and the package sliced back out (offsets skewed by exactly the prefix length).
+
+**What this phase delivers:**
+- A seekable destination positioned past 0 is refused before anything is staged, with a message
+  naming the position.
+- `truncate()` is explicitly gated on `start == 0`.
+- `_copy_stream_prefix` is gone.
+
+**Reference files to study before starting:**
+- `src/docx/opc/package.py` — `_atomic_stream_write`, `_stream_position`,
+  `_has_stream_rollback_surface`, `_write_staged_to_unrestorable_stream`, `_copy_stream_prefix`
+- `tests/paper/test_practical_opc_hardening.py` — `it_refuses_an_append_mode_stream_without_changing_it`
+  is the pattern to follow: refuse, and assert the destination is untouched
+
+## Steps
+
+### Step 1 — Refuse a nonzero start before staging
+
+**Goal:** `_atomic_stream_write` raises before it stages, snapshots, or writes anything when the
+destination is seekable and positioned past 0.
+
+**Work:**
+Immediately after `start` is computed, and before `_snapshot_stream_tail` is called, refuse when
+`start` is neither `None` nor `0`. This is the same category of fault as the append-mode refusal a
+few lines above, so it reads as a pair with it. Raise `OSError`. The
+message names the stream's position, states that a package written after existing bytes is not a
+file Word can open, and tells the caller to pass a stream positioned at 0 or to write to a path.
+
+`start is None` must stay permitted: that is the bare `write()`/`flush()` sink, which Word
+confirmed OPENS.
+
+**Constraints:**
+- `OSError`, not `PackageLimitError`. A destination's cursor position is a property of the
+  argument, not of the archive, and every other destination refusal in this module raises
+  `OSError`. Do not change the append-mode refusal's type either — callers catch `OSError` there.
+- Refuse before `_snapshot_stream_tail` is called, so nothing is read or copied.
+- Do not touch `_write_staged_to_unrestorable_stream`'s existing refusal. It now duplicates this
+  one for write-only streams; leaving it is harmless and keeps that branch independently correct.
+
+**Verification:**
+Saving into a stream seeked past 0 raises `OSError`, the message names the position, and the
+destination's bytes are unchanged. Saving into a stream at 0, and into a write-only sink, both
+still succeed.
+
+### Step 2 — Gate the truncation and delete the dead helper
+
+**Goal:** `truncate()` states its precondition, and no prefix-copying code remains.
+
+**Work:**
+Gate the `stream.truncate()` call on `start == 0`.
+
+Then remove `_copy_stream_prefix` and its call. With nonzero offsets refused, `start` in the
+snapshot branch is always 0, so the call copies nothing.
+
+**Constraints:**
+- The truncate gate is deliberately kept even though Step 1 makes it unreachable —
+  `_has_stream_rollback_surface` requires `start is not None`, so a `None` position routes to the
+  write-only branch and the snapshot branch is only reached with `start == 0`. It is one line and
+  `truncate()`'s no-argument semantics (truncate at the current position) are subtle enough that
+  stating the precondition documents intent. This is a different case from the `patch_save`
+  verbatim gate dropped in Phase 1: that one would have needed a loader bypass to test at all,
+  whereas this line sits inside a path every offset-0 save exercises.
+- Delete only `_copy_stream_prefix`. `_snapshot_stream_tail`, `_restore_stream_tail`,
+  `_has_stream_rollback_surface`, `_stream_position` and `_copy_stream` all keep live call sites —
+  verified — and rollback at offset 0 depends on them.
+- Do not restructure `_atomic_stream_write` beyond these two edits.
+
+**Verification:**
+```
+grep -rn "_copy_stream_prefix" src/ tests/
+```
+returns nothing. Offset-0 saves over a longer prior document still come out byte-identical to a
+fresh save with no stale tail.
+
+### Step 3 — Guard test
+
+**Goal:** the refusal and the untouched destination are pinned, and the offset-0 truncation
+behaviour it replaces is pinned alongside it.
+
+**Work:**
+Add a test in `tests/paper/test_practical_opc_hardening.py` following
+`it_refuses_an_append_mode_stream_without_changing_it`: seek a stream holding existing content
+past 0, assert `OSError`, assert the destination is byte-for-byte unchanged, and assert the
+position is untouched.
+
+Pair it with an offset-0 save over a longer prior document asserting the result is byte-identical
+to a fresh save — that is the behaviour truncation exists for, and it must not regress when the
+gate is added.
+
+**Constraints:**
+- Assert on the destination's full bytes, not just its length.
+- Do not duplicate the append-mode test; this is a distinct fault with a distinct message.
+
+**Verification:**
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q tests/paper/test_practical_opc_hardening.py
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q
+```
+Then run the fixture-verdict replay gate from the build sequence.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Edit | `src/docx/opc/package.py` — nonzero-start refusal, `truncate()` gated on `start == 0`, `_copy_stream_prefix` and its call removed |
+| Edit | `tests/paper/test_practical_opc_hardening.py` — refusal guard test plus the offset-0 truncation pair |
+
+## What this phase does NOT include
+
+- Offset rebasing to make embedding work. No output of that operation is Word-openable by either
+  route; supporting it is a separate design with its own Word round.
+- Any change to the append-mode refusal or its exception type.
+- Any change to `_zipguard.py` or `diagnose()`.
+- The non-writable-directory trade — inherent to atomic replacement, a documentation decision.
+
+## Tests this phase must include
+
+- Nonzero-offset save refuses with `OSError` and leaves the destination byte-for-byte unchanged.
+- Offset-0 save over a longer prior document is byte-identical to a fresh save — the truncation
+  behaviour the gate must not break.
+- Write-only sink still succeeds, so `start is None` stays permitted.
+
+**Does NOT need tests:** the removal of `_copy_stream_prefix`, and the exact wording beyond one
+substring naming the position.
+
+## Done when
+
+1. A seekable destination positioned past 0 raises `OSError` naming the position, before any
+   staging, and the destination is unchanged.
+2. Offset-0 saves, including over a longer prior document, still succeed and still truncate.
+3. A write-only `write()`/`flush()` sink still succeeds.
+4. `grep -rn "_copy_stream_prefix" src/ tests/` returns nothing.
+5. Full suite green per the baseline rule in the build sequence.
+6. Replay gate shows no status change beyond Phase 1's two.

--- a/docs/proposals/word-openable-packages/phases/phase-03-diagnose-label-accuracy.md
+++ b/docs/proposals/word-openable-packages/phases/phase-03-diagnose-label-accuracy.md
@@ -1,0 +1,133 @@
+# Phase 3 — diagnose() label accuracy
+
+**Created:** 2026-08-18
+**Status:** Ready
+
+## Motivation
+
+**This phase is diagnostic polish, not a safety fix.** The dangerous half of the `diagnose()`
+defect is closed for free by Phase 1: a prefixed archive whose prefix begins with the bytes `PK`
+currently returns `readable=True, kind="docx"` — the triage API vouching for a file Word refuses —
+and once the loader refuses it, `diagnose` catches `PackageLimitError` and already reports
+`kind="unsafe-archive"`. What remains is the other prefix shape, where `diagnose` returns
+`kind="not-a-zip"`, which is false: it *is* a ZIP, just not one that starts at the beginning of
+the file. `diagnose` exists so an agent can repair a file without a human, so a false label
+defeats its only purpose.
+
+## Context
+
+**What exists today:**
+- `src/docx/_paperpkg.py` `diagnose` reads 8 bytes, checks for a compound-file marker, then
+  returns `kind="not-a-zip"` when the header does not start with `b"PK"` — before ever attempting
+  `_read_zip` at `:481`.
+- Measured at the stack tip:
+
+  | input | result today |
+  |---|---|
+  | prefix not starting with `PK` | `readable=False, kind="not-a-zip"` — false label |
+  | prefix starting with `PK` | `readable=True, kind="docx"` — fixed by Phase 1 |
+  | genuine non-zip | `readable=False, kind="not-a-zip"` — correct |
+  | clean document | `readable=True, kind="docx"` — correct |
+
+- `PackageDiagnosis.kind` is a public field with a documented value set: `missing`,
+  `encrypted-or-legacy-binary`, `not-a-zip`, `corrupt-zip`, `unsafe-archive`, `xlsx`, `pptx`,
+  `docx`, `docm`, `dotm`, `dotx`, `opc-unknown`. `to_dict()` exposes it.
+
+**What this phase delivers:**
+- Both prefixed shapes report `readable=False, kind="unsafe-archive"` with a problem string naming
+  the defect.
+- A genuine non-zip still reports `not-a-zip`.
+
+**Reference files to study before starting:**
+- `src/docx/_paperpkg.py` — `diagnose`, its `result()` helper, and the `PackageDiagnosis` docstring
+- `src/docx/_zipguard.py` — `_find_end_record` shows the tail-scan technique for locating an
+  end-of-central-directory record
+
+## Steps
+
+### Step 1 — Distinguish "no ZIP structure" from "ZIP structure not at byte 0"
+
+**Goal:** the early `not-a-zip` conclusion is only drawn when the file genuinely has no ZIP
+structure.
+
+**Work:**
+Before concluding `not-a-zip`, determine whether the file contains an end-of-central-directory
+record at all. If it does, the file is a ZIP that does not begin at the start of the file: report
+`readable=False` with `kind="unsafe-archive"` and a problem string saying the archive does not
+begin at the start of the file and must be extracted to its own file. If it does not, keep the
+existing `not-a-zip` result unchanged.
+
+Locate the end record by scanning the tail, the same way `_find_end_record` does — the record is
+within the last 64 KiB plus the record's own size. Do not parse or validate it; its presence is
+the only question being asked.
+
+**Constraints:**
+- **Reuse `unsafe-archive`; do not add a `kind` value.** `kind` is a public field with a
+  documented value set, and callers may switch on it, so a new value is an additive public-surface
+  change. Reusing `unsafe-archive` also makes `diagnose` consistent across both prefix shapes —
+  the `PK`-prefixed one already lands there via Phase 1 — and the distinguishing detail belongs in
+  `problems`, which is free text for exactly this.
+- Do not remove or reorder the compound-file (`_CFB_MAGIC`) branch; an encrypted or legacy binary
+  document must keep its own specific label.
+- Do not make `diagnose` raise. It is the triage API; every input must produce a
+  `PackageDiagnosis`.
+- Keep the added work bounded — a tail read, not a whole-file scan.
+
+**Verification:**
+Both prefix shapes report `readable=False, kind="unsafe-archive"`; a genuine non-zip reports
+`not-a-zip`; a clean document reports `docx`; an OLE compound file still reports
+`encrypted-or-legacy-binary`.
+
+### Step 2 — Guard test
+
+**Goal:** all four `diagnose` outcomes above are pinned so the label cannot silently regress.
+
+**Work:**
+Add a test alongside the existing `diagnose` coverage asserting the four cases in the table above.
+Build the two prefixed fixtures in-test by prepending bytes to a real saved document and rebasing
+the central-directory offsets, so they differ only in whether the prefix begins with `PK`.
+
+**Constraints:**
+- Assert on `readable` and `kind`, plus one substring of the problem string. Do not assert the
+  full message.
+- The two prefixed fixtures must differ *only* in the prefix bytes, so the test isolates the
+  label decision.
+
+**Verification:**
+```
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q tests/paper/
+uv run --with pytest --with 'pyparsing<3.3' python -m pytest -q
+```
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Edit | `src/docx/_paperpkg.py` — `diagnose`: distinguish a prefixed archive from a non-zip before the early return |
+| Edit | `tests/paper/` — four-case `diagnose` guard test, in whichever module already covers `diagnose` |
+
+## What this phase does NOT include
+
+- A new `PackageDiagnosis.kind` value.
+- Any change to `_read_zip`, `_zipguard.py`, or `opc/package.py`.
+- Repairing a prefixed file, or reporting how many bytes precede the archive.
+- Any change to the other `diagnose` branches — compound files, `xlsx`/`pptx` detection,
+  macro-enabled and template kinds.
+
+## Tests this phase must include
+
+- Prefixed archive, prefix not starting with `PK` → `readable=False, kind="unsafe-archive"`.
+- Prefixed archive, prefix starting with `PK` → same result (via Phase 1's loader refusal).
+- Genuine non-zip → `not-a-zip`.
+- Clean document → `docx`.
+
+**Does NOT need tests:** the tail-scan window size, and the exact problem wording.
+
+## Done when
+
+1. Both prefixed shapes report `readable=False`, `kind="unsafe-archive"`, and a problem string
+   naming the defect.
+2. A genuine non-zip still reports `not-a-zip`, and a clean document still reports `docx`.
+3. No new value is present in the `kind` set.
+4. `diagnose` raises on no input.
+5. Full suite green per the baseline rule in the build sequence.

--- a/docs/proposals/word-openable-packages/phases/phase-04-documentation-hygiene.md
+++ b/docs/proposals/word-openable-packages/phases/phase-04-documentation-hygiene.md
@@ -1,0 +1,149 @@
+# Phase 4 — Documentation hygiene
+
+**Created:** 2026-08-18
+**Status:** Ready
+
+## Motivation
+
+The Word verdict ledger is the durable record of which guards are justified, and it currently
+describes the prefixed-archive hole as open with the fork on the wrong side of it. Once Phases
+1–3 land that is false, and a ledger that is wrong about a shipped fix is worse than one with a
+gap. This phase closes the record while the evidence is still fresh, and removes the generator
+text that still tells a human to expect the old behaviour.
+
+## Context
+
+**What exists today:**
+- `verifying-against-word/WORD-VERDICTS.md` records `prefix_data` and
+  `3-fork-output/07`/`08` as measured Word refusals with paper-docx on the permissive side, and
+  lists the save-path decisions under work still outstanding.
+- `verifying-against-word/scripts/make_save_variants.py` embeds README text telling the reader
+  what to expect from files 07 and 08.
+- `docs/proposals/word-openable-packages/spec.md` is `status: planned` and still carries two
+  decisions this plan resolved: the `patch_save` verbatim gate and the truncate gate.
+- Two parallel specs — `word-oracle-alignment.md`, `word-oracle-fixes.md` — reference the load
+  check as this branch's or theirs; whichever landed, the ownership note should match reality.
+
+**What this phase delivers:**
+- A ledger that reads correctly cold: the prefixed-archive hole is closed on both the read and
+  the write side.
+- Generator text that matches shipped behaviour.
+- No stale references to removed code.
+
+**Two files in this phase live outside the repo.** `WORD-VERDICTS.md` and
+`make_save_variants.py` are under `~/.claude/skills/verifying-against-word/`, so those edits will
+not appear in the PR diff and cannot be reviewed with it — flag them to the reviewer separately.
+They are also concurrently edited by other sessions: **re-read each file immediately before
+writing it** and merge into its current state rather than assuming the state described here.
+
+**Reference files to study before starting:**
+- `verifying-against-word/WORD-VERDICTS.md` — the save-path section, the container subsection, and
+  "Rows that still need a human"
+- `verifying-against-word/scripts/make_save_variants.py` — the README block and the per-file
+  expectation lines for 07 and 08
+- `docs/proposals/word-openable-packages/spec.md` — frontmatter and open questions
+
+## Steps
+
+### Step 1 — Update the verdict ledger
+
+**Goal:** the ledger states that the byte-zero rule shipped, on both sides, and nothing in it
+claims the fork accepts a prefixed archive.
+
+**Work:**
+Record in the save-path section and the container subsection that paper-docx now refuses a
+prefixed archive on load and refuses a nonzero-offset stream destination on write. Move
+`prefix_data` and `3-fork-output/07` out of any "fork too lenient" framing. Note that
+`3-fork-output/08` needs no separate fix — it was already refused, and the operation that produced
+it is now refused outright.
+
+Strike from "Rows that still need a human" the save-path items this plan closed, and keep the
+non-writable-directory trade listed as a decision rather than a verdict.
+
+**Constraints:**
+- Do not alter any recorded Word verdict. Those are human observations; only the paper-docx column
+  and the narrative change.
+- Do not claim a verdict for anything unmeasured — the reachability gap stays open.
+- Keep the "no verdict borrowed from another application" rule intact.
+
+**Verification:**
+```
+grep -n "too lenient" ~/.claude/skills/verifying-against-word/WORD-VERDICTS.md
+```
+returns no row describing a prefixed archive as accepted.
+
+### Step 2 — Update the generator and the spec
+
+**Goal:** anything a human reads before opening the fixtures matches shipped behaviour, and the
+spec records the decisions this plan made.
+
+**Work:**
+In `make_save_variants.py`, update the README text for files 07 and 08 to say the fork now
+refuses the write outright, so the artifacts are a record of why rather than a live test.
+
+In `spec.md`, set `status: planned` → `status: shipped`, and fold in the two resolutions: the
+`patch_save` verbatim gate was dropped in favour of a coupling test because it would have needed a
+loader bypass to test, and the truncate gate was kept as an explicit precondition. Remove the
+resolved open question about `compare()` — it routes through `_read_zip` at `_compare.py:314`, so
+that coverage is sufficient.
+
+Record the corpus-scan path used for false-positive validation — 87 `.docx` under the worktree
+root (45 in `tests/`, 41 in `features/`, 1 in `src/`) — so the number is reproducible and the
+discrepancy with the parallel specs' 83 is traceable to scanned paths rather than a conflict.
+
+**Constraints:**
+- Do not restate phase plans in the spec. It records decisions, not steps.
+- Leave the two parallel specs alone unless their ownership note contradicts what shipped.
+
+**Verification:** both files render cleanly; `spec.md` frontmatter reads `status: shipped`.
+
+### Step 3 — Stale-reference sweep
+
+**Goal:** nothing in the repo or the skill points at removed code or disproved behaviour.
+
+**Work:**
+Search for `_copy_stream_prefix` and for prose asserting that a nonzero-offset save preserves a
+caller's prefix or trailing data. Update or delete each hit.
+
+**Constraints:**
+- Sweep only for what this plan changed. `_snapshot_stream_tail`, `_restore_stream_tail`,
+  `_has_stream_rollback_surface` and `_stream_position` all stay live — verified — so do not
+  remove references to them.
+
+**Verification:**
+```
+grep -rn "_copy_stream_prefix" . --exclude-dir=.git
+grep -rniE "preserv(e|es|ing) (the )?(caller|prefix|trailing)" src/ tests/ docs/
+```
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Edit | `~/.claude/skills/verifying-against-word/WORD-VERDICTS.md` — shipped status for the byte-zero rule; outstanding-rows list |
+| Edit | `~/.claude/skills/verifying-against-word/scripts/make_save_variants.py` — README expectations for files 07 and 08 |
+| Edit | `docs/proposals/word-openable-packages/spec.md` — `status: shipped`, resolved decisions, corpus path |
+
+## What this phase does NOT include
+
+- New Word verdicts, or any change to a recorded one.
+- Edits to `word-oracle-alignment.md` or `word-oracle-fixes.md` beyond an ownership correction.
+- Documenting the reachability gap or the rendering axis as resolved — both remain open.
+- Any source change. If this phase finds a code defect, it goes back to the owning phase.
+
+## Tests this phase must include
+
+None. This phase changes documentation only. The verification is the grep sweep and a clean read
+of the ledger.
+
+## Done when
+
+1. `WORD-VERDICTS.md` records the byte-zero rule as shipped on both the read and the write side,
+   with every human-recorded Word verdict unchanged.
+2. No row in the ledger describes paper-docx as accepting a prefixed archive.
+3. `make_save_variants.py`'s README text for files 07 and 08 matches shipped behaviour.
+4. `spec.md` is `status: shipped` and records the verbatim-gate and truncate-gate decisions plus
+   the corpus-scan path.
+5. `grep -rn "_copy_stream_prefix" . --exclude-dir=.git` returns nothing.
+6. A reviewer can read the ledger and spec cold and see the hole is closed on both sides without
+   reading the phase plans.

--- a/docs/proposals/word-openable-packages/spec.md
+++ b/docs/proposals/word-openable-packages/spec.md
@@ -1,0 +1,252 @@
+---
+title: Refuse packages Word cannot open
+author: gavin
+created: 2026-08-18
+status: shipped
+---
+
+# Refuse packages Word cannot open
+
+## Motivation
+
+paper-docx exists because python-docx let agents produce `.docx` files that Word will not
+open. A Word for Mac round on 2026-08-18 found the fork doing exactly that, in the one place
+it is least excusable — its own save path.
+
+Word refuses a package that does not begin at byte 0. Prefixed archives are valid ZIP; they
+are not valid `.docx`. paper-docx currently **reads** them (reporting success), **writes**
+them when a caller saves into a stream positioned past 0, and **byte-copies** them on a no-op
+`patch_save`. Every Python reader — stdlib, upstream, and the fork — opens them, so nothing
+below Word flags the problem.
+
+All four behaviours were re-verified unfixed at `agent/missing-source-letterhead` (PR 22, the
+stack tip, which contains PRs 13 and 15–25). Word has refused the shape twice, on two
+independently built fixtures: `3-fork-output/07-container-WHOLE-FILE` (the fork's own output)
+and `1-refused-inputs/06-prefix-data`.
+
+## Relationship to the two parallel specs
+
+Three specs were drafted independently from the same Word rounds: `word-oracle-alignment.md`,
+`word-oracle-fixes.md`, and this one. They agree on every shared item. Ownership, as settled
+across all three:
+
+| item | owner |
+|---|---|
+| load-time byte-zero check | `word-oracle-alignment` (Fix 2) / `word-oracle-fixes` (L1) |
+| part-name character rule, prefix-collision, image content type, protection gate, messages | those two specs |
+| truncation gate (`package.py:339`) | folded into the write refusal; retired rather than fixed |
+| **write-side refusal of nonzero-offset streams** | **this spec** |
+| **`patch_save` verbatim-copy gate** | **this spec** |
+| **`diagnose()` reporting a prefixed file as `not-a-zip`** | **this spec** |
+
+Both parallel specs assign the last three here explicitly, so this spec narrows to them. The
+load check is cited below because it is what makes the two gates defence-in-depth rather than
+the fix — not because this branch implements it.
+
+**Their #5 is the keystone, and it closes more than expected.** Applied alone as an experiment,
+it: refuses prefixed reads; makes `patch_save`'s verbatim path unreachable for prefixed input
+(because `patch_save` reads through `preflight_zip`); and makes a nonzero-offset save fail
+*with the destination left byte-for-byte unchanged*. So the data-loss and bad-output outcomes of
+issues 1, 2, and 3 are all closed by the load check.
+
+What that leaves for this spec is **diagnosis quality and defence in depth**, not correctness:
+after their #5, a caller who saves into a stream at offset 33 gets
+`PackageLimitError: package does not begin with a ZIP local file header` — a complaint about an
+archive, raised from the staged-output validator, for what is actually a bad destination
+argument. An agent cannot act on that.
+
+Two coordination facts:
+
+- **Their `_zipguard.py` line numbers (280, 510, 947) are from the pre-PR-24 revision** (975
+  lines; this branch has 793). PR 24 removed 182 lines from that file, so their patch will
+  conflict. Their `package.py:339` and `pkgreader.py:417` refs are exact.
+- **Both threads break the same two tests.** Their #5 alone fails exactly
+  `it_validates_the_real_prefix_of_a_nonzero_position_stream` and
+  `it_restores_a_seekable_stream_after_commit_error`, and nothing else. Whichever lands first
+  owns those edits.
+
+## Goals
+
+- No sequence of paper-docx calls produces a `.docx` that Word refuses on envelope grounds.
+- Opening a package Word cannot open raises a typed refusal instead of reporting success.
+- `diagnose()` names the defect accurately enough for an agent to fix the file unaided.
+- The seven save destinations Word confirmed **OPENS** keep working, byte-for-byte.
+
+## Approach
+
+One rule — *an OPC package begins at byte 0* — enforced at both boundaries, plus two
+defence-in-depth gates behind it.
+
+**Load (`_zipguard._preflight_zip_stream`).** Require the first four bytes of the archive to be
+a local file header. This is the only new load-time check needed: `preflight_zip` is called from
+exactly two places — `opc/phys_pkg.py` (`Document()`, `PackageReader`) and
+`_paperpkg._read_zip` (`patch_save`, `diff_package`, `diagnose`, `compare`) — so one check
+covers every read entry point.
+
+**Placement is load-bearing.** The check must run *after* `_scan_central_directory`, at the end
+of `_preflight_zip_stream` — not immediately after the multi-disk check. Placed early it
+shadows more specific diagnoses: measured, it turned two preflight refusals that assert
+"central directory is too small for its member count" into the generic byte-0 message. Placed
+at the end, the full suite shows exactly the two expected failures and nothing else.
+
+**Write (`opc/package._atomic_stream_write`).** Refuse a seekable destination whose position is
+not 0, before anything is staged. The write-only branch already refuses this; only the seekable
+branch permits it. After the load check this no longer changes *whether* the save fails — it
+changes the caller's diagnosis from a complaint about a malformed archive to a statement that
+the destination cursor is wrong, and it fails before doing the staging work.
+
+**Two gates behind the rule.** `opc/package.py:339` truncates unconditionally, destroying a
+caller's trailing data — gate it on `start == 0`. `_paperpkg.patch_save` takes its
+verbatim-copy path on any no-op — gate it on the original beginning at byte 0. Fixing the load
+check already makes both unreachable for prefixed input; they stay as the last line of defence
+for any future envelope anomaly the loader tolerates.
+
+**Exception types.** Load refusals raise `PackageLimitError` — its contract is "a package
+archive is corrupt, encrypted, or malformed", which a prefixed archive is, and `diagnose()`
+already maps it to `kind="unsafe-archive"`. Write refusals raise `OSError`, matching
+append-mode and every other destination refusal in `opc/package.py`. A destination's cursor
+position is not a property of the archive.
+
+**Rejected alternatives:**
+- *Rebase offsets so the embedded package is extractable* — fixes the slice, leaves the
+  container file itself rejected by Word. Not a fix, and it keeps a capability that has no
+  Word-valid output.
+- *Also require `min(header_offset) == 0`* — redundant, and it false-positives on
+  `concatenated`, which existing logic already refuses with a better-aimed message.
+- *A new exception type* — `PackageLimitError` already means this.
+- *Unify append-mode onto `PackageLimitError`* — would mis-type a destination-protocol failure
+  and break callers catching `OSError`.
+- *Repair prefixed files on load* — silently editing something an agent thinks is intact is
+  the failure mode this package exists to prevent.
+
+## Scope
+
+### In scope
+- Write-time refusal of nonzero-offset seekable stream destinations.
+- Truncation gated on `start == 0`, as defence in depth.
+- `patch_save` verbatim-copy gated on a clean original envelope.
+- `diagnose()` distinguishing "no ZIP structure at all" from "ZIP structure not at byte 0";
+  today a prefixed file whose prefix does not start with `PK` is reported as `not-a-zip`,
+  which is false and unactionable.
+- Deleting `_copy_stream_prefix`, dead once nonzero-offset writes are refused.
+
+### Out of scope
+- **The load-time byte-zero check.** Owned by `word-oracle-alignment` Fix 2. This spec depends
+  on it and does not duplicate it. If it is placed at the end of `_preflight_zip_stream` as that
+  spec requires, it should also accept an end-of-central-directory signature at offset 0 for an
+  empty archive, and report the prefix length in its message.
+- **The read-side leniency and over-strictness fixes** — part-name characters, prefix collisions,
+  image relationship content types, the protection gate, message wording. All owned by the two
+  parallel specs.
+- **Embedding support.** Writing a package into a container has no Word-openable output by
+  either route; supporting it needs a separate design and its own Word round.
+- **The remaining ledger rows** — `undeclared_orphan_part`, `ds_store`, `macosx_sidecar`.
+  Same class of question (the fork is lenient where Word may not be), no Word verdict yet.
+- **The resource caps.** PR 24 removes them; merge it on its own merits.
+- **The non-writable-directory trade.** Inherent to atomic replacement; a documentation
+  decision, not a correctness bug.
+
+## Requirements
+
+### Functional requirements
+- Opening a package whose first four bytes are not a ZIP local file header raises
+  `PackageLimitError`, through every entry point that reaches `preflight_zip`.
+- Saving to a seekable stream whose position is not 0 raises `OSError` and writes nothing.
+  `tell()` returning `None`/unsupported stays permitted — that is the bare write/flush sink
+  Word confirmed OPENS.
+- Saving to a stream at position 0 still truncates, so no stale tail survives.
+- Saving to a stream at a nonzero position leaves the destination byte-for-byte unchanged.
+- `patch_save` takes the verbatim path only when the original begins at byte 0.
+- `diagnose()` returns `readable=False` with a distinct `kind` for a prefixed archive, and
+  does not raise.
+
+### Interface contracts
+Refusal messages must say what was found, why it cannot be interpreted, and what to do:
+
+- Load: names that the file does not begin with a ZIP local file header, that Word cannot open
+  a `.docx` with bytes ahead of the archive, and that the archive must be extracted to its own
+  file.
+- Write: names the stream's position, that a package written after existing bytes is not a file
+  Word can open, and that the caller should pass a stream at position 0 or write to a path.
+
+No public signature changes. `PatchSaveResult.verbatim_copy` keeps its meaning; it simply
+reports `False` more often.
+
+## Test strategy
+
+### What earns its keep
+- **Load refusal** on a self-consistent prefixed archive — internally correct offsets, clean
+  CRCs — through `Document()`, `patch_save`, and `diff_package`. This is the Word-verified
+  shape (`3-fork-output/07`), and every Python reader accepts it, so only a test pins it.
+- **Write refusal** at a nonzero offset, asserting the destination is unchanged.
+- **Truncation still happens at offset 0**, asserting output is byte-identical to a fresh save
+  and carries no tail of a longer prior document.
+- **`patch_save` verbatim gate** — clean original still byte-identical on no-op; prefixed
+  original refused at load.
+- **`diagnose()`** reports a prefixed archive without raising, with the distinct `kind`.
+- **No-regression sweep**: the 28 fixtures in `1-refused-inputs/` and the seven Word-confirmed
+  artifacts in `3-fork-output/` keep their current accept/refuse verdicts. Validated already —
+  the load check flags exactly one of 37 fixtures.
+
+### Two existing tests must change
+- `tests/paper/test_practical_opc_hardening.py::it_validates_the_real_prefix_of_a_nonzero_position_stream`
+  asserts the prefix is preserved *and* that the whole stream reopens as a `Document`. It
+  encodes the bug. Invert it: expect `OSError` and unchanged original bytes.
+- `tests/paper/test_practical_opc_hardening.py::it_restores_a_seekable_stream_after_commit_error`
+  does `stream.seek(7)`, so it would be refused before it could exercise rollback. Move it to
+  offset 0; rollback is still exercised via the snapshot path.
+
+### What does not need tests
+Constant definitions, the deleted `_copy_stream_prefix`, and re-proving that stdlib `zipfile`
+accepts a prefixed archive.
+
+## Risks and mitigations
+- **Risk:** ~~the byte-0 rule rests on a single Word observation~~ **Retired.** Word has now
+  refused the shape on two independently built fixtures — `3-fork-output/07` (fork output) and
+  `1-refused-inputs/06-prefix-data` (a mutated input). The rule has two data points.
+- **Risk:** both threads edit `_zipguard.py` and the same two tests. **Mitigation:** let the
+  hardening thread own the load check and the truncation gate; this branch takes only the
+  write-side refusal and the verbatim gate, and rebases after theirs lands.
+- **Risk:** a caller legitimately embeds packages today and this breaks them.
+  **Mitigation:** there is no Word-openable output from that path, so the operation was
+  already broken; the refusal makes it loud. Message names the alternative.
+- **Risk:** an exotic-but-valid `.docx` does not start with a local file header.
+  **Mitigation:** measured across 37 fixtures — zero false positives. Archives starting with a
+  multi-disk spanning marker are already refused elsewhere.
+
+## Decisions made during the build
+
+- **Exception types, as specced.** Load refusals raise `PackageLimitError`; the write refusal
+  raises `OSError`, matching append-mode and every other destination refusal in
+  `opc/package.py`. `word-oracle-fixes` L4 asked for "a typed refusal" on the write side, which
+  would mean a `PaperRefusal` subclass; that was not adopted, because a destination's cursor
+  position is a property of the argument, not of the archive.
+- **The `patch_save` verbatim-copy gate was dropped**, replaced by a coupling test asserting
+  `patch_save` refuses a prefixed original. Not because it is dead code — the truncate gate is
+  equally dead — but because it would need a loader bypass to exercise at all, whereas the
+  truncate gate sits in a path every offset-0 save runs.
+- **The truncate gate was kept**, as an explicit `if start == 0`, because `truncate()`'s
+  no-argument semantics are subtle enough to be worth stating.
+- **No new `PackageDiagnosis.kind` value.** Both prefixed shapes report `unsafe-archive`, which
+  keeps `kind` a closed set for callers switching on it and makes `diagnose` consistent across
+  the two shapes; the distinguishing detail lives in `problems`.
+- **`compare()` needs no separate regression test.** It routes through `_read_zip`
+  (`_compare.py:314`), so preflight coverage reaches it, as it does `Document()`, `patch_save`
+  (original and its own re-read), `diff_package` and `diagnose`.
+- **Prefix length is not reported** in the refusal message. `_scan_central_directory` returns
+  nothing and tracks no offsets; threading a value through it would buy wording, not correctness.
+
+## Validation corpus
+
+False-positive checking for the byte-zero rule used the **87 git-tracked `.docx` files** — 45 in
+`tests/`, 41 in `features/`, 1 in `src/`. Every one still opens except the two under
+`tests/paper/fixtures/generated/corrupt/`, which were already refused before this work and for
+unrelated reasons. (`rglob` also finds `features/_scratch/test_out.docx`, a gitignored behave
+artifact — not a corpus document.) The parallel specs cite 83 and 60 for the same check; the difference is the set of
+scanned paths, not a disagreement about the rule.
+
+The fixture replay covered **67 fixtures across five recorded-verdict sets**. Exactly two changed
+status, both intended: `4-followups/06-prefix-data.docx` and
+`3-fork-output/07-container-WHOLE-FILE.docx`, each accepted → refused. Note the set names:
+`1-refused-inputs/06-` is `06-concatenated.docx`, a different shape that was already refused, and
+`3-fork-output/08` was already refused too — neither moved.

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -421,19 +421,31 @@ _CFB_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
 
 
 def _has_end_of_central_directory(path: Path) -> bool:
-    """Whether an end-of-central-directory record is present anywhere in the tail.
+    """Whether the file ends with a structurally plausible end-of-central-directory record.
 
-    Presence is the only question: a file carrying one is a ZIP whose archive simply does not
-    start at byte 0, which is a different defect from having no ZIP structure at all. Scans the
-    same bounded tail `_zipguard._find_end_record` does, and never parses the record.
+    A file carrying one is a ZIP whose archive simply does not start at byte 0, which is a
+    different defect from having no ZIP structure at all. The record must *account for the rest
+    of the file* — its declared comment length has to reach exactly the end — which is the same
+    rule the preflight applies. Testing for the four signature bytes alone would misread any
+    non-ZIP that happens to contain them: measured, a text file with those bytes planted in its
+    tail was reported as a prefixed archive.
     """
     try:
         size = path.stat().st_size
         with path.open("rb") as stream:
-            stream.seek(max(0, size - (_END_RECORD.size + _MAX_END_COMMENT_BYTES)))
-            return _END_RECORD_SIGNATURE in stream.read()
+            window = min(size, _END_RECORD.size + _MAX_END_COMMENT_BYTES)
+            stream.seek(size - window)
+            tail = stream.read(window)
     except OSError:
         return False
+    cursor = tail.rfind(_END_RECORD_SIGNATURE)
+    while cursor >= 0:
+        if cursor + _END_RECORD.size <= len(tail):
+            comment_length = _END_RECORD.unpack_from(tail, cursor)[7]
+            if cursor + _END_RECORD.size + comment_length == len(tail):
+                return True
+        cursor = tail.rfind(_END_RECORD_SIGNATURE, 0, cursor)
+    return False
 
 
 _MAIN_PART_KINDS = {

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -38,6 +38,9 @@ from typing import IO, TYPE_CHECKING, Dict, List, Tuple, Union
 from lxml import etree
 
 from docx._zipguard import (
+    _END_RECORD,
+    _END_RECORD_SIGNATURE,
+    _MAX_END_COMMENT_BYTES,
     GuardedZipReader,
     preflight_zip,
     read_compressed_bytes,
@@ -416,6 +419,23 @@ def _write_bytes_atomically(out_path: Path, data: bytes, mode: int) -> None:
 #: OLE Compound File header — encrypted Office files and legacy .doc binaries
 _CFB_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
 
+
+def _has_end_of_central_directory(path: Path) -> bool:
+    """Whether an end-of-central-directory record is present anywhere in the tail.
+
+    Presence is the only question: a file carrying one is a ZIP whose archive simply does not
+    start at byte 0, which is a different defect from having no ZIP structure at all. Scans the
+    same bounded tail `_zipguard._find_end_record` does, and never parses the record.
+    """
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            stream.seek(max(0, size - (_END_RECORD.size + _MAX_END_COMMENT_BYTES)))
+            return _END_RECORD_SIGNATURE in stream.read()
+    except OSError:
+        return False
+
+
 _MAIN_PART_KINDS = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml": "docx",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml": "dotx",
@@ -476,6 +496,16 @@ def diagnose(path: _PathLike) -> PackageDiagnosis:
             " (decrypt it first) or a legacy binary .doc (convert to .docx)",
         )
     if not header.startswith(b"PK"):
+        # -- a package whose archive does not start at byte 0 is still a ZIP; saying
+        # -- "not a ZIP archive" would send the caller looking for the wrong problem
+        if _has_end_of_central_directory(file_path):
+            return result(
+                False,
+                "unsafe-archive",
+                "a ZIP archive is present but does not begin at the start of the file;"
+                " Word cannot open a .docx with anything in front of the package."
+                " Extract the archive to a file of its own and open that",
+            )
         return result(False, "not-a-zip", "not a ZIP archive, so not an OPC package")
     try:
         parts, _ = _read_zip(file_path)

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -193,6 +193,19 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
             central_size,
             total_entries,
         )
+
+        # -- Word refuses a package that does not begin at the start of the file, even when
+        # -- the archive itself is internally consistent: a rebased prefix satisfies every
+        # -- check above. Runs last so a genuinely malformed archive keeps its own, more
+        # -- specific diagnosis instead of this one.
+        stream.seek(0, os.SEEK_SET)
+        leading = stream.read(4)
+        if leading not in (_LOCAL_HEADER_SIGNATURE, _END_RECORD_SIGNATURE):
+            raise PackageLimitError(
+                "the package does not begin with a ZIP local file header, so bytes precede"
+                " the archive; Word cannot open a .docx with anything in front of the"
+                " package. Extract the archive to a file of its own and open that"
+            )
     finally:
         with suppress(AttributeError, OSError, TypeError, ValueError):
             stream.seek(original_position, os.SEEK_SET)

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -314,6 +314,12 @@ def _atomic_stream_write(stream: IO[bytes], relationships, parts) -> None:
             " nothing was written"
         )
     start = _stream_position(stream)
+    if start not in (None, 0):
+        raise OSError(
+            f"destination stream is positioned at offset {start}, so the package would be"
+            " written after existing bytes; Word cannot open a .docx with anything in front"
+            " of the archive. Pass a stream positioned at 0, or save to a path"
+        )
     snapshot_record = _snapshot_stream_tail(stream, start)
     if snapshot_record is None:
         if _has_stream_rollback_surface(stream, start):
@@ -328,15 +334,18 @@ def _atomic_stream_write(stream: IO[bytes], relationships, parts) -> None:
     snapshot, original_end = snapshot_record
     try:
         with tempfile.SpooledTemporaryFile(max_size=_STREAM_SPOOL_BYTES, mode="w+b") as staged:
-            assert start is not None
-            _copy_stream_prefix(stream, staged, start)
+            assert start == 0
             PackageWriter.write(staged, relationships, parts)
             _validate_serialized_output(staged)
             staged.seek(start)
             try:
                 stream.seek(start)
                 _copy_stream(staged, cast(BinaryIO, stream))
-                stream.truncate()
+                if start == 0:
+                    # -- truncate() cuts at the current position; doing that anywhere but
+                    # -- offset 0 would discard bytes the caller owns. Nonzero offsets are
+                    # -- refused above, so this states the precondition it relies on.
+                    stream.truncate()
                 flush = getattr(stream, "flush", None)
                 if callable(flush):
                     flush()
@@ -376,21 +385,6 @@ def _write_staged_to_unrestorable_stream(
         flush = getattr(stream, "flush", None)
         if callable(flush):
             flush()
-
-
-def _copy_stream_prefix(stream, destination: BinaryIO, length: int) -> None:
-    """Copy the exact preserved prefix into the staged validation stream."""
-    stream.seek(0)
-    remaining = length
-    while remaining:
-        chunk = stream.read(min(_STREAM_COPY_BYTES, remaining))
-        if not isinstance(chunk, bytes) or not chunk:
-            raise OSError(
-                "destination stream prefix could not be read; nothing was written"
-            )
-        destination.write(chunk)
-        remaining -= len(chunk)
-    stream.seek(length)
 
 
 def _stream_position(stream) -> "Optional[int]":

--- a/tests/paper/test_audit_zip_preflight.py
+++ b/tests/paper/test_audit_zip_preflight.py
@@ -167,3 +167,84 @@ class DescribeCentralDirectoryPreflight:
             _paperpkg._read_zip(path)
 
         assert constructions == 0
+
+
+_END_RECORD = struct.Struct("<4s4H2LH")
+_CENTRAL_HEADER = struct.Struct("<4s6H3L5H2L")
+
+
+def _prefixed_archive(clean: bytes, prefix: bytes) -> bytes:
+    """Return `clean` with `prefix` in front and every offset rebased.
+
+    The result is a fully self-consistent ZIP: the end record points at the real
+    central-directory position and each central record points at its real local header. So it
+    passes every structural check in the preflight and is refused only for not beginning at
+    byte 0 -- which is what makes the verdict attributable.
+    """
+    body = bytearray(prefix + clean)
+    end_offset = clean.rfind(b"PK\x05\x06")
+    fields = list(_END_RECORD.unpack_from(clean, end_offset))
+    central_size, central_offset = fields[5], fields[6]
+    cursor = central_offset + len(prefix)
+    limit = cursor + central_size
+    while cursor < limit:
+        record = _CENTRAL_HEADER.unpack_from(bytes(body), cursor)
+        struct.pack_into("<L", body, cursor + 42, record[16] + len(prefix))
+        cursor += _CENTRAL_HEADER.size + record[10] + record[11] + record[12]
+    fields[6] = central_offset + len(prefix)
+    _END_RECORD.pack_into(body, end_offset + len(prefix), *fields)
+    return bytes(body)
+
+
+class DescribeArchiveMustBeginAtByteZero:
+    """Word refuses a package with bytes in front of it (Word for Mac, 2026-08-18).
+
+    Every reader below Word accepts such a file and reports the correct content, so nothing but
+    a guard here can tell the caller the document is unusable.
+    """
+
+    @staticmethod
+    def _clean(tmp_path: Path) -> bytes:
+        source = tmp_path / "clean.docx"
+        docx.Document().save(str(source))
+        return source.read_bytes()
+
+    def it_refuses_a_self_consistent_prefixed_archive(self, tmp_path: Path):
+        target = tmp_path / "prefixed.docx"
+        target.write_bytes(_prefixed_archive(self._clean(tmp_path), b"# self-extracting stub\n"))
+
+        with pytest.raises(PackageLimitError, match="does not begin with a ZIP local file header"):
+            docx.Document(str(target))
+
+    def it_opens_the_same_document_without_the_prefix(self, tmp_path: Path):
+        """The control that makes the refusal above attributable to the prefix alone."""
+        target = tmp_path / "clean-control.docx"
+        target.write_bytes(self._clean(tmp_path))
+
+        assert isinstance(docx.Document(str(target)), docx.document.Document)
+
+    def it_still_opens_an_archive_carrying_a_declared_comment(self, tmp_path: Path):
+        """Bytes AFTER the archive, declared correctly, stay legal.
+
+        Separates this rule from the end-of-central-directory rule: one is about where the
+        archive starts, the other about what follows it.
+        """
+        target = tmp_path / "commented.docx"
+        target.write_bytes(self._clean(tmp_path))
+        with zipfile.ZipFile(target, "a") as archive:
+            archive.comment = b"produced by an internal build pipeline"
+
+        assert isinstance(docx.Document(str(target)), docx.document.Document)
+
+    def it_refuses_a_prefixed_original_through_patch_save(self, tmp_path: Path):
+        """`patch_save` reads the original through the same preflight.
+
+        This is the coupling that makes a verbatim-copy gate unnecessary: the no-op byte-copy
+        path used to reproduce a prefixed original verbatim, and it can no longer be reached
+        with one.
+        """
+        original = tmp_path / "prefixed.docx"
+        original.write_bytes(_prefixed_archive(self._clean(tmp_path), b"#" * 64))
+
+        with pytest.raises(PackageLimitError, match="does not begin with a ZIP local file header"):
+            _paperpkg.patch_save(original, docx.Document(), tmp_path / "out.docx")

--- a/tests/paper/test_honesty_guards.py
+++ b/tests/paper/test_honesty_guards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import shutil
+import struct
 import zipfile
 from pathlib import Path
 
@@ -167,6 +168,53 @@ class DescribePackageDiagnosis:
         text = tmp_path / "notes.docx"
         text.write_bytes(b"just some text pretending to be a docx")
         assert diagnose(text).kind == "not-a-zip"
+
+    @staticmethod
+    def _prefixed(source: Path, prefix: bytes) -> bytes:
+        """`source` with `prefix` in front and every ZIP offset rebased."""
+        end_record = struct.Struct("<4s4H2LH")
+        central = struct.Struct("<4s6H3L5H2L")
+        clean = source.read_bytes()
+        body = bytearray(prefix + clean)
+        end_offset = clean.rfind(b"PK\x05\x06")
+        fields = list(end_record.unpack_from(clean, end_offset))
+        central_size, central_offset = fields[5], fields[6]
+        cursor = central_offset + len(prefix)
+        limit = cursor + central_size
+        while cursor < limit:
+            record = central.unpack_from(bytes(body), cursor)
+            struct.pack_into("<L", body, cursor + 42, record[16] + len(prefix))
+            cursor += central.size + record[10] + record[11] + record[12]
+        fields[6] = central_offset + len(prefix)
+        end_record.pack_into(body, end_offset + len(prefix), *fields)
+        return bytes(body)
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [
+            pytest.param(b"# self-extracting stub\n" + b"#" * 40, id="prefix-not-starting-PK"),
+            pytest.param(b"PKSTUB" + b"#" * 58, id="prefix-starting-PK"),
+        ],
+    )
+    def it_diagnoses_an_archive_that_does_not_begin_at_byte_zero(
+        self, tmp_path: Path, prefix: bytes
+    ):
+        """Word refuses a prefixed package; `diagnose` must not call it healthy or non-ZIP.
+
+        Before this guard the two shapes reported differently and both wrongly: a prefix
+        starting with `PK` came back `readable=True, kind="docx"` -- the triage API vouching
+        for a file Word refuses -- and any other prefix came back `not-a-zip`, which is false
+        because the archive is present. Both now land on `unsafe-archive`; no new `kind` value
+        was introduced.
+        """
+        target = tmp_path / "prefixed.docx"
+        target.write_bytes(self._prefixed(fixture_path(MINIMAL), prefix))
+
+        report = diagnose(target)
+
+        assert not report.readable
+        assert report.kind == "unsafe-archive"
+        assert "does not begin" in report.problems[0]
 
     def it_diagnoses_macro_enabled_documents(self, tmp_path: Path):
         source = fixture_path(MINIMAL)

--- a/tests/paper/test_honesty_guards.py
+++ b/tests/paper/test_honesty_guards.py
@@ -216,6 +216,21 @@ class DescribePackageDiagnosis:
         assert report.kind == "unsafe-archive"
         assert "does not begin" in report.problems[0]
 
+    def it_does_not_mistake_stray_footer_bytes_for_a_prefixed_archive(self, tmp_path: Path):
+        """A non-ZIP carrying the footer signature by chance is still `not-a-zip`.
+
+        The prefixed-archive branch keys on an end-of-central-directory record that accounts
+        for the rest of the file, not on the four signature bytes appearing anywhere. Testing
+        for presence alone reported this file as a prefixed archive.
+        """
+        target = tmp_path / "planted.docx"
+        target.write_bytes(b"NOTAZIP" * 500 + b"PK\x05\x06" + b"\x00" * 18 + b"trailing text")
+
+        report = diagnose(target)
+
+        assert not report.readable
+        assert report.kind == "not-a-zip"
+
     def it_diagnoses_macro_enabled_documents(self, tmp_path: Path):
         source = fixture_path(MINIMAL)
         docm = tmp_path / "macros.docm"

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -162,13 +162,15 @@ def it_restores_a_seekable_stream_after_commit_error():
 
     original = b"prefix and original suffix"
     stream = FailOnce(original)
-    stream.seek(7)
+    stream.seek(0)
 
     with pytest.raises(OSError, match="commit failed"):
         docx.Document().save(stream)
 
+    # -- the subject is commit-failure rollback, not the cursor: a nonzero position is now
+    # -- refused outright, so this exercises snapshot/restore at offset 0
     assert stream.getvalue() == original
-    assert stream.tell() == 7
+    assert stream.tell() == 0
 
 
 def it_refuses_an_append_mode_stream_without_changing_it(tmp_path: Path):
@@ -184,28 +186,41 @@ def it_refuses_an_append_mode_stream_without_changing_it(tmp_path: Path):
     assert destination.read_bytes() == original
 
 
-def it_validates_the_real_prefix_of_a_nonzero_position_stream(monkeypatch):
+def it_refuses_a_nonzero_position_stream_without_changing_it():
+    """Word refuses a package with bytes in front of it.
+
+    This test previously asserted the opposite -- that the save succeeded, preserved the
+    caller's prefix, and that the whole stream reopened as a Document. Word for Mac
+    (2026-08-18) refuses exactly that file, and the extractable slice is offset-skewed by the
+    prefix length, so the operation has no usable output by either route.
+    """
     prefix = b"real destination prefix"
     original = prefix + b"existing suffix"
     stream = io.BytesIO(original)
     stream.seek(len(prefix))
-    validate = package_module._validate_serialized_output
-    validated_prefixes = []
 
-    def validate_and_record(source):
-        source.seek(0)
-        validated_prefixes.append(source.read(len(prefix)))
-        source.seek(0)
-        validate(source)
+    with pytest.raises(OSError, match="positioned at offset"):
+        docx.Document().save(stream)
 
-    monkeypatch.setattr(package_module, "_validate_serialized_output", validate_and_record)
+    assert stream.getvalue() == original
+    assert stream.tell() == len(prefix)
 
+
+def it_truncates_an_offset_zero_stream_holding_a_longer_document(tmp_path: Path):
+    """The behaviour the truncation gate must preserve.
+
+    A short document written over a longer one at offset 0 must leave no tail of the previous
+    document: undeclared trailing bytes are a shape Word refuses.
+    """
+    reference = tmp_path / "fresh.docx"
+    docx.Document().save(str(reference))
+    fresh_bytes = reference.read_bytes()
+
+    stream = io.BytesIO(b"Z" * (len(fresh_bytes) * 3))
+    stream.seek(0)
     docx.Document().save(stream)
 
-    assert validated_prefixes == [prefix]
-    assert stream.getvalue().startswith(prefix)
-    stream.seek(0)
-    assert isinstance(docx.Document(stream), docx.document.Document)
+    assert stream.getvalue() == fresh_bytes
 
 
 def it_refuses_before_overwriting_an_unreadable_seekable_stream():


### PR DESCRIPTION
## Summary

Stacked on #22 (the tip of #23 → #24 → #25 → #13 → #22), so this reviews as a delta on that stack.

Four rounds of Word for Mac verdicts (2026-08-18) found paper-docx wrong in both directions. The unsafe direction is what this PR closes: **the fork accepted a package Word refuses, reported the correct content for it, and would edit and re-save its own misreading.** That is the specific failure the package exists to prevent, occurring inside the package.

**Word refuses a `.docx` that does not begin at byte 0.** Prefixed archives are valid ZIP; they are not valid `.docx`. paper-docx read them, wrote them, and byte-copied them on a no-op `patch_save`. stdlib `zipfile`, upstream python-docx and LibreOffice all accept them, so nothing below Word flagged it.

## Changes

| Change | What it does | Why |
| --- | --- | --- |
| Packages must begin at byte 0 | `_preflight_zip_stream` requires a local file header at offset 0, or an end-of-central-directory record for a legal empty archive. `preflight_zip` has two callers, so one check covers `Document()`, `PackageReader`, `patch_save` (original and its own re-read), `diff_package`, `diagnose` and `compare`. | The preflight verified the central directory was *internally consistent*, which a rebased prefix satisfies exactly. Nothing checked where the archive started. |
| Nonzero-offset stream destinations refused | `_atomic_stream_write` refuses a seekable destination positioned past 0, before staging, leaving the destination and cursor untouched. `OSError`, matching append-mode and every other destination refusal in that module. | That write had no usable output by either route: the container file is a prefixed archive Word refuses, and the extracted slice is offset-skewed by the prefix length. It also destroyed the caller's tail — 312,000 bytes became 0, where upstream preserves 274,992. |
| `truncate()` gated on `start == 0`; `_copy_stream_prefix` removed | Truncation is correct at offset 0 and destructive anywhere else. The helper only existed to support the refused capability. | `truncate()` cuts at the current position. Stating the precondition is worth one line. |
| `diagnose()` labels a prefixed archive honestly | Both prefix shapes now report `readable=False, kind="unsafe-archive"`. | A prefix starting with `PK` returned `readable=True, kind="docx"` — the triage API vouching for a file Word refuses. Any other prefix returned `not-a-zip`, which is false. **No new `kind` value**: it is a public field with a closed set, and reusing `unsafe-archive` makes the two shapes consistent. |

## Deliberately not here

- **Embedding support.** No output of a nonzero-offset write is Word-openable, so it needs offset rebasing plus an explicit caveat that the container file is not itself openable. Separate design, separate Word round.
- **A `patch_save` verbatim-copy gate.** The byte-zero check makes it unreachable — `patch_save` reads the original through `_read_zip` well before the verbatim decision — and testing it would need a loader bypass. Replaced by a coupling test asserting `patch_save` refuses a prefixed original.
- **Prefix length in the message.** `_scan_central_directory` returns nothing and tracks no offsets; threading a value through buys wording, not correctness.
- **Part-name characters, prefix collisions, image relationship content types, the protection gate, message wording.** Owned by the two parallel specs drafted from the same rounds.

## Tests

Two tests encoded the assumption Word disproved and are **rewritten, not preserved**:

- `it_validates_the_real_prefix_of_a_nonzero_position_stream` asserted a nonzero-offset save succeeds, preserves the prefix, and that the whole stream reopens. Now asserts refusal and an untouched destination.
- `it_restores_a_seekable_stream_after_commit_error` seeked to offset 7 only incidentally; moved to 0 so it still exercises snapshot/restore.

Seven guard tests added, each keyed to a Word verdict, with the paired control that makes the verdict attributable — prefixed vs unprefixed, and a declared ZIP comment to separate this rule from the footer rule.

## Verification

- pytest: **2,651 passed** (baseline 2,644 on #22 + 7 guard tests). The 9 collection errors in `tests/opc/test_phys_pkg.py` are a pytest class-scoped-fixture deprecation, pre-existing and unrelated.
- behave: **67 features, 650 scenarios, 0 failed**
- `ruff check` clean on all three source files; pyright **167 → 163** (deleting the dead helper removed four)
- **All 87 tracked `.docx` in this repo still open.** The two under `fixtures/generated/corrupt/` were already refused before this work, for unrelated reasons.
- **Fixture replay: 67 fixtures across five recorded-verdict sets, exactly two status changes**, both intended — `4-followups/06-prefix-data` and `3-fork-output/07-container-WHOLE-FILE`, each accepted → refused. Note the set names: `1-refused-inputs/06-` is `06-concatenated`, already refused, and `3-fork-output/08` was already refused too.

## Reviewer note

Two files edited for this work live outside the repo and **will not appear in this diff**: `WORD-VERDICTS.md` and `scripts/make_save_variants.py`, under `~/.claude/skills/verifying-against-word/`. The ledger row for `prefix_data` moves from a confirmed leniency bug to shipped. Both are concurrently edited by other sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core package open/save validation used by every document entry point; behavior is intentional and heavily tested, but callers embedding packages or saving at nonzero stream offsets will now fail loudly.
> 
> **Overview**
> **Aligns paper-docx with Word on envelope rules:** a valid `.docx` OPC package must start at byte 0. Prefixed archives and embedded saves were previously accepted or misreported.
> 
> **Load path:** `_preflight_zip_stream` now requires the first four bytes to be a local file header or end-of-central-directory signature (after existing central-directory checks), raising `PackageLimitError`. That flows through every `preflight_zip` caller (`Document()`, `patch_save`, `diff_package`, etc.).
> 
> **Save path:** `_atomic_stream_write` raises `OSError` before staging when a seekable destination is past offset 0, leaving bytes and cursor unchanged. `truncate()` is gated on `start == 0`, and `_copy_stream_prefix` is removed.
> 
> **Triage:** `diagnose()` uses a tail scan for a plausible end-of-central-directory record when the header is not `PK`, reporting `unsafe-archive` instead of `not-a-zip` for prefixed ZIPs (no new `kind` value).
> 
> **Tests:** Two hardening tests are inverted or moved to offset 0; new guards cover prefixed refusal, ZIP comments, `patch_save` coupling, diagnose shapes, and truncation at offset 0. Proposal docs record the feature as **shipped**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dc3c19451329d3eec1d577a9bdce800d6288074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses `.docx` packages that don’t start at byte 0 on read and write, and fixes `diagnose()` to label prefixed ZIPs as unsafe. Previously we opened, edited, and re-saved packages Word refuses; now we reject them upfront and block nonzero‑offset saves.

- Load: `docx._zipguard._preflight_zip_stream` now requires a local file header at byte 0 (or EOCD for an empty archive), runs last, and raises `PackageLimitError`. This flows to `Document()`, `PackageReader`, and all `docx._paperpkg._read_zip` callers.
- Write: `docx.opc.package._atomic_stream_write` refuses seekable destinations positioned past 0 with `OSError` before staging, leaving bytes and cursor untouched. `truncate()` is gated on `start == 0`. `_copy_stream_prefix` is removed.
- Diagnose: When the header is not `PK` but a valid end‑of‑central‑directory record accounts for the file end (tail scan via `docx._paperpkg._has_end_of_central_directory`), `diagnose()` returns `readable=False, kind="unsafe-archive"`. Otherwise it returns `not-a-zip`. No new `kind` value.
- Tests/docs: Guard tests added and two saves-path tests rewritten; proposals and spec added under `docs/proposals/word-openable-packages/` (spec status: shipped).

**Migration**
- Seek save destinations to offset 0 or save to a path; nonzero positions now raise `OSError`.
- Do not embed packages inside larger container files; extract and save the archive to its own file.
- Handle `PackageLimitError` on open for prefixed archives and `OSError` on save for nonzero‑offset streams.

<sup>Written for commit c6e121d947374aef4958ac5befc4d34ac2d41d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-docx/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

