### PR TITLE
fix: align package validation and the protection gate with Word

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Session.vim
 /.tox/
 /reference/
 .DS_Store
+.worktrees/

--- a/docs/api/paper-errors.rst
+++ b/docs/api/paper-errors.rst
@@ -22,7 +22,7 @@ disk byte-for-byte unchanged. Programmer mistakes remain ordinary
 
 
 |MalformedPackageError|
--------------------
+-----------------------
 
 .. autoexception:: MalformedPackageError
    :show-inheritance:

--- a/docs/api/paper-errors.rst
+++ b/docs/api/paper-errors.rst
@@ -21,10 +21,10 @@ disk byte-for-byte unchanged. Programmer mistakes remain ordinary
    :show-inheritance:
 
 
-|PackageLimitError|
+|MalformedPackageError|
 -------------------
 
-.. autoexception:: PackageLimitError
+.. autoexception:: MalformedPackageError
    :show-inheritance:
 
 

--- a/docs/api/paper-protection.rst
+++ b/docs/api/paper-protection.rst
@@ -5,10 +5,12 @@ Document protection
 ===================
 
 *paper-docx addition.* Word's Restrict-Editing setting
-(``w:documentProtection``) is advisory, not security. Every paper-docx mutating
-API raises |DocumentProtectedError| on an enforced setting;
-``acknowledge_protection`` is the one explicit override. The setting itself is
-preserved, and upstream APIs are untouched.
+(``w:documentProtection``) is advisory, not security. paper-docx mutating APIs
+raise |DocumentProtectedError| wherever Word's own UI would refuse the edit: the
+gate mirrors Word's per-mode rules, so a comments-only restriction still permits
+commenting while it blocks body edits. ``acknowledge_protection`` is the one
+explicit override. The setting itself is preserved, and upstream APIs are
+untouched.
 
 .. currentmodule:: docx.protection
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,7 +212,7 @@ rst_epilog = """
 
 .. |PaperRefusal| replace:: :exc:`.PaperRefusal`
 
-.. |PackageLimitError| replace:: :exc:`.PackageLimitError`
+.. |MalformedPackageError| replace:: :exc:`.MalformedPackageError`
 
 .. |AmbiguousTargetError| replace:: :exc:`.AmbiguousTargetError`
 

--- a/docs/proposals/word-oracle-alignment.md
+++ b/docs/proposals/word-oracle-alignment.md
@@ -248,10 +248,12 @@ interact with Fix 1 — one member-level legality rule may cover both.
 **The rendering axis.** Numbering, tracked revisions, fields, `compare()`. Zero measurement, and
 a different question: not "did it open" but "did Word draw what the library claims".
 
-**Two further prefixed-archive paths**, owned by the `word-openable-packages` spec rather than
-this one: `patch_save` takes a verbatim byte-copy path on any no-op, which reproduces a prefixed
-original; and `diagnose()` reports a prefixed file as `not-a-zip`, which is false and
-unactionable. Fix 2 makes both unreachable for prefixed input, so they are defence in depth.
+**Two further prefixed-archive paths**, surfaced by the `word-openable-packages` spec and
+verified here: `patch_save` takes a verbatim byte-copy path on any no-op, which reproduces a
+prefixed original; and `diagnose()` reports a prefixed file as `not-a-zip`, which is false and
+unactionable. Fix 2 makes both unreachable for prefixed input, so they are defence in depth
+rather than correctness. **Both specs currently cover them. Which thread implements them is an
+open coordination decision, not something this spec settles** — see below.
 
 ## Relationship to the two parallel specs
 
@@ -280,9 +282,20 @@ refusing the write rather than preserving the tail; the measurement above confir
 - The byte-zero check's placement is load-bearing (above).
 - Two named tests break and must be rewritten (above).
 
-**Suggested ownership, to avoid three threads editing `_zipguard.py`:** this spec takes the load
-check and the read-side leniency fixes; `word-openable-packages` takes the write-side refusal,
-the `patch_save` gate and `diagnose()`; whichever lands first owns the two test rewrites.
+**Where the three threads collide, stated as fact rather than resolved.** Splitting the work is
+the maintainer's call; this spec does not claim or cede any of it.
+
+| contested surface | who covers it |
+|---|---|
+| `_zipguard._preflight_zip_stream` byte-zero check | this spec (Fix 2) and `word-openable-packages` (issue 4) — same rule, same file |
+| `_atomic_stream_write` nonzero-offset refusal | this spec (Fix 5), `word-oracle-fixes` (L4), `word-openable-packages` (write refusal) — all three |
+| `package.py` truncation gate | this spec (Fix 5) and `word-openable-packages` |
+| `patch_save` verbatim gate, `diagnose()` kind | `word-openable-packages`, and now recorded here |
+| the two test rewrites | all three break them |
+
+The practical constraint is that `_zipguard.py` cannot take three concurrent edits cleanly, and
+Fix 2 is the keystone the other items depend on — so it wants to land first regardless of who
+writes it. Everything else can follow in any order.
 
 ## Order
 

--- a/docs/proposals/word-oracle-alignment.md
+++ b/docs/proposals/word-oracle-alignment.md
@@ -151,29 +151,36 @@ non-Microsoft producer.
 
 ---
 
-## Fix 5 — container-tail truncation (finding 8)
+## Fix 5 — refuse nonzero-offset stream saves (finding 8) — **REVISED**
 
-**File:** `src/docx/opc/package.py`, `_atomic_stream_write`, the bare `stream.truncate()`.
+**File:** `src/docx/opc/package.py`, `_atomic_stream_write`.
 
-Not a Word question — the caller's own bytes are destroyed before any oracle sees the file.
+This spec originally proposed gating the bare `stream.truncate()` on `start == 0`, preserving
+the caller's trailing data and keeping the capability. **That was wrong**, and two parallel
+specs caught it. Measured:
 
-| | tail preserved |
-|---|---|
-| upstream python-docx | 274,992 of 312,000 |
-| paper-docx | **0** |
+| artifact of a nonzero-offset save | central-directory offset | opens? |
+|---|---|---|
+| a fresh save, for reference | 35,865 | opens |
+| the whole container file | 35,898 | **Word REFUSES** (prefixed archive) |
+| the package sliced back out | 35,898 | **paper-docx refuses** — skewed by exactly the 33-byte prefix |
 
-`truncate()` with no argument cuts at the current position, which is after the package, whatever
-offset the write began at. Upstream never truncates, so it preserves the tail.
+So the operation has **no usable output by either route**. The container file is a prefixed
+archive Word rejects, and the extracted slice carries offsets rebased to the container, so it
+is not a valid package either. Preserving the tail would have kept a capability whose every
+output is broken.
 
-Condition truncation on the write having started at offset zero. Truncating is correct when
-overwriting a whole file and destructive when writing into the middle of someone else's.
+**Refuse a seekable destination whose position is not zero**, before staging anything, raising
+`OSError` — matching the append-mode refusal and every other destination refusal in this module.
+A destination's cursor position is a property of the argument, not of the archive, so
+`PackageLimitError` would mis-type it. A stream whose `tell()` is unsupported stays permitted:
+that is the bare write/flush sink Word confirmed OPENS.
 
-    if start == 0:
-        stream.truncate()
+Keep the truncation gate (`if start == 0`) as defence in depth, and note that
+`_copy_stream_prefix` becomes dead code once nonzero offsets are refused.
 
-Both behaviours are already covered by fixtures: `3-fork-output/03` and `/04` (overwrite a longer
-document — must stay truncated, or they grow a stale tail that Word rejects) and `/07` (container
-— must keep the tail).
+**Consequence for the data-loss defect.** It disappears rather than being fixed: once the write
+always starts at zero, unconditional truncation is correct.
 
 ---
 
@@ -241,13 +248,67 @@ interact with Fix 1 — one member-level legality rule may cover both.
 **The rendering axis.** Numbering, tracked revisions, fields, `compare()`. Zero measurement, and
 a different question: not "did it open" but "did Word draw what the library claims".
 
+**Two further prefixed-archive paths**, owned by the `word-openable-packages` spec rather than
+this one: `patch_save` takes a verbatim byte-copy path on any no-op, which reproduces a prefixed
+original; and `diagnose()` reports a prefixed file as `not-a-zip`, which is false and
+unactionable. Fix 2 makes both unreachable for prefixed input, so they are defence in depth.
+
+## Relationship to the two parallel specs
+
+Three specs were drafted independently from the same Word rounds. They agree on nine of ten
+items — same rules, same files, same reasoning — which is worth stating plainly, because
+independent convergence is the main evidence that the reading of the verdicts is right.
+
+| this spec | `word-oracle-fixes.md` | `word-openable-packages/spec.md` |
+|---|---|---|
+| Fix 1 part names | L2 | — |
+| Fix 2 offset zero | L1 | issue 4 (load check) |
+| Fix 3 prefix collision | L3 | — |
+| Fix 4 image content type | S1 | — |
+| Fix 5 nonzero-offset writes | L4 | write refusal + truncation gate |
+| Fix 6 protection gate | S2, S3 | — |
+| Fix 7 messages | M1–M4 | interface contracts |
+
+**The one disagreement was Fix 5, and this spec was wrong.** Both parallel specs argued for
+refusing the write rather than preserving the tail; the measurement above confirms them.
+
+**Corrections this reconciliation produced, beyond Fix 5:**
+
+- Line numbers cited for `_zipguard.py` in earlier notes (280, 510, 947) came from `main`, where
+  the file is 975 lines. On this branch PR #24 has cut it to 793 and those numbers land on
+  unrelated lines. Refer to functions, not lines.
+- The byte-zero check's placement is load-bearing (above).
+- Two named tests break and must be rewritten (above).
+
+**Suggested ownership, to avoid three threads editing `_zipguard.py`:** this spec takes the load
+check and the read-side leniency fixes; `word-openable-packages` takes the write-side refusal,
+the `patch_save` gate and `diagnose()`; whichever lands first owns the two test rewrites.
+
 ## Order
 
-1. Fix 5 (truncation) — data loss, self-contained, no Word dependency.
-2. Fixes 1, 2, 3 — the leniency bugs, all in `_zipguard.py`, all validated against 83 documents.
-3. Fix 4 — one branch deleted.
-4. Fix 7 — wording.
-5. Fix 6 — largest surface (23 call sites) and carries the open decision above.
+1. Fix 2 (offset zero) — the keystone. Applied alone it also closes the save-path and
+   `patch_save` outcomes, because both read back through `preflight_zip`.
+2. Fixes 1, 3 — the other leniency bugs, same file, all validated against 83 documents.
+3. Fix 5 — the write-side refusal, which after Fix 2 changes the *diagnosis* rather than the
+   outcome: without it the caller gets a complaint about a malformed archive for what is
+   actually a bad destination argument.
+4. Fix 4 — one branch deleted.
+5. Fix 7 — wording.
+6. Fix 6 — largest surface (23 call sites) and carries the open decision above.
+
+**Placement matters for Fix 2.** The byte-zero check must run at the *end* of
+`_preflight_zip_stream`, after `_scan_central_directory`. Measured by the parallel thread:
+placed early it shadows more specific diagnoses, turning two preflight refusals that correctly
+say "central directory is too small for its member count" into a generic byte-zero message.
+
+**Two existing tests encode the disproved assumption** and must be rewritten, not preserved:
+
+- `tests/paper/test_practical_opc_hardening.py::it_validates_the_real_prefix_of_a_nonzero_position_stream`
+  asserts a nonzero-offset save succeeds, preserves the prefix, and reopens. Invert it.
+- `it_restores_a_seekable_stream_after_commit_error` seeks to offset 7 only incidentally. Move it
+  to offset 0 so it still exercises commit rollback.
+
+Applying Fix 2 alone fails exactly these two and nothing else.
 
 ## Test plan
 

--- a/docs/proposals/word-oracle-alignment.md
+++ b/docs/proposals/word-oracle-alignment.md
@@ -19,6 +19,33 @@ something Word rejects, reports correct content for it, and will edit and re-sav
 misreading. That is the exact failure the package was built to prevent, occurring inside the
 package. Those get priority.
 
+## Status — superseded in part by PR 30
+
+Most of this spec has shipped. PR 24 removed the resource caps, PR 29 closed the byte-zero
+rule and the nonzero-offset write, and **PR 30 landed Fixes 1, 3, 4, 6 and 7** — part-name
+legality, directory-prefix collisions, the image content type, the protection gate, and the
+message rewrites.
+
+What this branch adds on top of PR 30 is what none of them covered:
+
+- **The exception rename.** `PackageLimitError` -> `MalformedPackageError`. Nothing it raises
+  for is a limit any more; PR 24 removed every ceiling and rewrote the docstring without
+  renaming the class.
+- **The main-document content type defers to upstream.** `RT.OFFICE_DOCUMENT` is out of
+  `_KNOWN_RELATIONSHIP_CONTENT_TYPES`, so `api.Document`'s own `ValueError` fires instead of
+  being pre-empted with a different exception type.
+
+Two corrections PR 30 made to this spec's prose, worth keeping:
+
+- Fix 1's rule must be implemented as a **single pass** that consumes `%XX` as a unit. Written
+  as two rules — a literal-character check and a separate escape check — it refuses
+  `my%20image.png`, which Word opens: 6 of 7 verdicts instead of 7.
+- Fix 3's collision check must run as a **pre-pass** over the whole member-name set. Inside the
+  per-member loop the shallow member is reached first and its attribute check reports the wrong
+  defect.
+
+The sections below are the original design record and are left as written.
+
 ## State at this commit — measured, not assumed
 
 Every fixture set was replayed against this commit's code.
@@ -173,7 +200,7 @@ output is broken.
 **Refuse a seekable destination whose position is not zero**, before staging anything, raising
 `OSError` — matching the append-mode refusal and every other destination refusal in this module.
 A destination's cursor position is a property of the argument, not of the archive, so
-`PackageLimitError` would mis-type it. A stream whose `tell()` is unsupported stays permitted:
+`MalformedPackageError` would mis-type it. A stream whose `tell()` is unsupported stays permitted:
 that is the bare write/flush sink Word confirmed OPENS.
 
 Keep the truncation gate (`if start == 0`) as defence in depth, and note that

--- a/docs/proposals/word-oracle-alignment.md
+++ b/docs/proposals/word-oracle-alignment.md
@@ -1,0 +1,261 @@
+# Word-oracle alignment
+
+Base: `7e7cb51` (tip of the #23 → #24 → #25 → #13 → #22 stack).
+Evidence: Word for Mac, 2026-08-18, 31 documents opened by hand. Ledger:
+`verifying-against-word/WORD-VERDICTS.md`.
+
+## The principle this spec applies
+
+paper-docx exists because python-docx lets you build a document that looks fine in Python and
+fails to open in Word. Closing that gap is the only thing that justifies diverging from
+upstream. So each divergence has to fall into one of two buckets:
+
+- **Justified** — upstream accepts or writes something Word rejects, and the fork refuses it.
+- **Unjustified** — the fork refuses something Word opens. That is a regression against users
+  with no purpose, and it should be deleted.
+
+There is a third case the audit turned up that is worse than either: the fork *accepts*
+something Word rejects, reports correct content for it, and will edit and re-save its own
+misreading. That is the exact failure the package was built to prevent, occurring inside the
+package. Those get priority.
+
+## State at this commit — measured, not assumed
+
+Every fixture set was replayed against this commit's code.
+
+| # | Finding | Direction | Status here |
+|---|---|---|---|
+| 1 | `MAX_COMPRESSION_RATIO` | fork too strict | **fixed** by #24 |
+| 2 | `MAX_XML_MEMBER_BYTES` | fork too strict | **fixed** by #24 |
+| 3 | `MAX_MEMBER_COUNT` | fork too strict | **fixed** by #24 |
+| 4 | image relationship content type | fork too strict | open |
+| 5 | `prefix_data` accepted | **fork too lenient** | open |
+| 6 | part-name character rule | **fork too lenient** (×4 spellings) | open |
+| 7 | `prefix_collision_plain` accepted | **fork too lenient** | open |
+| 8 | container-tail truncation | data loss the fork introduced | open |
+| 9 | protection gate ignores mode | fork too strict | open |
+| 10 | three refusal messages | wording | open |
+
+#24 dropped all eight caps, not just the three measured. The other five were never Word rules
+either, so that is the right direction; it is simply unmeasured.
+
+Confirmed still correct and **not** to be touched: the ZIP footer rule (4 shapes), all three
+relationship-id guards, core-part content-type strictness, `case_ambiguous_names`, and the
+append-mode refusal — upstream silently writes a corrupt archive through an append handle and
+cannot reopen its own output, so that `OSError` is load-bearing.
+
+---
+
+## Fix 1 — part-name characters (finding 6)
+
+**File:** `src/docx/_zipguard.py`, `_validate_member_name`.
+
+Word refused four of the five renamed-media spellings it was shown. paper-docx refuses exactly
+one of them — the raw decomposed form — and opens the other three plus the literal space. So the
+NFC check is aimed at the wrong property: **non-ASCII in a part name is the defect**, and
+normalization form is not.
+
+Replace the NFC check with an OPC part-name legality rule:
+
+1. A member name may contain only ASCII characters.
+2. Unescaped characters must be legal in a URI path (RFC 3986 `pchar` plus `/`).
+3. A `%XX` escape is allowed only when it encodes a byte below `0x80`. Existing rejections for
+   escapes of unreserved characters, `/`, `\`, NUL, DEL and controls stay.
+4. **`[Content_Types].xml` is exempt.** It is a reserved ZIP item name, not an OPC part name.
+
+Rule 4 is not optional. Across 83 real documents in this repo it is the *only* member name
+outside the URI-path set — `[` and `]` are not `pchar`. Without the exemption every document
+breaks.
+
+Delete the NFC check entirely rather than keeping it alongside: a raw decomposed name is
+non-ASCII, so rule 1 subsumes it. That removes the `unicodedata` import.
+
+**Validation already run.** The rule reproduces all seven Word verdicts exactly and rejects
+none of the 52 distinct member names across those 83 documents.
+
+| name | rule | Word |
+|---|---|---|
+| `word/media/renamed1.png` | accept | OPENS |
+| `word/media/my%20image.png` | accept | OPENS |
+| `word/media/my image.png` | reject | REFUSES |
+| `word/media/imagé1.png` (NFC and NFD) | reject | REFUSES |
+| `word/media/imag%C3%A91.png` | reject | REFUSES |
+| `word/media/image%CC%811.png` | reject | REFUSES |
+
+**Message:** `"part name 'X' contains a character that is not legal in an OPC part name"`, naming
+the character. The current text — "is not Unicode-normalized" — describes a form, not the defect.
+
+---
+
+## Fix 2 — the archive must begin at offset zero (finding 5)
+
+**File:** `src/docx/_zipguard.py`, `_preflight_zip_stream`.
+
+The most serious item. Word **refuses** a package with a stub in front of it; paper-docx opens it
+and reports the *correct* content. Nothing downstream can tell the document is unusable.
+
+The preflight checks that the central directory is internally consistent
+(`central_offset + central_size == central_end`), which a rebased prefix satisfies. It never
+checks where the archive starts.
+
+Add: the first four bytes of the stream must be a local file header signature (`PK\x03\x04`), or
+an end-of-central-directory signature (`PK\x05\x06`) for an empty archive.
+
+**Validation already run.** Zero violations across 83 real documents; catches `prefix_data`;
+the control passes. It does not disturb `stray_signature` (about the EOCD scan, not offset zero)
+or `concatenated` (already refused for an ambiguous central-directory region).
+
+**Message:** `"the package does not begin at the start of the file: N bytes precede the archive"`.
+
+---
+
+## Fix 3 — directory-prefix collisions (finding 7)
+
+**File:** `src/docx/_zipguard.py`, `GuardedZipReader._validate_metadata`.
+
+Word refuses all three collision shapes — a zero-length member named `word` beside members under
+`word/` — **regardless of the member's attributes**. paper-docx refuses only the two carrying
+directory attributes and accepts the plain one.
+
+This inverts what the code currently assumes. The check fires on `info.is_dir() or external_attr
+& 0x10`, i.e. on mode bits. Word says the mode bits are incidental and **the name is the defect**.
+
+Add, for members whose names do not end in `/`: refuse when the name is a directory prefix of any
+other member name. Keep the existing attribute check — a member claiming to be a directory is
+still wrong — but it is no longer what carries this case.
+
+**Validation already run.** Zero violations across 83 real documents; catches
+`prefix_collision_plain`; the control passes. It must not apply to the `_directory_infos` set:
+zero-length folder records like `word/` are confirmed **OPENS** in Word and must keep working.
+
+**Message:** name the collision — `"member 'word' collides with the directory prefix used by
+'word/document.xml'"` — which is what the current wording already claims and now actually means.
+
+---
+
+## Fix 4 — image relationship content types (finding 4)
+
+**File:** `src/docx/opc/pkgreader.py`, `_validate_relationship_target_content_type`.
+
+Word **opens** a displayed image declared `application/octet-stream`, and **refuses**
+`styles.xml` declared `application/xml`. It cares what a core part claims to be; it does not care
+what a media part claims to be.
+
+Delete the `RT.IMAGE` branch. Images then fall through to the `_KNOWN_RELATIONSHIP_CONTENT_TYPES`
+loop, which has no image entry, so no check applies. Keep every core-part entry unchanged — three
+separate Word verdicts confirm that strictness is correct.
+
+This is the one remaining unjustified regression on the read path, and the likeliest of all of
+them to be hit by real third-party output, since a generic fallback media type is normal for a
+non-Microsoft producer.
+
+---
+
+## Fix 5 — container-tail truncation (finding 8)
+
+**File:** `src/docx/opc/package.py`, `_atomic_stream_write`, the bare `stream.truncate()`.
+
+Not a Word question — the caller's own bytes are destroyed before any oracle sees the file.
+
+| | tail preserved |
+|---|---|
+| upstream python-docx | 274,992 of 312,000 |
+| paper-docx | **0** |
+
+`truncate()` with no argument cuts at the current position, which is after the package, whatever
+offset the write began at. Upstream never truncates, so it preserves the tail.
+
+Condition truncation on the write having started at offset zero. Truncating is correct when
+overwriting a whole file and destructive when writing into the middle of someone else's.
+
+    if start == 0:
+        stream.truncate()
+
+Both behaviours are already covered by fixtures: `3-fork-output/03` and `/04` (overwrite a longer
+document — must stay truncated, or they grow a stale tail that Word rejects) and `/07` (container
+— must keep the tail).
+
+---
+
+## Fix 6 — protection gate: mode and operation aware (finding 9)
+
+**File:** `src/docx/protection.py`, `_refuse_if_protected`.
+
+The gate reads `enforced` and refuses. Its `operation` parameter is used only to build the
+message and never affects the decision, so all five restriction modes behave identically across
+all 23 call sites.
+
+Word's rules are per-mode *and* per-operation-class. Measured:
+
+| mode | comments | form fields | body |
+|---|---|---|---|
+| `readOnly` | blocked ✓measured | blocked | blocked |
+| `comments` | **ALLOWED** ✓measured | — | blocked ✓measured |
+| `trackedChanges` | **ALLOWED** ✓measured | — | permitted *(inferred)* |
+| `forms` | blocked ✓measured | **ALLOWED** ✓measured | blocked |
+| formatting-only | **ALLOWED** ✓measured | — | permitted *(inferred)* |
+
+Make `operation` load-bearing by classifying the 23 call sites:
+
+- **comments** — add/edit a comment, anchor a comment, delete a comment, reply to a comment,
+  resolve a comment
+- **form-field values** — set a control value
+- **body content** — everything else, including resolve a revision / resolve revisions
+
+`acknowledge_protection()` stays the escape hatch for genuinely blocked cases.
+
+**Message:** every B-file in the protection set opened cleanly in Word with the comment visible,
+so this refusal is a *policy* mirror of Word's UI, not a corruption guard. The message must say
+Word's own UI would not permit the edit — not imply the document would break.
+
+**Open decision, flagged rather than assumed.** Two body-content cells are inferred from Word's
+documented semantics, not observed: body edits under `trackedChanges` and under formatting-only.
+Under the principle at the top of this spec, an unmeasured cell has no evidence to justify
+refusing, and protection is not a corruption guard — so permitting matches upstream and risks
+nothing worse than doing something Word's UI would not let a human do. Either measure those two
+cells first, or ship them permissive deliberately. **Do not ship them refusing by default**,
+which is a regression with no evidence behind it.
+
+---
+
+## Fix 7 — three refusal messages (finding 10)
+
+| shape | current | problem |
+|---|---|---|
+| `duplicate_default_ct` | "contains an ambiguous Default declaration" | two entries declaring the *same* type are not ambiguous. Say "duplicate Default declaration for extension 'png'". Word does refuse the file, so only the wording is wrong. |
+| the four footer refusals | describe the end-of-central-directory record | say "the file has bytes after the end of the archive; re-save the document" |
+| `duplicate_rel_ids` vs `conflicting_rel_ids` | identical text | one is a redundant declaration, one a contradiction. Both are refused; what the caller does next differs. |
+
+---
+
+## Not in this spec
+
+**The reachability gap.** paper-docx opens `undeclared_orphan_part`, a top-level `.DS_Store`, and
+a `__MACOSX/._word` sidecar — all unreferenced members that resolve to no content type. Reachable
+undeclared parts are already refused correctly. Word has not been asked about the unreferenced
+ones. Given that Word proved strict about both core-part types and part-name characters, and that
+the fork has now been too lenient in three measured places, the prior is that these are a fourth.
+Fixtures exist in `1-refused-inputs/`. **Measure before writing this fix**, and expect it to
+interact with Fix 1 — one member-level legality rule may cover both.
+
+**The rendering axis.** Numbering, tracked revisions, fields, `compare()`. Zero measurement, and
+a different question: not "did it open" but "did Word draw what the library claims".
+
+## Order
+
+1. Fix 5 (truncation) — data loss, self-contained, no Word dependency.
+2. Fixes 1, 2, 3 — the leniency bugs, all in `_zipguard.py`, all validated against 83 documents.
+3. Fix 4 — one branch deleted.
+4. Fix 7 — wording.
+5. Fix 6 — largest surface (23 call sites) and carries the open decision above.
+
+## Test plan
+
+- Regression fixtures: every document in `1-refused-inputs/`, `4-followups/` and `5-encoding/`
+  must land on its recorded Word verdict. That is the acceptance criterion for fixes 1–4.
+- Real-document guard: the 83 `.docx` files in the repo must all still open. The three new rules
+  were validated against them and produced zero false positives; keep that as a test.
+- `3-fork-output/03`, `/04`, `/07` for fix 5.
+- Baseline at this commit is 2,644 passing. The 9 collection errors in
+  `tests/opc/test_phys_pkg.py` are a pytest deprecation about class-scoped fixtures declared as
+  instance methods, unrelated to this work.

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -93,9 +93,10 @@ deletions, format changes, table-row revisions, and moves as paired units:
     doc.revisions.reject_all(author="Bob Reviewer")     # or accept_all()
 
 Document protection is honored throughout:
-:ref:`docx.protection <paper_protection_api>` makes every fork mutating API
-refuse with |DocumentProtectedError| on a Restrict-Editing setting rather than
-silently editing a locked template.
+:ref:`docx.protection <paper_protection_api>` makes fork mutating APIs refuse
+with |DocumentProtectedError| wherever Word's own UI would refuse the edit,
+rather than silently editing a locked template. The gate follows Word's per-mode
+rules, so a comments-only restriction still permits commenting.
 
 
 Compose across documents

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -45,7 +45,7 @@ from docx._zipguard import (
     preflight_zip,
     read_compressed_bytes,
 )
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 
 if TYPE_CHECKING:
     from docx.document import Document
@@ -521,7 +521,7 @@ def diagnose(path: _PathLike) -> PackageDiagnosis:
         return result(False, "not-a-zip", "not a ZIP archive, so not an OPC package")
     try:
         parts, _ = _read_zip(file_path)
-    except PackageLimitError as exc:
+    except MalformedPackageError as exc:
         return result(False, "unsafe-archive", str(exc))
     except zipfile.BadZipFile as exc:
         return result(False, "corrupt-zip", f"ZIP structure is damaged: {exc}")

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import os
 import stat
 import struct
-import unicodedata
 import zlib
 from contextlib import suppress
 from typing import BinaryIO, Dict, List, Optional, Tuple, Union, cast
@@ -39,6 +38,7 @@ _ZIP64_LOCATOR_SIGNATURE = b"PK\x06\x07"
 _MAX_END_COMMENT_BYTES = 65_535
 
 _CONTENT_TYPES_NAME = "[Content_Types].xml"
+_CONTENT_TYPES_FOLDED = _CONTENT_TYPES_NAME.casefold()
 _CONTENT_TYPES_NAMESPACE = (
     "http://schemas.openxmlformats.org/package/2006/content-types"
 )
@@ -61,6 +61,10 @@ _FLAG_UTF8_NAME = 0x0800
 _SUPPORTED_COMPRESSION = (ZIP_STORED, ZIP_DEFLATED)
 _HEX_DIGITS = frozenset("0123456789ABCDEF")
 _URI_UNRESERVED = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+# RFC 3986 ``pchar`` minus ``pct-encoded``: unreserved / sub-delims / ":" / "@",
+# plus "/" as the segment separator. ``%`` is deliberately absent — it is legal
+# only as the head of a ``%XX`` triplet, which the walk consumes as a unit.
+_URI_PATH_LITERAL = _URI_UNRESERVED | frozenset(b"!$&'()*+,;=:@/")
 
 
 def compressed_size(source: object) -> Optional[int]:
@@ -233,7 +237,13 @@ def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[in
             candidates.append((archive_size - tail_size + index, fields))
 
     if not candidates:
-        raise PackageLimitError("ZIP package has no valid end-of-central-directory record")
+        raise PackageLimitError(
+            "the file does not end with an archive footer, so nothing marks where the"
+            " package stops: usually bytes were appended after the archive, or the file"
+            " was truncated in transfer. Word cannot open a .docx unless the archive is"
+            " exactly the file. Re-saving the document fixes an appended tail; a"
+            " truncated file needs a fresh copy"
+        )
     if len(candidates) != 1:
         raise PackageLimitError("ZIP package has ambiguous end-of-central-directory records")
     return candidates[0]
@@ -382,6 +392,7 @@ class GuardedZipReader:
         return dict(self._parts), list(self.order)
 
     def _validate_metadata(self) -> None:
+        self._refuse_directory_prefix_collisions()
         seen_names: set[str] = set()
         seen_equivalent_names: set[str] = set()
         seen_offsets: set[int] = set()
@@ -442,6 +453,32 @@ class GuardedZipReader:
                 raise PackageLimitError(
                     f"stored ZIP member {name!r} has inconsistent size metadata"
                 )
+
+    def _refuse_directory_prefix_collisions(self) -> None:
+        """Refuse a member whose name is a directory prefix of another member.
+
+        Word refuses a zero-length member named ``word`` sitting beside members
+        under ``word/`` whatever the member's attributes, so the name is the
+        defect. This runs as a pre-pass over the whole member-name set: the
+        collision is only visible from the deeper name, and the shallow member
+        is written first, so a per-member check would report whichever defect
+        the archive order happened to surface. Directory records are not in
+        ``self._infos`` and so are out of scope here, which is correct --
+        zero-length ``word/`` folder records open in Word.
+        """
+        member_names = {info.orig_filename for info in self._infos}
+        for info in self._infos:
+            name = info.orig_filename
+            boundary = name.find("/")
+            while boundary != -1:
+                prefix = name[:boundary]
+                if prefix in member_names:
+                    raise PackageLimitError(
+                        f"ZIP member {prefix!r} is also a directory prefix of member"
+                        f" {name!r}: one name cannot denote both a file and a"
+                        f" directory. Remove the member named {prefix!r}."
+                    )
+                boundary = name.find("/", boundary + 1)
 
     def _read_all_members(self) -> Dict[str, bytes]:
         if not self._infos and not self._directory_infos:
@@ -726,7 +763,11 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
             key = extension.lower()
             if key in defaults:
                 raise PackageLimitError(
-                    "[Content_Types].xml contains an ambiguous Default declaration"
+                    f"[Content_Types].xml declares the extension {extension!r} in more"
+                    " than one Default element; an extension may carry only one Default"
+                    " declaration, so the package does not bind it to a single content"
+                    " type and Word refuses to open it. Delete the duplicate Default so"
+                    f" {extension!r} is declared exactly once"
                 )
             defaults[key] = content_type
             continue
@@ -775,8 +816,6 @@ def _validate_directory_entry(info: "ZipInfo") -> None:
 def _validate_member_name(name: str) -> None:
     if not name:
         raise PackageLimitError("ZIP contains an empty member name")
-    if name != unicodedata.normalize("NFC", name):
-        raise PackageLimitError(f"ZIP member name {name!r} is not Unicode-normalized")
     if name.startswith("/") or name.endswith("/") or "\\" in name:
         raise PackageLimitError(f"ZIP member name {name!r} is noncanonical")
     if "?" in name or "#" in name:
@@ -791,16 +830,46 @@ def _validate_member_name(name: str) -> None:
     if len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":":
         raise PackageLimitError(f"ZIP member name {name!r} has a drive-qualified path")
 
+    if name.casefold() == _CONTENT_TYPES_FOLDED:
+        # Reserved package item rather than an OPC part name: "[" and "]" are
+        # not legal URI-path characters, and this is the only member carrying
+        # them. Word opens every package that has it, so it is exempt from the
+        # character rule below. Case-variant spellings are the same package item
+        # here as they are for the case-ambiguity check, and must reach their own
+        # content-types diagnosis rather than be renamed a character defect.
+        return
+
+    # One pass over the name, consuming "%XX" as a unit. It must stay a single
+    # pass: "%" is not a legal literal, so a separate literal check would refuse
+    # percent-escaped ASCII names such as "word/media/my%20image.png", which
+    # Word opens.
     index = 0
     while index < len(name):
-        if name[index] != "%":
+        char = name[index]
+        if char != "%":
+            code = ord(char)
+            if code > 0x7F:
+                raise PackageLimitError(
+                    f"ZIP member name {name!r} contains the non-ASCII character {char!r}; "
+                    "an OPC part name may contain only ASCII characters legal in a URI path"
+                )
+            if code not in _URI_PATH_LITERAL:
+                raise PackageLimitError(
+                    f"ZIP member name {name!r} contains the character {char!r}, which is not "
+                    "legal in an OPC part name; percent-escape it or rename the part"
+                )
             index += 1
             continue
         if index + 2 >= len(name) or any(
-            char not in _HEX_DIGITS for char in name[index + 1 : index + 3]
+            digit not in _HEX_DIGITS for digit in name[index + 1 : index + 3]
         ):
             raise PackageLimitError(f"ZIP member name {name!r} has a noncanonical percent escape")
         value = int(name[index + 1 : index + 3], 16)
         if value in _URI_UNRESERVED or value in (0x00, 0x2F, 0x5C, 0x7F) or value < 0x20:
             raise PackageLimitError(f"ZIP member name {name!r} has an unsafe percent escape")
+        if value >= 0x80:
+            raise PackageLimitError(
+                f"ZIP member name {name!r} percent-escapes the non-ASCII byte 0x{value:02X}; "
+                "an OPC part name may escape only ASCII characters"
+            )
         index += 3

--- a/src/docx/_zipguard.py
+++ b/src/docx/_zipguard.py
@@ -22,7 +22,7 @@ from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 
 from lxml import etree
 
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 
 _READ_CHUNK_BYTES = 64 * 1024
 _LOCAL_HEADER = struct.Struct("<4s5H3L2H")
@@ -139,7 +139,7 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
         stream.seek(0, os.SEEK_END)
         archive_size_value = cast(object, stream.tell())
     except (AttributeError, OSError, TypeError, ValueError) as exc:
-        raise PackageLimitError("ZIP package input must be a seekable binary stream") from exc
+        raise MalformedPackageError("ZIP package input must be a seekable binary stream") from exc
 
     try:
         if not isinstance(archive_size_value, int) or isinstance(archive_size_value, bool):
@@ -160,7 +160,7 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
             _comment_length,
         ) = end_fields
         if disk_number != 0 or central_disk != 0:
-            raise PackageLimitError("multi-disk ZIP packages are not supported")
+            raise MalformedPackageError("multi-disk ZIP packages are not supported")
 
         zip64_required = (
             disk_entries == 0xFFFF
@@ -179,17 +179,17 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
             ) = _read_zip64_end_record(stream, end_offset, end_fields)
 
         if disk_entries != total_entries:
-            raise PackageLimitError("ZIP central-directory counts disagree across disks")
+            raise MalformedPackageError("ZIP central-directory counts disagree across disks")
         if central_offset < 0 or central_size < 0:
-            raise PackageLimitError("ZIP central-directory metadata is negative")
+            raise MalformedPackageError("ZIP central-directory metadata is negative")
         if central_offset + central_size != central_end:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 "ZIP central-directory offset and size do not identify one unambiguous region"
             )
         if total_entries == 0 and central_size != 0:
-            raise PackageLimitError("empty ZIP package has a non-empty central directory")
+            raise MalformedPackageError("empty ZIP package has a non-empty central directory")
         if total_entries and central_size < total_entries * _CENTRAL_HEADER.size:
-            raise PackageLimitError("ZIP central directory is too small for its member count")
+            raise MalformedPackageError("ZIP central directory is too small for its member count")
 
         _scan_central_directory(
             stream,
@@ -205,7 +205,7 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
         stream.seek(0, os.SEEK_SET)
         leading = stream.read(4)
         if leading not in (_LOCAL_HEADER_SIGNATURE, _END_RECORD_SIGNATURE):
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 "the package does not begin with a ZIP local file header, so bytes precede"
                 " the archive; Word cannot open a .docx with anything in front of the"
                 " package. Extract the archive to a file of its own and open that"
@@ -220,7 +220,7 @@ def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[in
     stream.seek(archive_size - tail_size, os.SEEK_SET)
     tail = stream.read(tail_size)
     if len(tail) != tail_size:
-        raise PackageLimitError("ZIP package ends before its declared physical size")
+        raise MalformedPackageError("ZIP package ends before its declared physical size")
 
     candidates: List[Tuple[int, Tuple[int, ...]]] = []
     cursor = 0
@@ -237,7 +237,7 @@ def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[in
             candidates.append((archive_size - tail_size + index, fields))
 
     if not candidates:
-        raise PackageLimitError(
+        raise MalformedPackageError(
             "the file does not end with an archive footer, so nothing marks where the"
             " package stops: usually bytes were appended after the archive, or the file"
             " was truncated in transfer. Word cannot open a .docx unless the archive is"
@@ -245,7 +245,7 @@ def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[in
             " truncated file needs a fresh copy"
         )
     if len(candidates) != 1:
-        raise PackageLimitError("ZIP package has ambiguous end-of-central-directory records")
+        raise MalformedPackageError("ZIP package has ambiguous end-of-central-directory records")
     return candidates[0]
 
 
@@ -256,23 +256,23 @@ def _read_zip64_end_record(
 ) -> Tuple[int, int, int, int, int]:
     locator_offset = end_offset - _ZIP64_LOCATOR.size
     if locator_offset < 0:
-        raise PackageLimitError("ZIP64 package is missing its locator")
+        raise MalformedPackageError("ZIP64 package is missing its locator")
     stream.seek(locator_offset, os.SEEK_SET)
     locator_data = stream.read(_ZIP64_LOCATOR.size)
     if len(locator_data) != _ZIP64_LOCATOR.size:
-        raise PackageLimitError("ZIP64 locator is truncated")
+        raise MalformedPackageError("ZIP64 locator is truncated")
     signature, record_disk, record_offset, disk_count = _ZIP64_LOCATOR.unpack(locator_data)
     if signature != _ZIP64_LOCATOR_SIGNATURE:
-        raise PackageLimitError("ZIP64 package is missing its locator")
+        raise MalformedPackageError("ZIP64 package is missing its locator")
     if record_disk != 0 or disk_count != 1:
-        raise PackageLimitError("multi-disk ZIP64 packages are not supported")
+        raise MalformedPackageError("multi-disk ZIP64 packages are not supported")
     if record_offset < 0 or record_offset + _ZIP64_END_RECORD.size != locator_offset:
-        raise PackageLimitError("ZIP64 end record has an ambiguous offset or size")
+        raise MalformedPackageError("ZIP64 end record has an ambiguous offset or size")
 
     stream.seek(record_offset, os.SEEK_SET)
     record_data = stream.read(_ZIP64_END_RECORD.size)
     if len(record_data) != _ZIP64_END_RECORD.size:
-        raise PackageLimitError("ZIP64 end record is truncated")
+        raise MalformedPackageError("ZIP64 end record is truncated")
     (
         signature,
         record_size,
@@ -286,9 +286,9 @@ def _read_zip64_end_record(
         central_offset,
     ) = _ZIP64_END_RECORD.unpack(record_data)
     if signature != _ZIP64_END_RECORD_SIGNATURE or record_size != 44:
-        raise PackageLimitError("ZIP64 end record has an unsupported or ambiguous shape")
+        raise MalformedPackageError("ZIP64 end record has an unsupported or ambiguous shape")
     if disk_number != 0 or central_disk != 0 or disk_entries != total_entries:
-        raise PackageLimitError("multi-disk ZIP64 packages are not supported")
+        raise MalformedPackageError("multi-disk ZIP64 packages are not supported")
 
     legacy_disk_entries = legacy_fields[3]
     legacy_total_entries = legacy_fields[4]
@@ -318,7 +318,7 @@ def _validate_zip64_legacy_value(
     label: str,
 ) -> None:
     if legacy != sentinel and legacy != actual:
-        raise PackageLimitError(f"ZIP64 {label} disagrees with the legacy end record")
+        raise MalformedPackageError(f"ZIP64 {label} disagrees with the legacy end record")
 
 
 def _scan_central_directory(
@@ -332,27 +332,29 @@ def _scan_central_directory(
     actual_count = 0
     while cursor < central_end:
         if cursor + _CENTRAL_HEADER.size > central_end:
-            raise PackageLimitError("ZIP central directory ends inside a member record")
+            raise MalformedPackageError("ZIP central directory ends inside a member record")
         stream.seek(cursor, os.SEEK_SET)
         header = stream.read(_CENTRAL_HEADER.size)
         if len(header) != _CENTRAL_HEADER.size:
-            raise PackageLimitError("ZIP central-directory member record is truncated")
+            raise MalformedPackageError("ZIP central-directory member record is truncated")
         fields = _CENTRAL_HEADER.unpack(header)
         if fields[0] != _CENTRAL_HEADER_SIGNATURE:
-            raise PackageLimitError("ZIP central directory contains an unsupported record")
+            raise MalformedPackageError("ZIP central directory contains an unsupported record")
         name_length, extra_length, comment_length = fields[10:13]
         if fields[13] != 0:
-            raise PackageLimitError("multi-disk ZIP member records are not supported")
+            raise MalformedPackageError("multi-disk ZIP member records are not supported")
         record_size = _CENTRAL_HEADER.size + name_length + extra_length + comment_length
         if cursor + record_size > central_end:
-            raise PackageLimitError("ZIP central-directory member record exceeds its region")
+            raise MalformedPackageError("ZIP central-directory member record exceeds its region")
         cursor += record_size
         actual_count += 1
         if actual_count > expected_count:
-            raise PackageLimitError("ZIP central-directory member count exceeds its end record")
+            raise MalformedPackageError("ZIP central-directory member count exceeds its end record")
 
     if cursor != central_end or actual_count != expected_count:
-        raise PackageLimitError("ZIP central-directory member count disagrees with its end record")
+        raise MalformedPackageError(
+            "ZIP central-directory member count disagrees with its end record"
+        )
 
 
 class GuardedZipReader:
@@ -400,7 +402,7 @@ class GuardedZipReader:
             # directory entries occupy archive space: they participate in the
             # overlap accounting even though they are not members
             if info.header_offset < 0 or info.header_offset in seen_offsets:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP directory entry {info.orig_filename!r} has an invalid"
                     " or shared local-header offset"
                 )
@@ -408,49 +410,49 @@ class GuardedZipReader:
         for info in self._infos:
             name = info.orig_filename
             if name != info.filename:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member name {name!r} contains a noncanonical NUL suffix"
                 )
             _validate_member_name(name)
 
             if name in seen_names:
-                raise PackageLimitError(f"ZIP contains duplicate member name {name!r}")
+                raise MalformedPackageError(f"ZIP contains duplicate member name {name!r}")
             equivalent_name = name.casefold()
             if equivalent_name in seen_equivalent_names:
-                raise PackageLimitError(f"ZIP contains case-ambiguous member name {name!r}")
+                raise MalformedPackageError(f"ZIP contains case-ambiguous member name {name!r}")
             seen_names.add(name)
             seen_equivalent_names.add(equivalent_name)
 
             if info.header_offset < 0 or info.header_offset in seen_offsets:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {name!r} has an invalid or shared local-header offset"
                 )
             seen_offsets.add(info.header_offset)
 
             if info.flag_bits & (_FLAG_ENCRYPTED | _FLAG_STRONG_ENCRYPTION):
-                raise PackageLimitError(f"ZIP member {name!r} is encrypted")
+                raise MalformedPackageError(f"ZIP member {name!r} is encrypted")
             if info.flag_bits & _FLAG_PATCHED_DATA:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {name!r} uses unsupported patched-data encoding"
                 )
             if info.compress_type not in _SUPPORTED_COMPRESSION:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {name!r} uses unsupported compression method {info.compress_type}"
                 )
             if info.is_dir() or info.external_attr & 0x10:
-                raise PackageLimitError(f"ZIP member {name!r} is a directory entry")
+                raise MalformedPackageError(f"ZIP member {name!r} is a directory entry")
 
             unix_mode = (info.external_attr >> 16) & 0xFFFF
             file_type = stat.S_IFMT(unix_mode)
             if file_type not in (0, stat.S_IFREG):
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {name!r} uses unsupported filesystem entry type"
                 )
 
             if info.file_size < 0 or info.compress_size < 0:
-                raise PackageLimitError(f"ZIP member {name!r} has a negative size")
+                raise MalformedPackageError(f"ZIP member {name!r} has a negative size")
             if info.compress_type == ZIP_STORED and info.file_size != info.compress_size:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"stored ZIP member {name!r} has inconsistent size metadata"
                 )
 
@@ -473,7 +475,7 @@ class GuardedZipReader:
             while boundary != -1:
                 prefix = name[:boundary]
                 if prefix in member_names:
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"ZIP member {prefix!r} is also a directory prefix of member"
                         f" {name!r}: one name cannot denote both a file and a"
                         f" directory. Remove the member named {prefix!r}."
@@ -485,14 +487,14 @@ class GuardedZipReader:
             return {}
         stream = self._zip_file.fp
         if stream is None:
-            raise PackageLimitError("ZIP package stream is closed")
+            raise MalformedPackageError("ZIP package stream is closed")
 
         start_dir = self._zip_file.start_dir
         archive_size = compressed_size(stream)
         if start_dir < 0:
-            raise PackageLimitError("ZIP central-directory offset is invalid")
+            raise MalformedPackageError("ZIP central-directory offset is invalid")
         if archive_size is not None and start_dir > archive_size:
-            raise PackageLimitError("ZIP central directory lies beyond the package")
+            raise MalformedPackageError("ZIP central directory lies beyond the package")
 
         sorted_infos = sorted(
             self._infos + self._directory_infos, key=lambda info: info.header_offset
@@ -546,14 +548,14 @@ class GuardedZipReader:
     def _validate_local_header(self, info: ZipInfo, boundary: int) -> int:
         stream = self._zip_file.fp
         if stream is None:
-            raise PackageLimitError("ZIP package stream is closed")
+            raise MalformedPackageError("ZIP package stream is closed")
         if info.header_offset + _LOCAL_HEADER.size > boundary:
-            raise PackageLimitError(f"ZIP member {info.filename!r} has an overlapping header")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} has an overlapping header")
 
         stream.seek(info.header_offset, os.SEEK_SET)
         header = stream.read(_LOCAL_HEADER.size)
         if len(header) != _LOCAL_HEADER.size:
-            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated header")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} has a truncated header")
         (
             signature,
             _extract_version,
@@ -568,15 +570,15 @@ class GuardedZipReader:
             extra_length,
         ) = _LOCAL_HEADER.unpack(header)
         if signature != _LOCAL_HEADER_SIGNATURE:
-            raise PackageLimitError(f"ZIP member {info.filename!r} has an invalid header")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} has an invalid header")
         if flags != info.flag_bits or compression != info.compress_type:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} has inconsistent local-header metadata"
             )
 
         raw_name = stream.read(name_length)
         if len(raw_name) != name_length:
-            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated name")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} has a truncated name")
         try:
             local_name = raw_name.decode(
                 "utf-8"
@@ -584,11 +586,11 @@ class GuardedZipReader:
                 else (getattr(self._zip_file, "metadata_encoding", None) or "cp437")
             )
         except UnicodeDecodeError as exc:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} has an invalid encoded name"
             ) from exc
         if local_name != info.orig_filename:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} has conflicting local and central names"
             )
 
@@ -601,39 +603,43 @@ class GuardedZipReader:
             valid_compressed = compressed in (info.compress_size, 0xFFFFFFFF)
             valid_expanded = expanded in (info.file_size, 0xFFFFFFFF)
         if not (valid_crc and valid_compressed and valid_expanded):
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} has inconsistent local size or CRC metadata"
             )
 
         data_start = info.header_offset + _LOCAL_HEADER.size + name_length + extra_length
         data_end = data_start + info.compress_size
         if data_start > boundary or data_end > boundary:
-            raise PackageLimitError(f"ZIP member {info.filename!r} overlaps another ZIP record")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} overlaps another ZIP record")
         self._validate_data_descriptor(info, data_end, boundary)
         return data_start
 
     def _validate_data_descriptor(self, info: ZipInfo, data_end: int, boundary: int) -> None:
         stream = self._zip_file.fp
         if stream is None:
-            raise PackageLimitError("ZIP package stream is closed")
+            raise MalformedPackageError("ZIP package stream is closed")
         descriptor_size = boundary - data_end
         if not info.flag_bits & _FLAG_DATA_DESCRIPTOR:
             if descriptor_size:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {info.filename!r} has undeclared trailing data"
                 )
             return
         if descriptor_size not in (12, 16, 20, 24):
-            raise PackageLimitError(f"ZIP member {info.filename!r} has an invalid data descriptor")
+            raise MalformedPackageError(
+                f"ZIP member {info.filename!r} has an invalid data descriptor"
+            )
 
         stream.seek(data_end, os.SEEK_SET)
         descriptor = stream.read(descriptor_size)
         if len(descriptor) != descriptor_size:
-            raise PackageLimitError(f"ZIP member {info.filename!r} has a truncated data descriptor")
+            raise MalformedPackageError(
+                f"ZIP member {info.filename!r} has a truncated data descriptor"
+            )
         has_signature = descriptor_size in (16, 24)
         if has_signature:
             if descriptor[:4] != b"PK\x07\x08":
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {info.filename!r} has an invalid data descriptor"
                 )
             descriptor = descriptor[4:]
@@ -646,14 +652,14 @@ class GuardedZipReader:
             info.compress_size,
             info.file_size,
         ):
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} has inconsistent data-descriptor metadata"
             )
 
     def _inflate_member(self, info: ZipInfo, data_start: int) -> bytes:
         stream = self._zip_file.fp
         if stream is None:
-            raise PackageLimitError("ZIP package stream is closed")
+            raise MalformedPackageError("ZIP package stream is closed")
         stream.seek(data_start, os.SEEK_SET)
 
         chunks: List[bytes] = []
@@ -666,7 +672,7 @@ class GuardedZipReader:
                 return
             actual_size += len(data)
             if actual_size > info.file_size:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {info.filename!r} inflates past its declared size"
                 )
             crc = zlib.crc32(data, crc)
@@ -677,7 +683,7 @@ class GuardedZipReader:
             while remaining:
                 raw = stream.read(min(_READ_CHUNK_BYTES, remaining))
                 if not raw:
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"ZIP member {info.filename!r} has truncated stored data"
                     )
                 remaining -= len(raw)
@@ -688,21 +694,21 @@ class GuardedZipReader:
                 while remaining:
                     raw = stream.read(min(_READ_CHUNK_BYTES, remaining))
                     if not raw:
-                        raise PackageLimitError(
+                        raise MalformedPackageError(
                             f"ZIP member {info.filename!r} has truncated compressed data"
                         )
                     remaining -= len(raw)
                     pending = raw
                     while pending:
                         if decompressor.eof:
-                            raise PackageLimitError(
+                            raise MalformedPackageError(
                                 f"ZIP member {info.filename!r} has trailing compressed data"
                             )
                         output = decompressor.decompress(pending, _READ_CHUNK_BYTES)
                         pending = decompressor.unconsumed_tail
                         consume(output)
                         if decompressor.unused_data:
-                            raise PackageLimitError(
+                            raise MalformedPackageError(
                                 f"ZIP member {info.filename!r} has trailing compressed data"
                             )
 
@@ -712,21 +718,21 @@ class GuardedZipReader:
                     if not output:
                         break
             except zlib.error as exc:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {info.filename!r} has invalid deflate data"
                 ) from exc
             if not decompressor.eof:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member {info.filename!r} compressed data ends before deflate EOF"
                 )
 
         if actual_size != info.file_size:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member {info.filename!r} actual expanded size {actual_size} bytes "
                 f"does not match declared size {info.file_size} bytes"
             )
         if crc & 0xFFFFFFFF != info.CRC:
-            raise PackageLimitError(f"ZIP member {info.filename!r} fails its CRC check")
+            raise MalformedPackageError(f"ZIP member {info.filename!r} fails its CRC check")
         return b"".join(chunks)
 
 
@@ -734,12 +740,12 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
     try:
         root = etree.fromstring(data, _CONTENT_TYPES_PARSER)
     except etree.XMLSyntaxError as exc:
-        raise PackageLimitError("[Content_Types].xml is malformed") from exc
+        raise MalformedPackageError("[Content_Types].xml is malformed") from exc
     docinfo = root.getroottree().docinfo
     if docinfo.doctype or docinfo.internalDTD is not None:
-        raise PackageLimitError("[Content_Types].xml contains a prohibited DTD")
+        raise MalformedPackageError("[Content_Types].xml contains a prohibited DTD")
     if root.tag != _CONTENT_TYPES_TAG:
-        raise PackageLimitError("[Content_Types].xml has an unexpected root element")
+        raise MalformedPackageError("[Content_Types].xml has an unexpected root element")
 
     defaults: Dict[str, str] = {}
     overrides: Dict[str, str] = {}
@@ -757,12 +763,12 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
                 or not content_type
                 or content_type != content_type.strip()
             ):
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     "[Content_Types].xml contains an invalid Default declaration"
                 )
             key = extension.lower()
             if key in defaults:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"[Content_Types].xml declares the extension {extension!r} in more"
                     " than one Default element; an extension may carry only one Default"
                     " declaration, so the package does not bind it to a single content"
@@ -782,17 +788,17 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
                 or not content_type
                 or content_type != content_type.strip()
             ):
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     "[Content_Types].xml contains an invalid Override declaration"
                 )
             key = part_name.casefold()
             if key in overrides:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     "[Content_Types].xml contains an ambiguous Override declaration"
                 )
             overrides[key] = content_type
             continue
-        raise PackageLimitError(
+        raise MalformedPackageError(
             "[Content_Types].xml contains an unsupported declaration"
         )
     return defaults, overrides
@@ -802,33 +808,33 @@ def _validate_directory_entry(info: "ZipInfo") -> None:
     """A folder record may occupy archive space but must be inert."""
     name = info.orig_filename
     if name != info.filename:
-        raise PackageLimitError(
+        raise MalformedPackageError(
             f"ZIP directory entry {name!r} contains a noncanonical NUL suffix"
         )
     if info.flag_bits & (_FLAG_ENCRYPTED | _FLAG_STRONG_ENCRYPTION | _FLAG_PATCHED_DATA):
-        raise PackageLimitError(
+        raise MalformedPackageError(
             f"ZIP directory entry {name!r} uses unsupported encoding flags"
         )
     if info.file_size or info.compress_size:
-        raise PackageLimitError(f"ZIP directory entry {name!r} carries data")
+        raise MalformedPackageError(f"ZIP directory entry {name!r} carries data")
 
 
 def _validate_member_name(name: str) -> None:
     if not name:
-        raise PackageLimitError("ZIP contains an empty member name")
+        raise MalformedPackageError("ZIP contains an empty member name")
     if name.startswith("/") or name.endswith("/") or "\\" in name:
-        raise PackageLimitError(f"ZIP member name {name!r} is noncanonical")
+        raise MalformedPackageError(f"ZIP member name {name!r} is noncanonical")
     if "?" in name or "#" in name:
-        raise PackageLimitError(f"ZIP member name {name!r} contains a URI query or fragment")
+        raise MalformedPackageError(f"ZIP member name {name!r} contains a URI query or fragment")
     if any(ord(char) < 0x20 or ord(char) == 0x7F for char in name):
-        raise PackageLimitError(f"ZIP member name {name!r} contains a control character")
+        raise MalformedPackageError(f"ZIP member name {name!r} contains a control character")
 
     segments = name.split("/")
     if any(segment in ("", ".", "..") for segment in segments):
-        raise PackageLimitError(f"ZIP member name {name!r} has a noncanonical path segment")
+        raise MalformedPackageError(f"ZIP member name {name!r} has a noncanonical path segment")
     first_segment = segments[0]
     if len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":":
-        raise PackageLimitError(f"ZIP member name {name!r} has a drive-qualified path")
+        raise MalformedPackageError(f"ZIP member name {name!r} has a drive-qualified path")
 
     if name.casefold() == _CONTENT_TYPES_FOLDED:
         # Reserved package item rather than an OPC part name: "[" and "]" are
@@ -849,12 +855,12 @@ def _validate_member_name(name: str) -> None:
         if char != "%":
             code = ord(char)
             if code > 0x7F:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member name {name!r} contains the non-ASCII character {char!r}; "
                     "an OPC part name may contain only ASCII characters legal in a URI path"
                 )
             if code not in _URI_PATH_LITERAL:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"ZIP member name {name!r} contains the character {char!r}, which is not "
                     "legal in an OPC part name; percent-escape it or rename the part"
                 )
@@ -863,12 +869,14 @@ def _validate_member_name(name: str) -> None:
         if index + 2 >= len(name) or any(
             digit not in _HEX_DIGITS for digit in name[index + 1 : index + 3]
         ):
-            raise PackageLimitError(f"ZIP member name {name!r} has a noncanonical percent escape")
+            raise MalformedPackageError(
+                f"ZIP member name {name!r} has a noncanonical percent escape"
+            )
         value = int(name[index + 1 : index + 3], 16)
         if value in _URI_UNRESERVED or value in (0x00, 0x2F, 0x5C, 0x7F) or value < 0x20:
-            raise PackageLimitError(f"ZIP member name {name!r} has an unsafe percent escape")
+            raise MalformedPackageError(f"ZIP member name {name!r} has an unsafe percent escape")
         if value >= 0x80:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"ZIP member name {name!r} percent-escapes the non-ASCII byte 0x{value:02X}; "
                 "an OPC part name may escape only ASCII characters"
             )

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -22,7 +22,7 @@ from docx.opc.packuri import PackURI
 from docx.opc.part import XmlPart
 from docx.oxml.ns import nsdecls, qn
 from docx.oxml.parser import parse_xml
-from docx.protection import _refuse_if_protected
+from docx.protection import OP_COMMENT, _refuse_if_protected
 from docx.story import _story_elements
 
 _W_DECL = nsdecls("w")
@@ -159,7 +159,8 @@ def _preflight_comment_range(
     document: "Document", first_run: "_Element", last_run: "_Element", *, operation: str
 ) -> None:
     """Validate only the selected run interval before adding range markers."""
-    _refuse_if_protected(document, operation)
+    # Every caller of this funnel is anchoring a comment; hardcode the class.
+    _refuse_if_protected(document, operation, operation_class=OP_COMMENT)
     nodes = tuple(document.element.iter())
     positions = {id(node): index for index, node in enumerate(nodes)}
     first = positions.get(id(first_run))
@@ -551,7 +552,7 @@ def is_resolved(document: "Document", comment: "Comment") -> bool:
 def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) -> None:
     """Mark `comment` resolved (or reopened) the way Word does."""
     comment_elm = _comment_element(document, comment)
-    _refuse_if_protected(document, "resolve a comment")
+    _refuse_if_protected(document, "resolve a comment", operation_class=OP_COMMENT)
     # Validate a pre-existing extension part before adding a paraId to the
     # comment. An opaque extension must refuse without touching comments.xml.
     _preflight_comments_extended_write(document)
@@ -676,7 +677,7 @@ def reply(
     if date is not None and not isinstance(date, dt.datetime):
         raise TypeError("date must be a datetime or None")
     parent_elm = _comment_element(document, comment)
-    _refuse_if_protected(document, "reply to a comment")
+    _refuse_if_protected(document, "reply to a comment", operation_class=OP_COMMENT)
     start, end, reference_run = _anchor_elements(document, comment.comment_id)
     if start is None or end is None or reference_run is None:
         raise TargetNotFoundError(
@@ -806,7 +807,7 @@ def _remove_comment_anchors(document: "Document", comment_id: int) -> None:
 def delete_comment(document: "Document", comment: "Comment") -> None:
     """Remove one comment and its replies. Anchored document text stays."""
     _comment_element(document, comment)
-    _refuse_if_protected(document, "delete a comment")
+    _refuse_if_protected(document, "delete a comment", operation_class=OP_COMMENT)
     _preflight_comment_add(document)
     _preflight_comments_extended_write(document)
     with rollback_on_error(document):

--- a/src/docx/comments.py
+++ b/src/docx/comments.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING, Callable, Iterator, Optional, cast
+from typing import TYPE_CHECKING, Iterator, Optional, cast
 
 from docx._transaction import rollback_on_error, rollback_xml_on_error
 from docx.blkcntnr import BlockItemContainer
@@ -61,10 +61,12 @@ def _document_for_comments_part(comments_part: "CommentsPart") -> "Optional[Docu
 
 
 def _refuse_document_protection(document: "Document", operation: str) -> None:
-    from docx.protection import _refuse_if_protected  # pyright: ignore[reportUnknownVariableType]
+    """Gate every comment mutator. Comment class, hardcoded: every caller of
+    this forwarder is a comment operation, and Word permits commenting under
+    `comments`, `trackedChanges` and formatting-only protection."""
+    from docx.protection import OP_COMMENT, _refuse_if_protected
 
-    refuse = cast("Callable[[Document, str], None]", _refuse_if_protected)
-    refuse(document, operation)
+    _refuse_if_protected(document, operation, operation_class=OP_COMMENT)
 
 
 class Comments:

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -30,7 +30,7 @@ from docx.errors import (
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement, parse_xml
-from docx.protection import _refuse_if_protected
+from docx.protection import OP_FORM_FIELD, _refuse_if_protected
 from docx.search import _validate_writable_text
 from docx.story import _first_choice_children, _story_elements
 
@@ -466,7 +466,9 @@ class Control:
         text. Date: date/datetime (stamps `w:fullDate`) or display string.
         """
         self._validate_ownership()
-        _refuse_if_protected(self._document, "set a control value")
+        _refuse_if_protected(
+            self._document, "set a control value", operation_class=OP_FORM_FIELD
+        )
         if self.is_data_bound:
             control_type = self.control_type
             if control_type not in ("text", "rich_text"):

--- a/src/docx/errors.py
+++ b/src/docx/errors.py
@@ -21,13 +21,18 @@ class PaperRefusal(Exception):
     """
 
 
-class PackageLimitError(PaperRefusal):
-    """A package archive is corrupt, encrypted, or malformed.
+class MalformedPackageError(PaperRefusal):
+    """The file is not a package this library can safely read.
 
-    Package reads validate ZIP structure before any XML is parsed or output is
-    replaced. This exception therefore represents a safe refusal, including for
-    encrypted entries, duplicate/noncanonical member
-    names, unsupported entry types, and forged ZIP size metadata.
+    Raised for a damaged or inconsistent ZIP envelope, an encrypted or
+    unsupported member, a member name that cannot denote one part, and a
+    `[Content_Types].xml` or relationship graph that does not describe a
+    readable package. Validation runs before any XML is parsed or any output is
+    replaced, so this is a safe refusal: nothing was read into the object model
+    and nothing on disk was touched.
+
+    It does not mean the file is too large. Size and member-count ceilings were
+    removed once Word was measured opening documents past all of them.
     """
 
 

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -4,7 +4,7 @@ import os
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo, is_zipfile
 
 from docx._zipguard import GuardedZipReader, preflight_zip
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc.exceptions import PackageNotFoundError
 from docx.opc.packuri import CONTENT_TYPES_URI
 
@@ -46,18 +46,18 @@ class _DirPkgReader(PhysPkgReader):
         super(_DirPkgReader, self).__init__()
         self._path = os.path.abspath(os.fspath(path))
         if os.path.islink(self._path):
-            raise PackageLimitError("expanded package root is a symbolic link")
+            raise MalformedPackageError("expanded package root is a symbolic link")
         names = []
         for root, directories, files in os.walk(self._path, followlinks=False):
             directories.sort()
             files.sort()
             for directory in directories:
                 if os.path.islink(os.path.join(root, directory)):
-                    raise PackageLimitError("expanded package contains a symbolic link")
+                    raise MalformedPackageError("expanded package contains a symbolic link")
             for filename in files:
                 file_path = os.path.join(root, filename)
                 if os.path.islink(file_path):
-                    raise PackageLimitError("expanded package contains a symbolic link")
+                    raise MalformedPackageError("expanded package contains a symbolic link")
                 member = os.path.relpath(file_path, self._path).replace(
                     os.sep, "/"
                 )
@@ -66,7 +66,7 @@ class _DirPkgReader(PhysPkgReader):
         for name in names:
             folded = name.casefold()
             if folded in self._member_name_by_fold:
-                raise PackageLimitError(
+                raise MalformedPackageError(
                     f"expanded package contains case-ambiguous member name {name!r}"
                 )
             self._member_name_by_fold[folded] = name

--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -5,7 +5,7 @@ from lxml import etree
 from docx._contenttypes import content_type_matches
 from docx._rels import is_relationship_type, is_xml_id
 from docx._zipguard import _parse_content_types
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TARGET_MODE as RTM
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -88,14 +88,14 @@ class PackageReader:
                 try:
                     phys_reader.partname_for(partname)
                 except KeyError as exc:
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"relationship {srel.rId!r} targets missing package part"
                         f" {partname!s}"
                     ) from exc
                 try:
                     content_type = content_types[partname]
                 except KeyError as exc:
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"relationship {srel.rId!r} targets {partname!s}, which has no"
                         " declared content type"
                     ) from exc
@@ -308,11 +308,11 @@ class _SerializedRelationships:
             for rel_elm in rels_elm.Relationship_lst:
                 serialized = _SerializedRelationship(baseURI, rel_elm)
                 if isinstance(serialized.rId, str) and not is_xml_id(serialized.rId):
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"relationship Id {serialized.rId!r} is not a valid XML ID"
                     )
                 if isinstance(serialized.rId, str) and serialized.rId in seen_ids:
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         _duplicate_relationship_id_message(
                             baseURI,
                             serialized.rId,
@@ -326,14 +326,14 @@ class _SerializedRelationships:
                     RTM.INTERNAL,
                     RTM.EXTERNAL,
                 ):
-                    raise PackageLimitError(
+                    raise MalformedPackageError(
                         f"relationship {serialized.rId!r} has invalid TargetMode"
                     )
                 if not serialized.is_external:
                     try:
                         serialized.target_partname
                     except (IndexError, TypeError, ValueError) as exc:
-                        raise PackageLimitError(
+                        raise MalformedPackageError(
                             f"relationship {serialized.rId!r} has an invalid target"
                         ) from exc
                 srels._srels.append(serialized)
@@ -350,10 +350,10 @@ def _validate_relationship_records(blob, base_uri) -> None:
     try:
         root = etree.fromstring(blob, parser)
     except etree.XMLSyntaxError as exc:
-        raise PackageLimitError(f"relationships for {base_uri!r} are malformed") from exc
+        raise MalformedPackageError(f"relationships for {base_uri!r} are malformed") from exc
     docinfo = root.getroottree().docinfo
     if docinfo.doctype or docinfo.internalDTD is not None:
-        raise PackageLimitError(
+        raise MalformedPackageError(
             f"relationships for {base_uri!r} contain a prohibited DTD"
         )
     relationships_tag = (
@@ -363,7 +363,7 @@ def _validate_relationship_records(blob, base_uri) -> None:
         "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
     )
     if root.tag != relationships_tag:
-        raise PackageLimitError(
+        raise MalformedPackageError(
             f"relationships for {base_uri!r} have an unexpected root element"
         )
     seen = {}
@@ -371,24 +371,28 @@ def _validate_relationship_records(blob, base_uri) -> None:
         if not isinstance(child.tag, str):
             continue
         if child.tag != relationship_tag:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 f"relationships for {base_uri!r} contain an unexpected element"
             )
         relationship_id = child.get("Id")
         if not is_xml_id(relationship_id):
-            raise PackageLimitError(f"relationship Id {relationship_id!r} is not a valid XML ID")
+            raise MalformedPackageError(
+                f"relationship Id {relationship_id!r} is not a valid XML ID"
+            )
         target = child.get("Target")
         if relationship_id in seen:
-            raise PackageLimitError(
+            raise MalformedPackageError(
                 _duplicate_relationship_id_message(
                     base_uri, relationship_id, seen[relationship_id], target
                 )
             )
         seen[relationship_id] = target
         if not child.get("Type") or not child.get("Target"):
-            raise PackageLimitError(f"relationship {relationship_id!r} is missing Type or Target")
+            raise MalformedPackageError(
+                f"relationship {relationship_id!r} is missing Type or Target"
+            )
         if child.get("TargetMode", RTM.INTERNAL) not in (RTM.INTERNAL, RTM.EXTERNAL):
-            raise PackageLimitError(f"relationship {relationship_id!r} has invalid TargetMode")
+            raise MalformedPackageError(f"relationship {relationship_id!r} has invalid TargetMode")
 
 
 def _validate_package_relationships(relationships) -> None:
@@ -399,32 +403,20 @@ def _validate_package_relationships(relationships) -> None:
         if is_relationship_type(relationship.reltype, RT.OFFICE_DOCUMENT)
     ]
     if len(office_documents) > 1:
-        raise PackageLimitError(
+        raise MalformedPackageError(
             "package contains multiple officeDocument relationships"
         )
     if office_documents and office_documents[0].is_external:
-        raise PackageLimitError("package officeDocument relationship is external")
+        raise MalformedPackageError("package officeDocument relationship is external")
 
 
-_OFFICE_DOCUMENT_CONTENT_TYPES = (
-    CT.WML_DOCUMENT_MAIN,
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml",
-    "application/vnd.ms-word.document.macroEnabled.main+xml",
-    "application/vnd.ms-word.template.macroEnabledTemplate.main+xml",
-    CT.PML_PRESENTATION_MAIN,
-    CT.PML_SLIDESHOW_MAIN,
-    CT.PML_TEMPLATE_MAIN,
-    "application/vnd.ms-powerpoint.presentation.macroEnabled.main+xml",
-    "application/vnd.ms-powerpoint.slideshow.macroEnabled.main+xml",
-    "application/vnd.ms-powerpoint.template.macroEnabled.main+xml",
-    CT.SML_SHEET_MAIN,
-    CT.SML_TEMPLATE_MAIN,
-    "application/vnd.ms-excel.sheet.macroEnabled.main+xml",
-    "application/vnd.ms-excel.template.macroEnabled.main+xml",
-)
 _KNOWN_RELATIONSHIP_CONTENT_TYPES = (
     (RT.CORE_PROPERTIES, (CT.OPC_CORE_PROPERTIES,)),
-    (RT.OFFICE_DOCUMENT, _OFFICE_DOCUMENT_CONTENT_TYPES),
+    # -- RT.OFFICE_DOCUMENT is deliberately absent. `api.Document` already checks the
+    # -- main part's content type and raises ValueError naming the file and the type it
+    # -- found; that check is upstream's, byte-identical, and a caller migrating from
+    # -- python-docx may rely on it. Validating the same condition during package load
+    # -- only pre-empted it with a different exception type.
     (RT.STYLES, (CT.WML_STYLES, CT.SML_STYLES)),
     (RT.SETTINGS, (CT.WML_SETTINGS,)),
     (RT.NUMBERING, (CT.WML_NUMBERING,)),
@@ -450,7 +442,7 @@ def _validate_relationship_target_content_type(reltype, content_type, partname) 
             continue
         if any(content_type_matches(content_type, item) for item in expected_types):
             return
-        raise PackageLimitError(
+        raise MalformedPackageError(
             f"relationship type {reltype!r} targets {partname!s} with invalid content type"
             f" {content_type!r}"
         )

--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -261,6 +261,25 @@ class _SerializedRelationship:
         return self._target_partname
 
 
+def _duplicate_relationship_id_message(
+    base_uri, relationship_id, first_target, second_target
+) -> str:
+    """Word refuses both shapes; the caller's next step differs, so name which it is."""
+    if first_target == second_target:
+        return (
+            f"relationships for {base_uri!r} declare Id {relationship_id!r} twice for the"
+            f" same target {first_target!r}; a relationships part may use each Id only"
+            " once, so Word refuses to open the package even though the two declarations"
+            " agree. Delete the repeated Relationship element and keep one"
+        )
+    return (
+        f"relationships for {base_uri!r} point Id {relationship_id!r} at two different"
+        f" targets, {first_target!r} and {second_target!r}; nothing in the package says"
+        " which target the Id means, so Word refuses to open it. Give the second"
+        " relationship an Id of its own and repoint whatever refers to it"
+    )
+
+
 class _SerializedRelationships:
     """Read-only sequence of |_SerializedRelationship| instances corresponding to the
     relationships item XML passed to constructor."""
@@ -285,7 +304,7 @@ class _SerializedRelationships:
             if isinstance(rels_item_xml, (bytes, str)):
                 _validate_relationship_records(rels_item_xml, baseURI)
             rels_elm = parse_xml(rels_item_xml)
-            seen_ids = set()
+            seen_ids = {}
             for rel_elm in rels_elm.Relationship_lst:
                 serialized = _SerializedRelationship(baseURI, rel_elm)
                 if isinstance(serialized.rId, str) and not is_xml_id(serialized.rId):
@@ -294,10 +313,15 @@ class _SerializedRelationships:
                     )
                 if isinstance(serialized.rId, str) and serialized.rId in seen_ids:
                     raise PackageLimitError(
-                        f"relationships for {baseURI!r} contain duplicate Id {serialized.rId!r}"
+                        _duplicate_relationship_id_message(
+                            baseURI,
+                            serialized.rId,
+                            seen_ids[serialized.rId],
+                            serialized.target_ref,
+                        )
                     )
                 if isinstance(serialized.rId, str):
-                    seen_ids.add(serialized.rId)
+                    seen_ids[serialized.rId] = serialized.target_ref
                 if isinstance(serialized.target_mode, str) and serialized.target_mode not in (
                     RTM.INTERNAL,
                     RTM.EXTERNAL,
@@ -342,7 +366,7 @@ def _validate_relationship_records(blob, base_uri) -> None:
         raise PackageLimitError(
             f"relationships for {base_uri!r} have an unexpected root element"
         )
-    seen = set()
+    seen = {}
     for child in root:
         if not isinstance(child.tag, str):
             continue
@@ -353,11 +377,14 @@ def _validate_relationship_records(blob, base_uri) -> None:
         relationship_id = child.get("Id")
         if not is_xml_id(relationship_id):
             raise PackageLimitError(f"relationship Id {relationship_id!r} is not a valid XML ID")
+        target = child.get("Target")
         if relationship_id in seen:
             raise PackageLimitError(
-                f"relationships for {base_uri!r} contain duplicate Id {relationship_id!r}"
+                _duplicate_relationship_id_message(
+                    base_uri, relationship_id, seen[relationship_id], target
+                )
             )
-        seen.add(relationship_id)
+        seen[relationship_id] = target
         if not child.get("Type") or not child.get("Target"):
             raise PackageLimitError(f"relationship {relationship_id!r} is missing Type or Target")
         if child.get("TargetMode", RTM.INTERNAL) not in (RTM.INTERNAL, RTM.EXTERNAL):
@@ -412,13 +439,12 @@ _KNOWN_RELATIONSHIP_CONTENT_TYPES = (
 
 
 def _validate_relationship_target_content_type(reltype, content_type, partname) -> None:
-    """Reject a known role pointing at a part with an incompatible media type."""
-    if is_relationship_type(reltype, RT.IMAGE):
-        if content_type.partition(";")[0].strip().casefold().startswith("image/"):
-            return
-        raise PackageLimitError(
-            f"image relationship targets {partname!s} with invalid content type {content_type!r}"
-        )
+    """Reject a known role pointing at a part with an incompatible media type.
+
+    Only core parts carry a content-type requirement. Word opens a displayed image
+    declared ``application/octet-stream``, so media parts are deliberately unconstrained
+    and have no entry in the table below.
+    """
     for expected_reltype, expected_types in _KNOWN_RELATIONSHIP_CONTENT_TYPES:
         if not is_relationship_type(reltype, expected_reltype):
             continue

--- a/src/docx/protection.py
+++ b/src/docx/protection.py
@@ -4,8 +4,10 @@ Word's Restrict Editing pane writes `w:documentProtection` into
 word/settings.xml; Word then blocks or restricts editing. This package's own
 mutating APIs check that setting and refuse with |DocumentProtectedError|
 rather than silently editing a locked template — the same fail-loudly
-principle applied elsewhere in this fork. Upstream python-docx APIs are untouched
-(strict superset).
+principle applied elsewhere in this fork. The refusal follows Word's own rules,
+which are per-mode AND per-operation-class (see `_PROTECTION_MATRIX`): a
+comments-only restriction blocks body edits but still permits commenting.
+Upstream python-docx APIs are untouched (strict superset).
 
 Protection is ADVISORY, not security: the setting is plain XML anyone can
 remove. The sanctioned override is one explicit, document-level
@@ -18,7 +20,7 @@ reported by `protection_status` and never removed.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from docx._guard import check_install
 from docx._transaction import rollback_on_error
@@ -33,7 +35,68 @@ check_install()
 
 _ACK_ATTR = "_paper_protection_acknowledged"
 _TRUTHY = ("1", "true", "on")
-_EDIT_MODES = ("readOnly", "comments", "forms", "trackedChanges")
+
+# --- Operation classes -------------------------------------------------------
+#
+# Word's Restrict Editing rules are per-mode AND per-operation-class: `comments`
+# exists precisely to permit commenting while forbidding body edits, and `forms`
+# exists to permit filling a form field while locking everything around it. The
+# gate therefore needs to know what KIND of operation is being attempted, not
+# just that protection is enforced.
+OP_COMMENT = "comment"
+OP_FORM_FIELD = "form-field-value"
+OP_BODY = "body-content"
+OPERATION_CLASSES = (OP_COMMENT, OP_FORM_FIELD, OP_BODY)
+
+# The formatting-only row of the matrix: `w:formatting="1"` with no `w:edit`
+# restriction (or `w:edit="none"`). The key is a sentinel object rather than a
+# string so that no `w:edit` token can ever spell it: a document declaring
+# `w:edit="formatting-only"` is an unrecognised restriction and must refuse
+# every class, not land on this row. The noun the refusal message uses is a
+# separate name for the same reason in reverse — rewording the message must not
+# change which matrix row is looked up.
+_FORMATTING_ONLY = object()
+_FORMATTING_ONLY_NOUN = "formatting-only"
+
+# True = permit, False = refuse. Cells marked (measured) were verified in Word
+# for Mac on 2026-08-18 (verdict set `2-refused-operations`); see
+# verifying-against-word/WORD-VERDICTS.md, "The protection gate".
+#
+# TWO CELLS ARE UNMEASURED and ship PERMISSIVE: body content under
+# `trackedChanges` and under formatting-only. Word has not been asked about
+# either. A refusal with no Word verdict behind it is an unjustified
+# regression, and this gate is a policy mirror of Word's UI rather than a
+# corruption guard, so permitting cannot produce a file Word refuses. Both are
+# pinned by a test naming them unmeasured, so measuring one later changes a
+# test deliberately rather than silently.
+_PROTECTION_MATRIX: Dict[object, Dict[str, bool]] = {
+    #                    comment          form-field value  body content
+    "readOnly": {
+        OP_COMMENT: False,  # measured: blocked
+        OP_FORM_FIELD: False,  # measured: blocked
+        OP_BODY: False,  # measured: blocked
+    },
+    "comments": {
+        OP_COMMENT: True,  # measured: ALLOWED
+        OP_FORM_FIELD: False,  # unmeasured; the mode is not about form fields
+        OP_BODY: False,  # measured: blocked
+    },
+    "trackedChanges": {
+        OP_COMMENT: True,  # measured: ALLOWED
+        OP_FORM_FIELD: False,  # unmeasured; the mode is not about form fields
+        OP_BODY: True,  # UNMEASURED — ships permissive, see note above
+    },
+    "forms": {
+        OP_COMMENT: False,  # measured: blocked
+        OP_FORM_FIELD: True,  # measured: ALLOWED
+        OP_BODY: False,  # measured: blocked
+    },
+    _FORMATTING_ONLY: {
+        OP_COMMENT: True,  # measured: ALLOWED
+        OP_FORM_FIELD: True,  # unmeasured; no content restriction is declared
+        OP_BODY: True,  # UNMEASURED — ships permissive, see note above
+    },
+}
 _DOCUMENT_PROTECTION_SUCCESSORS = (
     "w:autoFormatOverride",
     "w:styleLockTheme",
@@ -101,6 +164,12 @@ _DOCUMENT_PROTECTION_SUCCESSORS = (
 )
 
 
+# `set_protection` accepts exactly the `w:edit` tokens the matrix has a row
+# for, so the two cannot drift apart. The formatting-only row is keyed by a
+# sentinel rather than a string, so it drops out here.
+_EDIT_MODES = tuple(mode for mode in _PROTECTION_MATRIX if isinstance(mode, str))
+
+
 def _is_on(value: Optional[str]) -> bool:
     return (value or "").lower() in _TRUTHY
 
@@ -134,7 +203,7 @@ class ProtectionStatus:
         }
 
 
-def _package_of(obj):
+def _package_of(obj: object):
     """The OPC package behind a |Document| or any Parented proxy/part."""
     part = getattr(obj, "part", None) or getattr(obj, "_part", None)
     if part is None:
@@ -207,12 +276,22 @@ def set_protection(document: "Document", *, edit: str) -> ProtectionStatus:
     return protection_status(document)
 
 
-def _refuse_if_protected(obj, operation: str) -> None:
+def _refuse_if_protected(
+    obj: object, operation: str, *, operation_class: str = OP_BODY
+) -> None:
     """Typed refusal when `obj`'s document enforces edit/format protection.
 
     `obj` is whatever the mutating API has in hand: a |Document|, or any
     proxy/part with a `.part` (Table, Paragraph, ...). Called BEFORE any
     mutation (refusal atomicity).
+
+    `operation_class` says what KIND of edit this is — one of `OP_COMMENT`,
+    `OP_FORM_FIELD`, `OP_BODY` — and is consulted against the declared
+    restriction mode via `_PROTECTION_MATRIX`. It defaults to `OP_BODY`, the
+    strictest class, so a call site added without a class keeps the
+    conservative behaviour rather than silently becoming permissive.
+    `operation` is unchanged: the class decides *whether* to refuse, the
+    operation string still says *what* was refused.
     """
     package = _package_of(obj)
     if getattr(package, _ACK_ATTR, False):
@@ -225,15 +304,20 @@ def _refuse_if_protected(obj, operation: str) -> None:
     enforcement = _is_on(element.get(qn("w:enforcement")))
     if (edit in (None, "none") and not formatting) or not enforcement:
         return
+    mode: object = edit if edit not in (None, "none") else _FORMATTING_ONLY
+    # An unrecognised `w:edit` token has no row: an unknown restriction is not
+    # a licence, so every class refuses.
+    if _PROTECTION_MATRIX.get(mode, {}).get(operation_class):
+        return
     restriction = (
-        f"{edit!r} editing"
-        if edit not in (None, "none")
-        else "formatting-only"
+        _FORMATTING_ONLY_NOUN if mode is _FORMATTING_ONLY else f"{edit!r} editing"
     )
     raise DocumentProtectedError(
-        f"cannot {operation}: this document enforces {restriction}"
-        " protection (w:documentProtection). Protection is advisory, not"
-        " security — if editing is intended, call"
+        f"cannot {operation}: this document is under Restrict Editing"
+        f" ({restriction} protection, w:documentProtection), and Word's own"
+        " UI would not permit this edit either. The document itself is fine —"
+        " this is a policy restriction, not a defect in the file. Protection"
+        " is advisory, not security: if the edit is intended, call"
         " docx.protection.acknowledge_protection(document) first; paper-docx"
         " never removes the protection setting itself"
     )

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -30,7 +30,7 @@ from docx.errors import (
 )
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
-from docx.protection import _refuse_if_protected
+from docx.protection import OP_COMMENT, _refuse_if_protected
 from docx.story import (
     VIEWS,
     Anchor,
@@ -418,7 +418,9 @@ class Span:
             _validate_xml_characters(initials, argument="initials")
         if date is not None and not isinstance(date, dt.datetime):
             raise TypeError("date must be a datetime or None")
-        _refuse_if_protected(self._document, "anchor a comment")
+        _refuse_if_protected(
+            self._document, "anchor a comment", operation_class=OP_COMMENT
+        )
         main_story = next(
             story
             for story, root in _story_elements(self._document)

--- a/tests/paper/test_audit_editing.py
+++ b/tests/paper/test_audit_editing.py
@@ -11,7 +11,6 @@ import docx
 from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import (
     BoundaryViolationError,
-    DocumentProtectedError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
@@ -459,7 +458,7 @@ class DescribeNumberingAudit:
 
 
 class DescribeFormatOnlyProtection:
-    def it_reports_and_enforces_formatting_only_protection(self):
+    def it_reports_formatting_only_protection(self):
         from docx.protection import acknowledge_protection, protection_status
         from docx.search import find_one
 
@@ -476,11 +475,14 @@ class DescribeFormatOnlyProtection:
         assert status.enforced
         assert status.blocks_paper_edits
         assert status.to_dict()["formatting"] is True
-        with pytest.raises(DocumentProtectedError, match="formatting-only"):
-            find_one(document, "protected formatting").replace("changed")
+        # The gate itself permits body content under a formatting-only
+        # restriction — an UNMEASURED cell that ships permissive. See
+        # tests/paper/test_word_protection_matrix.py, which owns that decision;
+        # `blocks_paper_edits` is a status report and is deliberately unchanged.
+        find_one(document, "protected formatting").replace("changed")
 
         acknowledge_protection(document)
-        find_one(document, "protected formatting").replace("changed")
+        find_one(document, "changed").replace("changed again")
 
 
 class DescribeFormattingDisclosure:

--- a/tests/paper/test_audit_package.py
+++ b/tests/paper/test_audit_package.py
@@ -16,7 +16,7 @@ import pytest
 
 import docx
 from docx._zipguard import GuardedZipReader
-from docx.errors import PackageLimitError, PaperRefusal
+from docx.errors import MalformedPackageError, PaperRefusal
 from docx.package import diagnose, diff_package, patch_save
 
 from .harness.paths import fixture_path
@@ -102,7 +102,7 @@ class DescribeZipStructureGuard:
             with zipfile.ZipFile(path, "w") as archive:
                 archive.writestr(info, b"elsewhere.xml")
 
-        with pytest.raises(PackageLimitError):
+        with pytest.raises(MalformedPackageError):
             _guarded_read(path)
 
     def it_rejects_case_ambiguous_names(self, tmp_path: Path):
@@ -111,7 +111,7 @@ class DescribeZipStructureGuard:
             path,
             (("word/document.xml", b"<one/>"), ("WORD/document.xml", b"<two/>")),
         )
-        with pytest.raises(PackageLimitError, match="case-ambiguous"):
+        with pytest.raises(MalformedPackageError, match="case-ambiguous"):
             _guarded_read(path)
 
 
@@ -140,7 +140,7 @@ class DescribeZipInflationHonesty:
         )
         _understate_expanded_size(path, declared_size=32)
 
-        with pytest.raises(PackageLimitError, match="declared size"):
+        with pytest.raises(MalformedPackageError, match="declared size"):
             _guarded_read(path)
 
     def it_rejects_undeclared_stored_bytes_even_with_matching_forged_crc(self, tmp_path: Path):
@@ -148,7 +148,7 @@ class DescribeZipInflationHonesty:
         _write_archive(path, (("word/media/data.bin", b"abcdefgh"),))
         _understate_stored_member(path, declared_data=b"abcd")
 
-        with pytest.raises(PackageLimitError, match="undeclared trailing data"):
+        with pytest.raises(MalformedPackageError, match="undeclared trailing data"):
             _guarded_read(path)
 
 
@@ -164,12 +164,12 @@ class DescribeGuardedPackageApis:
         out.write_bytes(sentinel)
         out.chmod(0o640)
 
-        assert issubclass(PackageLimitError, PaperRefusal)
-        with pytest.raises(PackageLimitError):
+        assert issubclass(MalformedPackageError, PaperRefusal)
+        with pytest.raises(MalformedPackageError):
             docx.Document(str(unsafe))
-        with pytest.raises(PackageLimitError):
+        with pytest.raises(MalformedPackageError):
             diff_package(source, unsafe)
-        with pytest.raises(PackageLimitError):
+        with pytest.raises(MalformedPackageError):
             patch_save(unsafe, document, out)
 
         assert out.read_bytes() == sentinel
@@ -333,7 +333,7 @@ class DescribeDirectoryEntries:
             )
             for name in zin.namelist():
                 zout.writestr(name, zin.read(name))
-        with pytest.raises(PackageLimitError, match="carries data"):
+        with pytest.raises(MalformedPackageError, match="carries data"):
             docx.Document(str(path))
 
     def and_it_validates_local_records_in_a_directory_only_archive(
@@ -347,5 +347,5 @@ class DescribeDirectoryEntries:
         data[local_offset : local_offset + 4] = b"BAD!"
         path.write_bytes(data)
 
-        with pytest.raises(PackageLimitError, match="invalid header"):
+        with pytest.raises(MalformedPackageError, match="invalid header"):
             _guarded_read(path)

--- a/tests/paper/test_audit_zip_preflight.py
+++ b/tests/paper/test_audit_zip_preflight.py
@@ -213,7 +213,9 @@ class DescribeArchiveMustBeginAtByteZero:
         target = tmp_path / "prefixed.docx"
         target.write_bytes(_prefixed_archive(self._clean(tmp_path), b"# self-extracting stub\n"))
 
-        with pytest.raises(MalformedPackageError, match="does not begin with a ZIP local file header"):
+        with pytest.raises(
+            MalformedPackageError, match="does not begin with a ZIP local file header"
+        ):
             docx.Document(str(target))
 
     def it_opens_the_same_document_without_the_prefix(self, tmp_path: Path):
@@ -246,5 +248,7 @@ class DescribeArchiveMustBeginAtByteZero:
         original = tmp_path / "prefixed.docx"
         original.write_bytes(_prefixed_archive(self._clean(tmp_path), b"#" * 64))
 
-        with pytest.raises(MalformedPackageError, match="does not begin with a ZIP local file header"):
+        with pytest.raises(
+            MalformedPackageError, match="does not begin with a ZIP local file header"
+        ):
             _paperpkg.patch_save(original, docx.Document(), tmp_path / "out.docx")

--- a/tests/paper/test_audit_zip_preflight.py
+++ b/tests/paper/test_audit_zip_preflight.py
@@ -10,7 +10,7 @@ import pytest
 
 import docx
 from docx import _paperpkg
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc import phys_pkg
 
 _END_RECORD = struct.Struct("<4s4H2LH")
@@ -115,7 +115,7 @@ class DescribeCentralDirectoryPreflight:
 
         monkeypatch.setattr(_paperpkg.zipfile, "ZipFile", UnexpectedZipFile)
 
-        with pytest.raises(PackageLimitError, match="too small for its member count"):
+        with pytest.raises(MalformedPackageError, match="too small for its member count"):
             _paperpkg._read_zip(path)
 
         assert constructions == 0
@@ -137,7 +137,7 @@ class DescribeCentralDirectoryPreflight:
 
         monkeypatch.setattr(phys_pkg, "ZipFile", UnexpectedZipFile)
 
-        with pytest.raises(PackageLimitError, match="too small for its member count"):
+        with pytest.raises(MalformedPackageError, match="too small for its member count"):
             docx.Document(path)
 
         assert constructions == 0
@@ -163,7 +163,7 @@ class DescribeCentralDirectoryPreflight:
 
         monkeypatch.setattr(_paperpkg.zipfile, "ZipFile", UnexpectedZipFile)
 
-        with pytest.raises(PackageLimitError, match="member count"):
+        with pytest.raises(MalformedPackageError, match="member count"):
             _paperpkg._read_zip(path)
 
         assert constructions == 0
@@ -213,7 +213,7 @@ class DescribeArchiveMustBeginAtByteZero:
         target = tmp_path / "prefixed.docx"
         target.write_bytes(_prefixed_archive(self._clean(tmp_path), b"# self-extracting stub\n"))
 
-        with pytest.raises(PackageLimitError, match="does not begin with a ZIP local file header"):
+        with pytest.raises(MalformedPackageError, match="does not begin with a ZIP local file header"):
             docx.Document(str(target))
 
     def it_opens_the_same_document_without_the_prefix(self, tmp_path: Path):
@@ -246,5 +246,5 @@ class DescribeArchiveMustBeginAtByteZero:
         original = tmp_path / "prefixed.docx"
         original.write_bytes(_prefixed_archive(self._clean(tmp_path), b"#" * 64))
 
-        with pytest.raises(PackageLimitError, match="does not begin with a ZIP local file header"):
+        with pytest.raises(MalformedPackageError, match="does not begin with a ZIP local file header"):
             _paperpkg.patch_save(original, docx.Document(), tmp_path / "out.docx")

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -15,7 +15,7 @@ import docx
 import docx._paperpkg as paperpkg_module
 import docx.opc.package as package_module
 from docx._transaction import rollback_on_error
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.packuri import PackURI
 from docx.opc.part import Part
@@ -84,7 +84,7 @@ def it_refuses_a_dtd_before_parsing_relationship_records():
       <Relationship Id="rId1" Type="&role;" Target="word/document.xml"/>
     </Relationships>"""
 
-    with pytest.raises(PackageLimitError, match="prohibited DTD"):
+    with pytest.raises(MalformedPackageError, match="prohibited DTD"):
         _SerializedRelationships.load_from_xml("/", relationships)
 
 
@@ -116,7 +116,7 @@ def it_validates_patch_save_after_final_recompression(
         lambda _parts, _order: bytes(payload),
     )
 
-    with pytest.raises(PackageLimitError, match="encrypted"):
+    with pytest.raises(MalformedPackageError, match="encrypted"):
         patch_save(source, document, destination)
 
     assert destination.read_bytes() == b"existing destination"
@@ -296,7 +296,7 @@ def it_refuses_a_symlinked_member_in_an_expanded_package(tmp_path: Path):
     member.replace(outside)
     member.symlink_to(outside)
 
-    with pytest.raises(PackageLimitError, match="symbolic link"):
+    with pytest.raises(MalformedPackageError, match="symbolic link"):
         docx.Document(expanded)
 
 
@@ -306,7 +306,7 @@ def it_refuses_duplicate_relationship_ids():
       <Relationship Id="rId1" Type="urn:two" Target="two.xml"/>
     </Relationships>"""
 
-    with pytest.raises(PackageLimitError, match="two different targets"):
+    with pytest.raises(MalformedPackageError, match="two different targets"):
         _SerializedRelationships.load_from_xml("/word", relationships)
 
 
@@ -320,7 +320,7 @@ def it_refuses_multiple_main_document_relationships_before_replacing_a_path(
         RT.OFFICE_DOCUMENT, document.part, "rIdDuplicateMain"
     )
 
-    with pytest.raises(PackageLimitError, match="multiple officeDocument"):
+    with pytest.raises(MalformedPackageError, match="multiple officeDocument"):
         document.save(destination)
 
     assert destination.read_bytes() == b"original"
@@ -352,7 +352,7 @@ def it_refuses_unexpected_relationship_elements_instead_of_dropping_them():
             blob = etree.tostring(root, encoding="UTF-8", standalone=True)
         return name, blob
 
-    with pytest.raises(PackageLimitError, match="unexpected element"):
+    with pytest.raises(MalformedPackageError, match="unexpected element"):
         docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
 
 
@@ -372,11 +372,39 @@ def it_validates_case_insensitive_content_types_without_losing_duplicates():
             etree.tostring(root, encoding="UTF-8", standalone=True),
         )
 
-    with pytest.raises(PackageLimitError, match="ambiguous Override"):
+    with pytest.raises(MalformedPackageError, match="ambiguous Override"):
         docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
 
 
 def it_refuses_a_known_relationship_role_with_the_wrong_content_type():
+    """A core part declared as the wrong media type is refused.
+
+    Uses the styles role rather than officeDocument: Word refuses `styles.xml`
+    declared `application/xml`, so this is the Word-verified case. The main-document
+    role is deliberately not checked here -- see the test below.
+    """
+
+    def transform(name: str, blob: bytes):
+        if name == "[Content_Types].xml":
+            blob = blob.replace(
+                b"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+                b"application/xml",
+            )
+        return name, blob
+
+    with pytest.raises(MalformedPackageError, match="invalid content type"):
+        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+
+
+def it_leaves_the_main_document_content_type_check_to_upstream():
+    """The officeDocument role is not validated during load, on purpose.
+
+    `api.Document` already checks the main part's content type and raises `ValueError`
+    naming the file and the type it found. That check is upstream's, byte-identical,
+    and a caller migrating from python-docx may rely on it. Validating the same
+    condition during package load only pre-empted it with a different exception type.
+    """
+
     def transform(name: str, blob: bytes):
         if name == "[Content_Types].xml":
             blob = blob.replace(
@@ -385,7 +413,7 @@ def it_refuses_a_known_relationship_role_with_the_wrong_content_type():
             )
         return name, blob
 
-    with pytest.raises(PackageLimitError, match="invalid content type"):
+    with pytest.raises(ValueError, match="is not a Word file, content type is"):
         docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
 
 
@@ -395,7 +423,7 @@ def it_refuses_a_relationship_to_a_missing_package_part():
         lambda name, blob: None if name == "word/styles.xml" else (name, blob),
     )
 
-    with pytest.raises(PackageLimitError, match="targets missing package part"):
+    with pytest.raises(MalformedPackageError, match="targets missing package part"):
         docx.Document(io.BytesIO(data))
 
 
@@ -413,7 +441,7 @@ def it_refuses_a_relationship_target_without_a_declared_content_type():
             blob = etree.tostring(root, encoding="UTF-8", standalone=True)
         return name, blob
 
-    with pytest.raises(PackageLimitError, match="no declared content type"):
+    with pytest.raises(MalformedPackageError, match="no declared content type"):
         docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
 
 

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -376,24 +376,10 @@ def it_validates_case_insensitive_content_types_without_losing_duplicates():
         docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
 
 
-def it_refuses_a_known_relationship_role_with_the_wrong_content_type():
-    """A core part declared as the wrong media type is refused.
-
-    Uses the styles role rather than officeDocument: Word refuses `styles.xml`
-    declared `application/xml`, so this is the Word-verified case. The main-document
-    role is deliberately not checked here -- see the test below.
-    """
-
-    def transform(name: str, blob: bytes):
-        if name == "[Content_Types].xml":
-            blob = blob.replace(
-                b"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
-                b"application/xml",
-            )
-        return name, blob
-
-    with pytest.raises(MalformedPackageError, match="invalid content type"):
-        docx.Document(io.BytesIO(_rewrite_package(_document_bytes(), transform)))
+# The "known relationship role declared with the wrong content type" mechanism is
+# covered by test_word_media_content_types.py, which mutates the styles role -- the
+# case Word actually verified -- and asserts the declaration changed before opening.
+# This file keeps only the main-document exception, below.
 
 
 def it_leaves_the_main_document_content_type_check_to_upstream():

--- a/tests/paper/test_practical_opc_hardening.py
+++ b/tests/paper/test_practical_opc_hardening.py
@@ -306,7 +306,7 @@ def it_refuses_duplicate_relationship_ids():
       <Relationship Id="rId1" Type="urn:two" Target="two.xml"/>
     </Relationships>"""
 
-    with pytest.raises(PackageLimitError, match="duplicate Id"):
+    with pytest.raises(PackageLimitError, match="two different targets"):
         _SerializedRelationships.load_from_xml("/word", relationships)
 
 

--- a/tests/paper/test_word_media_content_types.py
+++ b/tests/paper/test_word_media_content_types.py
@@ -18,7 +18,7 @@ import zipfile
 import pytest
 
 import docx
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
@@ -77,5 +77,5 @@ def it_still_refuses_a_core_part_declared_with_a_generic_content_type():
     data = _rewrite_package(_document_with_image_bytes(), transform)
     assert b'PartName="/word/styles.xml" ContentType="application/xml"' in _content_types(data)
 
-    with pytest.raises(PackageLimitError, match="invalid content type"):
+    with pytest.raises(MalformedPackageError, match="invalid content type"):
         docx.Document(io.BytesIO(data))

--- a/tests/paper/test_word_media_content_types.py
+++ b/tests/paper/test_word_media_content_types.py
@@ -1,0 +1,81 @@
+"""Word's content-type rule is about core parts, not media parts.
+
+Measured in Word (see ``verifying-against-word/WORD-VERDICTS.md``, "Content types"):
+
+- ``image_octet_stream`` — a displayed image declared ``application/octet-stream`` —
+  **OPENS**.
+- ``styles_generic_ct`` — ``word/styles.xml`` declared ``application/xml`` — **REFUSES**.
+
+The pair is what documents the split. Either test alone invites re-tightening the media
+side or loosening the core side.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+import docx
+from docx.errors import PackageLimitError
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+from .test_composition import TINY_PNG
+from .test_practical_opc_hardening import _rewrite_package
+
+_STYLES_CT = CT.WML_STYLES.encode()
+
+
+def _content_types(data: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(data)) as package:
+        return package.read("[Content_Types].xml")
+
+
+def _document_with_image_bytes() -> bytes:
+    document = docx.Document()
+    document.add_paragraph("before the image")
+    document.add_picture(io.BytesIO(TINY_PNG))
+    stream = io.BytesIO()
+    document.save(stream)
+    return stream.getvalue()
+
+
+def _image_blobs(document) -> list[bytes]:
+    return [
+        rel.target_part.blob
+        for rel in document.part.rels.values()
+        if not rel.is_external and rel.reltype == RT.IMAGE
+    ]
+
+
+def it_opens_a_displayed_image_declared_application_octet_stream():
+    def transform(name: str, blob: bytes):
+        if name == "[Content_Types].xml":
+            blob = blob.replace(
+                b'ContentType="image/png"', b'ContentType="application/octet-stream"'
+            )
+        return name, blob
+
+    data = _rewrite_package(_document_with_image_bytes(), transform)
+    assert b'Extension="png" ContentType="application/octet-stream"' in _content_types(data)
+
+    document = docx.Document(io.BytesIO(data))
+
+    assert document.paragraphs[0].text == "before the image"
+    assert len(document.inline_shapes) == 1
+    assert _image_blobs(document) == [TINY_PNG]
+
+
+def it_still_refuses_a_core_part_declared_with_a_generic_content_type():
+    def transform(name: str, blob: bytes):
+        if name == "[Content_Types].xml":
+            blob = blob.replace(_STYLES_CT, b"application/xml")
+        return name, blob
+
+    data = _rewrite_package(_document_with_image_bytes(), transform)
+    assert b'PartName="/word/styles.xml" ContentType="application/xml"' in _content_types(data)
+
+    with pytest.raises(PackageLimitError, match="invalid content type"):
+        docx.Document(io.BytesIO(data))

--- a/tests/paper/test_word_part_name_legality.py
+++ b/tests/paper/test_word_part_name_legality.py
@@ -19,7 +19,7 @@ import pytest
 import docx
 from docx import _paperpkg
 from docx._zipguard import _validate_member_name
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 
 from .test_audit_zip_preflight import _write_archive
 
@@ -41,7 +41,7 @@ class DescribeWordVerdictMemberNames:
 
     def it_refuses_a_literal_space_naming_the_character(self):
         # Word: REFUSES
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/media/my image.png")
         message = str(exc.value)
         assert "' '" in message
@@ -49,13 +49,13 @@ class DescribeWordVerdictMemberNames:
 
     def it_refuses_a_raw_non_ascii_name_in_composed_form(self):
         # Word: REFUSES
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name(_NFC_NAME)
         assert "non-ASCII character" in str(exc.value)
 
     def it_refuses_a_raw_non_ascii_name_in_decomposed_form(self):
         # Word: REFUSES. Refused for being non-ASCII, not for its normal form.
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name(_NFD_NAME)
         message = str(exc.value)
         assert "non-ASCII character" in message
@@ -63,7 +63,7 @@ class DescribeWordVerdictMemberNames:
 
     def it_refuses_a_percent_escaped_composed_non_ascii_name(self):
         # Word: REFUSES
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/media/imag%C3%A91.png")
         message = str(exc.value)
         assert "percent-escapes the non-ASCII byte 0xC3" in message
@@ -71,7 +71,7 @@ class DescribeWordVerdictMemberNames:
 
     def it_refuses_a_percent_escaped_decomposed_non_ascii_name(self):
         # Word: REFUSES
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/media/image%CC%811.png")
         assert "percent-escapes the non-ASCII byte 0xCC" in str(exc.value)
 
@@ -97,24 +97,24 @@ class DescribeContentTypesExemption:
         _validate_member_name("[CONTENT_TYPES].XML")
 
     def it_does_not_exempt_brackets_in_any_other_member(self):
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/[Content_Types].xml")
         assert "not legal in an OPC part name" in str(exc.value)
 
 
 class DescribeMemberNameMessagesAreNotShadowed:
     def it_still_names_a_control_character_rather_than_an_illegal_literal(self):
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/med\x01ia.png")
         assert "contains a control character" in str(exc.value)
 
     def it_still_names_a_malformed_escape_rather_than_an_illegal_literal(self):
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/media/x%ZZ.png")
         assert "noncanonical percent escape" in str(exc.value)
 
     def it_still_names_an_unsafe_escape_of_an_unreserved_character(self):
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _validate_member_name("word/media/x%41.png")
         assert "unsafe percent escape" in str(exc.value)
 
@@ -126,7 +126,7 @@ class DescribePartNameLegalityOnRead:
         path = tmp_path / "spaced.docx"
         _write_archive(path, (("word/media/my image.png", b"payload"),))
 
-        with pytest.raises(PackageLimitError, match="not legal in an OPC part name"):
+        with pytest.raises(MalformedPackageError, match="not legal in an OPC part name"):
             _paperpkg._read_zip(path)
 
     def it_reads_a_package_whose_member_name_escapes_an_ascii_space(

--- a/tests/paper/test_word_part_name_legality.py
+++ b/tests/paper/test_word_part_name_legality.py
@@ -1,0 +1,140 @@
+"""Part-name legality, pinned to measured Microsoft Word verdicts.
+
+Word was shown seven spellings of the same renamed media part. One rule accounts
+for every verdict: a part name may contain only ASCII characters that are legal
+in a URI path, and a percent escape is acceptable only where it encodes such a
+character. ``[Content_Types].xml`` is a reserved package item rather than an OPC
+part name and is exempt — it carries ``[`` and ``]``, neither of which is legal.
+
+Ledger: ``verifying-against-word/WORD-VERDICTS.md``, "Member names".
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+import docx
+from docx import _paperpkg
+from docx._zipguard import _validate_member_name
+from docx.errors import PackageLimitError
+
+from .test_audit_zip_preflight import _write_archive
+
+_NFC_NAME = "word/media/" + unicodedata.normalize("NFC", "imagé1.png")
+_NFD_NAME = "word/media/" + unicodedata.normalize("NFD", "imagé1.png")
+
+
+class DescribeWordVerdictMemberNames:
+    """One test per row of the ledger's seven-row member-name table."""
+
+    def it_accepts_a_plain_ascii_renamed_media_part(self):
+        # Word: OPENS (the rename mechanism control)
+        _validate_member_name("word/media/renamed1.png")
+
+    def it_accepts_a_percent_escaped_ascii_space(self):
+        # Word: OPENS. This is the row a literal-character pass placed ahead of
+        # the escape walk breaks, because "%" is not itself a legal literal.
+        _validate_member_name("word/media/my%20image.png")
+
+    def it_refuses_a_literal_space_naming_the_character(self):
+        # Word: REFUSES
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/media/my image.png")
+        message = str(exc.value)
+        assert "' '" in message
+        assert "not legal in an OPC part name" in message
+
+    def it_refuses_a_raw_non_ascii_name_in_composed_form(self):
+        # Word: REFUSES
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name(_NFC_NAME)
+        assert "non-ASCII character" in str(exc.value)
+
+    def it_refuses_a_raw_non_ascii_name_in_decomposed_form(self):
+        # Word: REFUSES. Refused for being non-ASCII, not for its normal form.
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name(_NFD_NAME)
+        message = str(exc.value)
+        assert "non-ASCII character" in message
+        assert "Unicode-normalized" not in message
+
+    def it_refuses_a_percent_escaped_composed_non_ascii_name(self):
+        # Word: REFUSES
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/media/imag%C3%A91.png")
+        message = str(exc.value)
+        assert "percent-escapes the non-ASCII byte 0xC3" in message
+        assert "may escape only ASCII characters" in message
+
+    def it_refuses_a_percent_escaped_decomposed_non_ascii_name(self):
+        # Word: REFUSES
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/media/image%CC%811.png")
+        assert "percent-escapes the non-ASCII byte 0xCC" in str(exc.value)
+
+
+class DescribeContentTypesExemption:
+    def it_accepts_the_content_types_stream_despite_its_brackets(self):
+        _validate_member_name("[Content_Types].xml")
+
+    def it_still_reopens_a_document_it_just_saved(self, tmp_path: Path):
+        path = tmp_path / "roundtrip.docx"
+        document = docx.Document()
+        document.add_paragraph("exempt")
+        document.save(path)
+
+        reopened = docx.Document(path)
+
+        assert [paragraph.text for paragraph in reopened.paragraphs] == ["exempt"]
+
+    def it_exempts_a_case_variant_spelling_of_the_same_package_item(self):
+        # A case-variant content-types stream is the same package item, and must
+        # keep reaching its own content-types diagnosis rather than be renamed a
+        # character defect by this rule.
+        _validate_member_name("[CONTENT_TYPES].XML")
+
+    def it_does_not_exempt_brackets_in_any_other_member(self):
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/[Content_Types].xml")
+        assert "not legal in an OPC part name" in str(exc.value)
+
+
+class DescribeMemberNameMessagesAreNotShadowed:
+    def it_still_names_a_control_character_rather_than_an_illegal_literal(self):
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/med\x01ia.png")
+        assert "contains a control character" in str(exc.value)
+
+    def it_still_names_a_malformed_escape_rather_than_an_illegal_literal(self):
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/media/x%ZZ.png")
+        assert "noncanonical percent escape" in str(exc.value)
+
+    def it_still_names_an_unsafe_escape_of_an_unreserved_character(self):
+        with pytest.raises(PackageLimitError) as exc:
+            _validate_member_name("word/media/x%41.png")
+        assert "unsafe percent escape" in str(exc.value)
+
+
+class DescribePartNameLegalityOnRead:
+    def it_refuses_a_package_carrying_a_literal_space_in_a_member_name(
+        self, tmp_path: Path
+    ):
+        path = tmp_path / "spaced.docx"
+        _write_archive(path, (("word/media/my image.png", b"payload"),))
+
+        with pytest.raises(PackageLimitError, match="not legal in an OPC part name"):
+            _paperpkg._read_zip(path)
+
+    def it_reads_a_package_whose_member_name_escapes_an_ascii_space(
+        self, tmp_path: Path
+    ):
+        path = tmp_path / "escaped.docx"
+        _write_archive(path, (("word/media/my%20image.png", b"payload"),))
+
+        parts, _ = _paperpkg._read_zip(path)
+
+        assert parts == {"word/media/my%20image.png": b"payload"}

--- a/tests/paper/test_word_prefix_collisions.py
+++ b/tests/paper/test_word_prefix_collisions.py
@@ -1,0 +1,201 @@
+"""Directory-prefix collisions, pinned to measured Microsoft Word verdicts.
+
+Word was shown three spellings of the same collision: a zero-length member named
+``word`` sitting beside members under ``word/``. It refused all three -- plain,
+with the MS-DOS directory bit set, and with a unix directory mode -- so the
+colliding *name* is the defect and the attributes are incidental. Word opens a
+package carrying ordinary zero-length ``word/`` folder records, so the rule must
+apply to members only.
+
+Ledger: ``verifying-against-word/WORD-VERDICTS.md``, the ``prefix_collision_*``
+rows.
+"""
+
+from __future__ import annotations
+
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import docx
+from docx import _paperpkg
+from docx.errors import PackageLimitError
+
+_COLLIDING_MEMBERS = ("word/document.xml", "word/_rels/document.xml.rels")
+
+
+def _write_collision(path: Path, external_attr: int) -> None:
+    """Write an archive whose member ``word`` collides with the ``word/`` tree.
+
+    ``word`` is written first, as it is in every recorded fixture: that ordering
+    is what makes a per-member attribute check report the wrong defect.
+    """
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        info = zipfile.ZipInfo("word")
+        info.external_attr = external_attr
+        archive.writestr(info, b"")
+        for name in _COLLIDING_MEMBERS:
+            archive.writestr(name, b"payload")
+
+
+def _repack_with_folder_records(source: Path, target: Path) -> None:
+    """Copy a package, inserting zero-length folder records ahead of it.
+
+    ``ZIP_STORED`` is load-bearing: a deflated empty member carries a two-byte
+    payload and is refused as a directory entry carrying data, which is a
+    different defect and would make this control misleading.
+    """
+    with zipfile.ZipFile(source) as original:
+        members = [(info.filename, original.read(info.filename)) for info in original.infolist()]
+
+    with zipfile.ZipFile(target, "w", compression=zipfile.ZIP_STORED) as archive:
+        for folder in ("word/", "word/_rels/", "docProps/", "word/media/"):
+            info = zipfile.ZipInfo(folder)
+            info.external_attr = (stat.S_IFDIR | 0o755) << 16 | 0x10
+            archive.writestr(info, b"")
+        for name, data in members:
+            archive.writestr(name, data)
+
+
+class DescribeWordVerdictPrefixCollisions:
+    """All three shapes refuse, and all three name the collision."""
+
+    @pytest.mark.parametrize(
+        ("shape", "external_attr"),
+        [
+            ("plain", 0),
+            ("dosbit", 0x10),
+            ("dirmode", (stat.S_IFDIR | 0o755) << 16),
+        ],
+    )
+    def it_refuses_every_measured_collision_shape(
+        self, tmp_path: Path, shape: str, external_attr: int
+    ):
+        # Word: REFUSES, for all three.
+        path = tmp_path / f"collision-{shape}.docx"
+        _write_collision(path, external_attr)
+
+        with pytest.raises(PackageLimitError) as exc:
+            _paperpkg._read_zip(path)
+
+        message = str(exc.value)
+        assert "'word'" in message
+        assert "directory prefix of member 'word/" in message
+        assert "one name cannot denote both a file and a directory" in message
+        assert "Remove the member named 'word'." in message
+
+    @pytest.mark.parametrize(
+        ("shape", "external_attr"),
+        [
+            ("plain", 0),
+            ("dosbit", 0x10),
+            ("dirmode", (stat.S_IFDIR | 0o755) << 16),
+        ],
+    )
+    def it_names_the_collision_rather_than_the_attributes(
+        self, tmp_path: Path, shape: str, external_attr: int
+    ):
+        # The pre-pass placement is what makes this true: inside the per-member
+        # loop the shallow member's attribute check fires first for two of the
+        # three shapes and reports the wrong defect.
+        path = tmp_path / f"collision-{shape}.docx"
+        _write_collision(path, external_attr)
+
+        with pytest.raises(PackageLimitError) as exc:
+            _paperpkg._read_zip(path)
+
+        message = str(exc.value)
+        assert "is a directory entry" not in message
+        assert "unsupported filesystem entry type" not in message
+
+    def it_refuses_a_collision_nested_deeper_than_the_top_level(self, tmp_path: Path):
+        path = tmp_path / "deep.docx"
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("word/media", b"")
+            archive.writestr("word/media/image1.png", b"payload")
+
+        with pytest.raises(PackageLimitError) as exc:
+            _paperpkg._read_zip(path)
+
+        assert "'word/media'" in str(exc.value)
+
+    def it_reads_a_package_whose_names_merely_share_a_prefix_string(self, tmp_path: Path):
+        # "word" is a string prefix of "wordy.xml" but not a directory prefix.
+        path = tmp_path / "sharedstring.docx"
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("word", b"")
+            archive.writestr("wordy.xml", b"payload")
+
+        parts, _ = _paperpkg._read_zip(path)
+
+        assert set(parts) == {"word", "wordy.xml"}
+
+
+class DescribeFolderRecordsStillOpen:
+    """Zero-length ``word/`` folder records are confirmed OPENS in Word."""
+
+    def it_opens_a_package_carrying_zero_length_folder_records(self, tmp_path: Path):
+        source = tmp_path / "plain.docx"
+        document = docx.Document()
+        document.add_paragraph("folder records")
+        document.save(source)
+        repacked = tmp_path / "foldered.docx"
+        _repack_with_folder_records(source, repacked)
+
+        reopened = docx.Document(repacked)
+
+        assert [paragraph.text for paragraph in reopened.paragraphs] == ["folder records"]
+
+    def it_opens_an_ordinary_package_unchanged(self, tmp_path: Path):
+        path = tmp_path / "ordinary.docx"
+        document = docx.Document()
+        document.add_paragraph("ordinary")
+        document.save(path)
+
+        reopened = docx.Document(path)
+
+        assert [paragraph.text for paragraph in reopened.paragraphs] == ["ordinary"]
+
+
+class DescribeNonCollidingAttributedMembers:
+    """The two attribute checks stay; this phase moves exactly one fixture.
+
+    A directory-attributed member that collides with nothing has no Word verdict.
+    Both checks are kept, so both refusals are pinned here as today's behaviour
+    rather than left incidental.
+    """
+
+    def it_still_refuses_a_ms_dos_directory_bit_on_a_non_colliding_member(self, tmp_path: Path):
+        path = tmp_path / "dosbit.docx"
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("notes")
+            info.external_attr = 0x10
+            archive.writestr(info, b"")
+
+        with pytest.raises(PackageLimitError) as exc:
+            _paperpkg._read_zip(path)
+
+        assert "is a directory entry" in str(exc.value)
+
+    def it_still_refuses_a_unix_directory_mode_on_a_non_colliding_member(self, tmp_path: Path):
+        path = tmp_path / "dirmode.docx"
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("notes")
+            info.external_attr = (stat.S_IFDIR | 0o755) << 16
+            archive.writestr(info, b"")
+
+        with pytest.raises(PackageLimitError) as exc:
+            _paperpkg._read_zip(path)
+
+        assert "unsupported filesystem entry type" in str(exc.value)
+
+    def it_still_reads_a_plain_non_colliding_member(self, tmp_path: Path):
+        path = tmp_path / "plainmember.docx"
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("notes", b"payload")
+
+        parts, _ = _paperpkg._read_zip(path)
+
+        assert parts == {"notes": b"payload"}

--- a/tests/paper/test_word_prefix_collisions.py
+++ b/tests/paper/test_word_prefix_collisions.py
@@ -21,7 +21,7 @@ import pytest
 
 import docx
 from docx import _paperpkg
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 
 _COLLIDING_MEMBERS = ("word/document.xml", "word/_rels/document.xml.rels")
 
@@ -77,7 +77,7 @@ class DescribeWordVerdictPrefixCollisions:
         path = tmp_path / f"collision-{shape}.docx"
         _write_collision(path, external_attr)
 
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _paperpkg._read_zip(path)
 
         message = str(exc.value)
@@ -103,7 +103,7 @@ class DescribeWordVerdictPrefixCollisions:
         path = tmp_path / f"collision-{shape}.docx"
         _write_collision(path, external_attr)
 
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _paperpkg._read_zip(path)
 
         message = str(exc.value)
@@ -116,7 +116,7 @@ class DescribeWordVerdictPrefixCollisions:
             archive.writestr("word/media", b"")
             archive.writestr("word/media/image1.png", b"payload")
 
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _paperpkg._read_zip(path)
 
         assert "'word/media'" in str(exc.value)
@@ -174,7 +174,7 @@ class DescribeNonCollidingAttributedMembers:
             info.external_attr = 0x10
             archive.writestr(info, b"")
 
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _paperpkg._read_zip(path)
 
         assert "is a directory entry" in str(exc.value)
@@ -186,7 +186,7 @@ class DescribeNonCollidingAttributedMembers:
             info.external_attr = (stat.S_IFDIR | 0o755) << 16
             archive.writestr(info, b"")
 
-        with pytest.raises(PackageLimitError) as exc:
+        with pytest.raises(MalformedPackageError) as exc:
             _paperpkg._read_zip(path)
 
         assert "unsupported filesystem entry type" in str(exc.value)

--- a/tests/paper/test_word_protection_matrix.py
+++ b/tests/paper/test_word_protection_matrix.py
@@ -1,0 +1,512 @@
+"""The protection gate, cell by cell against Word's measured behaviour.
+
+Word's Restrict Editing rules are per-mode AND per-operation-class. The verdict
+set `2-refused-operations` (Word for Mac, 2026-08-18) measured them:
+
+| `w:edit`         | comment | form-field value | body content |
+|------------------|---------|------------------|--------------|
+| `readOnly`       | refuse  | refuse           | refuse       |
+| `comments`       | PERMIT  | refuse           | refuse       |
+| `trackedChanges` | PERMIT  | refuse           | PERMIT (u)   |
+| `forms`          | refuse  | PERMIT           | refuse       |
+| formatting-only  | PERMIT  | PERMIT           | PERMIT (u)   |
+
+"(u)" marks the two cells Word has NOT been asked about. They ship permissive:
+a refusal with no Word verdict behind it is an unjustified regression, and this
+gate is a policy mirror of Word's UI rather than a corruption guard, so
+permitting cannot produce a file Word refuses. See
+`it_permits_the_two_unmeasured_body_content_cells` — measuring one later should
+change that test deliberately.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import io
+import pathlib
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import pytest
+
+import docx
+from docx.controls import iter_controls
+from docx.drawing import Drawing
+from docx.errors import DocumentProtectedError
+from docx.links import add_hyperlink
+from docx.notes import add_footnote
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import OxmlElement, parse_xml
+from docx.protection import (
+    _DOCUMENT_PROTECTION_SUCCESSORS,
+    OP_BODY,
+    OP_COMMENT,
+    OP_FORM_FIELD,
+    OPERATION_CLASSES,
+    acknowledge_protection,
+)
+from docx.search import find_one
+
+from .test_composition import TINY_PNG
+
+# -- fixture helpers ---------------------------------------------------------
+
+BODY_PHRASE = "an ordinary sentence of body text"
+
+
+def _protect(
+    document: "docx.document.Document",
+    *,
+    edit: Optional[str] = None,
+    formatting: bool = False,
+    enforcement: bool = True,
+) -> "docx.document.Document":
+    """Write `w:documentProtection` at its schema position.
+
+    `_DOCUMENT_PROTECTION_SUCCESSORS` is the CT_Settings child sequence that
+    follows `w:documentProtection`, so inserting before the first of them puts
+    the element ahead of `w:defaultTabStop` where the schema requires it.
+    """
+    element = OxmlElement("w:documentProtection")
+    if edit is not None:
+        element.set(qn("w:edit"), edit)
+    if formatting:
+        element.set(qn("w:formatting"), "1")
+    if enforcement:
+        element.set(qn("w:enforcement"), "1")
+    settings = document.settings.element
+    settings.insert_element_before(element, *_DOCUMENT_PROTECTION_SUCCESSORS)
+    return document
+
+
+def _document() -> "docx.document.Document":
+    document = docx.Document()
+    document.add_paragraph(BODY_PHRASE)
+    return document
+
+
+def _control_document() -> Tuple["docx.document.Document", None]:
+    """A document carrying one plain inline content control (a form field)."""
+    document = _document()
+    paragraph = parse_xml(
+        f"<w:p {nsdecls('w')}>"
+        "<w:sdt>"
+        "<w:sdtPr>"
+        '<w:alias w:val="Field"/><w:tag w:val="field-1"/><w:id w:val="4242"/>'
+        "</w:sdtPr>"
+        "<w:sdtContent><w:r><w:t>controlled text</w:t></w:r></w:sdtContent>"
+        "</w:sdt>"
+        "</w:p>"
+    )
+    body = document.element.body
+    sect_pr = body.find(qn("w:sectPr"))
+    if sect_pr is not None:
+        sect_pr.addprevious(paragraph)
+    else:
+        body.append(paragraph)
+    return document, None
+
+
+# -- the operations, as real API calls ----------------------------------------
+#
+# Each entry is (setup, action). `setup` returns the fully populated document
+# and whatever handle `action` needs; protection is applied BETWEEN the two, so
+# the setup itself never trips the gate.
+
+
+def _plain_document() -> Tuple["docx.document.Document", None]:
+    return _document(), None
+
+
+def _document_with_picture() -> Tuple["docx.document.Document", Drawing]:
+    document = _document()
+    run = document.add_paragraph().add_run()
+    run.add_picture(io.BytesIO(TINY_PNG))
+    drawing = next(item for item in run.iter_inner_content() if isinstance(item, Drawing))
+    return document, drawing
+
+
+def _document_with_hyperlink() -> Tuple["docx.document.Document", Any]:
+    document = _document()
+    link = add_hyperlink(document, find_one(document, "ordinary"), "https://example.com/a")
+    return document, link
+
+
+def _retarget(document: "docx.document.Document", link: Any) -> None:
+    link.address = "https://example.com/b"
+
+
+OPERATIONS: Dict[str, Tuple[Callable[[], Tuple[Any, Any]], Callable[[Any, Any], Any]]] = {
+    # `comments.py` -> `_refuse_document_protection` -> the gate
+    "comment": (
+        _plain_document,
+        lambda document, _: document.comments.add_comment("note", author="A"),
+    ),
+    # `search.py:Span.comment` and the `commentops` range funnel
+    "anchored-comment": (
+        _plain_document,
+        lambda document, _: find_one(document, BODY_PHRASE).comment("note", author="A"),
+    ),
+    # `controls.py:Control.set_value` — the single form-field call site
+    "form-field": (
+        _control_document,
+        lambda document, _: next(iter_controls(document)).set_value("typed in"),
+    ),
+    # `search.py:Span.replace` — plain body-content editing
+    "body": (
+        _plain_document,
+        lambda document, _: find_one(document, BODY_PHRASE).replace("something else"),
+    ),
+    # `notes.py` builds its operation string at runtime — body content
+    "note": (
+        _plain_document,
+        lambda document, _: add_footnote(document, find_one(document, BODY_PHRASE), "n"),
+    ),
+    # `drawing/__init__.py` — a subpackage site earlier counts missed
+    "picture": (
+        _document_with_picture,
+        lambda document, drawing: drawing.replace_picture(io.BytesIO(TINY_PNG)),
+    ),
+    # `text/hyperlink.py` — the other subpackage site earlier counts missed
+    "hyperlink": (_document_with_hyperlink, _retarget),
+}
+
+
+def _build(operation: str, **protection) -> Tuple["docx.document.Document", Callable[[], object]]:
+    """Populate a document, protect it, and hand back the operation as a thunk."""
+    setup, action = OPERATIONS[operation]
+    document, handle = setup()
+    _protect(document, **protection)
+    return document, lambda: action(document, handle)
+
+
+# -- the matrix --------------------------------------------------------------
+
+MODES: Dict[str, dict] = {
+    "readOnly": {"edit": "readOnly"},
+    "comments": {"edit": "comments"},
+    "trackedChanges": {"edit": "trackedChanges"},
+    "forms": {"edit": "forms"},
+    "formatting-only": {"formatting": True},
+}
+
+#: True = Word permits it, so the gate must permit it. Every cell not listed in
+#: `UNMEASURED` was measured in Word for Mac.
+MATRIX: Dict[Tuple[str, str], bool] = {
+    ("readOnly", OP_COMMENT): False,
+    ("readOnly", OP_FORM_FIELD): False,
+    ("readOnly", OP_BODY): False,
+    ("comments", OP_COMMENT): True,
+    ("comments", OP_FORM_FIELD): False,
+    ("comments", OP_BODY): False,
+    ("trackedChanges", OP_COMMENT): True,
+    ("trackedChanges", OP_FORM_FIELD): False,
+    ("trackedChanges", OP_BODY): True,
+    ("forms", OP_COMMENT): False,
+    ("forms", OP_FORM_FIELD): True,
+    ("forms", OP_BODY): False,
+    ("formatting-only", OP_COMMENT): True,
+    ("formatting-only", OP_FORM_FIELD): True,
+    ("formatting-only", OP_BODY): True,
+}
+
+#: The two cells Word has NOT been asked about; see the module docstring.
+UNMEASURED: Tuple[Tuple[str, str], ...] = (
+    ("trackedChanges", OP_BODY),
+    ("formatting-only", OP_BODY),
+)
+
+#: the operation exercising each class in the matrix
+BUILDERS: Dict[str, str] = {
+    OP_COMMENT: "comment",
+    OP_FORM_FIELD: "form-field",
+    OP_BODY: "body",
+}
+
+
+def _assert_matches(mode: str, operation_class: str, operate: Callable[[], object]) -> None:
+    """Run `operate`, expecting exactly the verdict the matrix records."""
+    if MATRIX[(mode, operation_class)]:
+        operate()  # Word permits it, so paper-docx must not refuse
+        return
+    with pytest.raises(DocumentProtectedError):
+        operate()
+
+
+class DescribeTheProtectionMatrix:
+    """One test per populated cell — Fix 4 of the word-oracle-fixes spec."""
+
+    @pytest.mark.parametrize(("mode", "operation_class"), sorted(MATRIX))
+    def it_matches_words_measured_verdict_for_every_cell(
+        self, mode: str, operation_class: str
+    ):
+        _, operate = _build(BUILDERS[operation_class], **MODES[mode])
+        _assert_matches(mode, operation_class, operate)
+
+    @pytest.mark.parametrize("mode", [mode for mode, _ in UNMEASURED])
+    def it_permits_the_two_unmeasured_body_content_cells(self, mode: str):
+        """Body content under `trackedChanges` and under formatting-only.
+
+        NEITHER CELL IS MEASURED IN WORD. They ship permissive because a
+        refusal with no verdict behind it is an unjustified regression, and the
+        gate is a policy mirror rather than a corruption guard. If someone
+        measures either cell in Word and it turns out blocked, this test is the
+        one that must change, deliberately.
+        """
+        assert MATRIX[(mode, OP_BODY)] is True
+        _, operate = _build("body", **MODES[mode])
+        operate()
+
+    @pytest.mark.parametrize("operation_class", sorted(OPERATION_CLASSES))
+    @pytest.mark.parametrize("token", ["lockedTighterThanThis", "formatting-only"])
+    def it_refuses_every_class_for_an_unrecognised_edit_token(
+        self, token: str, operation_class: str
+    ):
+        """An unknown restriction is not a licence.
+
+        `formatting-only` is the name this module gives the row for a document
+        that declares `w:formatting` and no `w:edit`. A document declaring
+        `w:edit="formatting-only"` is a different thing — an unrecognised token —
+        and must not reach that permissive row by spelling its label.
+        """
+        _, operate = _build(BUILDERS[operation_class], edit=token)
+        with pytest.raises(DocumentProtectedError):
+            operate()
+
+    def it_ignores_protection_that_is_not_enforced(self):
+        _, operate = _build("body", edit="readOnly", enforcement=False)
+        operate()
+
+    @pytest.mark.parametrize(("mode", "operation_class"), sorted(MATRIX))
+    def it_lets_the_acknowledgement_flag_override_every_refused_cell(
+        self, mode: str, operation_class: str
+    ):
+        if MATRIX[(mode, operation_class)]:
+            pytest.skip("cell already permits; nothing to override")
+        document, operate = _build(BUILDERS[operation_class], **MODES[mode])
+        acknowledge_protection(document)
+        operate()
+
+
+class DescribeCommentClassCallSites:
+    """The comment-class call lines, reached through both funnels."""
+
+    @pytest.mark.parametrize("mode", sorted(MODES))
+    def it_matches_the_comment_verdict_when_anchoring_a_comment(self, mode: str):
+        _, operate = _build("anchored-comment", **MODES[mode])
+        _assert_matches(mode, OP_COMMENT, operate)
+
+    @pytest.mark.parametrize(
+        "mode", [mode for mode in sorted(MODES) if MATRIX[(mode, OP_COMMENT)]]
+    )
+    def it_permits_the_inherited_comment_mutators(self, mode: str):
+        document = _document()
+        comment = document.comments.add_comment("first", author="A")
+        _protect(document, **MODES[mode])
+        comment.add_paragraph("second")
+
+
+class DescribeThePreviouslyMissedSubpackageSites:
+    """`drawing/__init__.py` and `text/hyperlink.py`.
+
+    Both live in subpackages and an earlier `src/docx/*.py` glob skipped them.
+    Left unclassified they would keep the old blanket gate while their siblings
+    became mode-aware — silently inconsistent rather than broken.
+    """
+
+    @pytest.mark.parametrize("operation", ["picture", "hyperlink"])
+    @pytest.mark.parametrize("mode", sorted(MODES))
+    def it_matches_the_body_content_verdict(self, operation: str, mode: str):
+        _, operate = _build(operation, **MODES[mode])
+        _assert_matches(mode, OP_BODY, operate)
+
+
+class DescribeTheRuntimeOperationStrings:
+    """Four call expressions pass `operation` as a variable, not a literal."""
+
+    @pytest.mark.parametrize("mode", sorted(MODES))
+    def it_matches_the_body_content_verdict_for_the_runtime_note_operation(self, mode: str):
+        _, operate = _build("note", **MODES[mode])
+        _assert_matches(mode, OP_BODY, operate)
+
+    def it_names_the_runtime_operation_in_the_message(self):
+        _, operate = _build("note", edit="readOnly")
+        with pytest.raises(DocumentProtectedError) as exc:
+            operate()
+        assert "add a footnote" in str(exc.value)
+
+
+class DescribeTheRefusalMessage:
+    """Fix 4's wording half: a policy restriction, not a broken document."""
+
+    def it_says_word_would_not_permit_the_edit(self):
+        _, operate = _build("body", edit="readOnly")
+        with pytest.raises(DocumentProtectedError) as exc:
+            operate()
+        message = str(exc.value)
+        assert "Word" in message
+        assert "would not permit" in message
+        assert "acknowledge_protection" in message
+        assert "'readOnly' editing" in message
+
+    def it_no_longer_implies_the_document_would_break(self):
+        """Every protected document carrying an upstream-added comment opened
+        cleanly in Word with the comment visible: the artifact is never
+        damaged, so the message must not suggest it is."""
+        _, operate = _build("body", edit="readOnly")
+        with pytest.raises(DocumentProtectedError) as exc:
+            operate()
+        message = str(exc.value).lower()
+        for word in ("corrupt", "damage", "broken", "unreadable", "invalid"):
+            assert word not in message
+
+    def it_names_the_edit_token_when_formatting_is_also_restricted(self):
+        _, operate = _build("form-field", edit="lockedTighterThanThis", formatting=True)
+        with pytest.raises(DocumentProtectedError) as exc:
+            operate()
+        assert "'lockedTighterThanThis' editing" in str(exc.value)
+
+
+# -- coverage assertion ------------------------------------------------------
+#
+# Enumerated with an AST walk, NOT a regex, for two reasons: the operation class
+# of a call site is a keyword argument that has to be resolved back to its
+# constant, and `comments.py` reaches the gate through a one-line forwarder, so
+# counting spellings of the gate's own name would miss its two call sites.
+
+_SRC = pathlib.Path(docx.__file__).parent
+_GATE = "_refuse_if_protected"
+
+#: The one function whose whole body is a gate call: calling it is calling the
+#: gate. A validation routine that merely happens to call the gate (like
+#: `commentops._preflight_comment_range`) is NOT one — it does other work, and
+#: its callers are not gate call expressions.
+_FORWARDER = "_refuse_document_protection"
+
+
+def _callee(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _class_of(call: ast.Call, constants: Dict[str, str]) -> str:
+    """The operation class a gate call resolves to; the default is body content."""
+    for keyword in call.keywords:
+        if keyword.arg != "operation_class":
+            continue
+        value = keyword.value
+        if isinstance(value, ast.Constant):
+            return str(value.value)
+        name = _callee(value)
+        assert name in constants, f"operation_class is not a known constant: {name!r}"
+        return constants[name]
+    return OP_BODY
+
+
+def _forwarder_class(trees: Dict[str, ast.Module], constants: Dict[str, str]) -> str:
+    """The class `_FORWARDER` passes on, read off its single gate call."""
+    definitions = [
+        node
+        for tree in trees.values()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == _FORWARDER
+    ]
+    assert len(definitions) == 1, f"expected exactly one {_FORWARDER} definition"
+    call = next(
+        node
+        for node in ast.walk(definitions[0])
+        if isinstance(node, ast.Call) and _callee(node.func) == _GATE
+    )
+    return _class_of(call, constants)
+
+
+@functools.lru_cache(maxsize=None)
+def _census() -> Dict[str, Dict[str, int]]:
+    """module -> operation class -> number of call expressions reaching the gate."""
+    import docx.protection as protection_module
+
+    constants = {
+        name: getattr(protection_module, name)
+        for name in ("OP_COMMENT", "OP_FORM_FIELD", "OP_BODY")
+    }
+    trees = {
+        str(path.relative_to(_SRC)): ast.parse(path.read_text(encoding="utf-8"))
+        for path in sorted(_SRC.rglob("*.py"))
+    }
+    forwarded = _forwarder_class(trees, constants)
+
+    census: Dict[str, Dict[str, int]] = {}
+    for module, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _callee(node.func)
+            if name == _GATE:
+                operation_class = _class_of(node, constants)
+            elif name == _FORWARDER:
+                operation_class = forwarded
+            else:
+                continue
+            counts = census.setdefault(module, {})
+            counts[operation_class] = counts.get(operation_class, 0) + 1
+    return census
+
+
+def _sites(operation_class: str) -> Dict[str, int]:
+    """The call-site count per module for one operation class."""
+    return {
+        module: counts[operation_class]
+        for module, counts in _census().items()
+        if operation_class in counts
+    }
+
+
+#: The census phase 4 settled by AST parse: 36 call expressions across 15
+#: modules. The totals are pinned rather than the whole per-module table
+#: because body content is the default, so pinning where every body site lands
+#: would make moving a gated function between modules fail a protection test
+#: for a reason that has nothing to do with protection. The totals still do the
+#: job the pin is for: a gate call added anywhere fails here, so it has to be
+#: classified deliberately instead of silently inheriting the default.
+TOTAL_SITES = 36
+TOTAL_MODULES = 15
+
+
+class DescribeGateCallSiteCoverage:
+    """Every call expression reaching the gate resolves to a declared class."""
+
+    def it_classifies_every_call_expression_in_every_module(self):
+        census = _census()
+        assert census, "no gate call sites found at all"
+        seen = {
+            operation_class for counts in census.values() for operation_class in counts
+        }
+        assert seen <= set(OPERATION_CLASSES), seen - set(OPERATION_CLASSES)
+        assert len(census) == TOTAL_MODULES, sorted(census)
+        total = sum(count for counts in census.values() for count in counts.values())
+        assert total == TOTAL_SITES, census
+
+    def it_declares_every_comment_class_call_site(self):
+        assert _sites(OP_COMMENT) == {
+            "commentops.py": 4,
+            "comments.py": 3,
+            "search.py": 1,
+        }
+
+    def it_declares_the_single_form_field_call_site(self):
+        assert _sites(OP_FORM_FIELD) == {"controls.py": 1}
+
+    def it_covers_the_two_subpackage_modules_earlier_counts_missed(self):
+        census = _census()
+        assert census["drawing/__init__.py"] == {OP_BODY: 1}
+        assert census["text/hyperlink.py"] == {OP_BODY: 1}
+
+    def it_defaults_an_unclassified_call_to_body_content(self):
+        """The strictest class, so a new site cannot become permissive by
+        omission."""
+        tree = ast.parse("_refuse_if_protected(document, 'do a thing')\n")
+        call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+        assert _class_of(call, {}) == OP_BODY

--- a/tests/paper/test_word_refusal_messages.py
+++ b/tests/paper/test_word_refusal_messages.py
@@ -1,0 +1,144 @@
+"""Refusal messages that name the defect Word objected to, and the fix.
+
+Word refuses every package exercised here; only the wording is under test. Each case
+asserts the distinguishing phrase rather than the whole string, so copy-editing a message
+does not break the suite.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import zipfile
+
+import pytest
+
+import docx
+import docx.opc.pkgreader as pkgreader_module
+from docx.errors import PackageLimitError
+from docx.opc.pkgreader import _SerializedRelationships
+
+_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+
+def _document_bytes() -> bytes:
+    stream = io.BytesIO()
+    docx.Document().save(stream)
+    return stream.getvalue()
+
+
+def _relationships_xml(second_target: str) -> bytes:
+    return (
+        f'<Relationships xmlns="{_RELATIONSHIPS_NS}">'
+        '<Relationship Id="rId1" Type="urn:one" Target="one.xml"/>'
+        f'<Relationship Id="rId1" Type="urn:one" Target="{second_target}"/>'
+        "</Relationships>"
+    ).encode("utf-8")
+
+
+def _refusal(callable_, *args) -> str:
+    with pytest.raises(PackageLimitError) as exc_info:
+        callable_(*args)
+    return str(exc_info.value)
+
+
+def _duplicate_first_default(data: bytes) -> tuple[bytes, str]:
+    """Repeat the first `Default` element of `[Content_Types].xml` verbatim."""
+    extension = ""
+    destination = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(data)) as package, zipfile.ZipFile(
+        destination, "w", zipfile.ZIP_DEFLATED
+    ) as output:
+        for name in package.namelist():
+            blob = package.read(name)
+            if name == "[Content_Types].xml":
+                text = blob.decode("utf-8")
+                element = re.search(r'<Default Extension="([^"]+)"[^>]*/>', text)
+                assert element is not None
+                extension = element.group(1)
+                blob = text.replace(
+                    element.group(0), element.group(0) * 2, 1
+                ).encode("utf-8")
+            output.writestr(name, blob)
+    return destination.getvalue(), extension
+
+
+def it_names_the_duplicated_extension_when_a_default_is_declared_twice():
+    """Two entries declaring the same content type are duplicated, not ambiguous."""
+    data, extension = _duplicate_first_default(_document_bytes())
+
+    message = _refusal(docx.Document, io.BytesIO(data))
+
+    assert "more than one Default" in message
+    assert repr(extension) in message
+    assert "Delete the duplicate Default" in message
+    assert "ambiguous" not in message
+
+
+def it_reports_the_missing_footer_rather_than_the_record_that_holds_it():
+    """The actionable fact is where the archive stops, not the record it stops with."""
+    message = _refusal(docx.Document, io.BytesIO(_document_bytes() + b"\x00" * 64))
+
+    assert "does not end with an archive footer" in message
+    assert "Re-saving the document" in message
+    assert "end-of-central-directory" not in message
+
+
+def it_does_not_blame_appended_bytes_for_a_file_that_is_merely_short():
+    """The same refusal covers truncation and non-packages, so it may not assert a tail."""
+    message = _refusal(docx.Document, io.BytesIO(_document_bytes()[:4096]))
+
+    assert "truncated in transfer" in message
+    assert "needs a fresh copy" in message
+
+
+def it_calls_a_repeated_id_for_one_target_a_redundant_declaration():
+    message = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("one.xml")
+    )
+
+    assert "twice for the same target" in message
+    assert "Delete the repeated Relationship element" in message
+
+
+def it_calls_a_repeated_id_for_two_targets_a_contradiction():
+    message = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("two.xml")
+    )
+
+    assert "two different targets" in message
+    assert "an Id of its own" in message
+
+
+def it_distinguishes_the_redundant_and_contradictory_relationship_refusals():
+    """Both stay refused, but the caller's next step differs."""
+    redundant = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("one.xml")
+    )
+    contradictory = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("two.xml")
+    )
+
+    assert redundant != contradictory
+
+
+def it_distinguishes_the_two_cases_through_the_object_model_path_too(monkeypatch):
+    """The second call site validates the built objects; it must draw the same line.
+
+    `_validate_relationship_records` reaches the raw XML first, so it is stubbed out here
+    to let the object-model check run. Both sites stay, and both name their case.
+    """
+    monkeypatch.setattr(
+        pkgreader_module, "_validate_relationship_records", lambda blob, base_uri: None
+    )
+
+    redundant = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("one.xml")
+    )
+    contradictory = _refusal(
+        _SerializedRelationships.load_from_xml, "/word", _relationships_xml("two.xml")
+    )
+
+    assert "twice for the same target" in redundant
+    assert "two different targets" in contradictory
+    assert redundant != contradictory

--- a/tests/paper/test_word_refusal_messages.py
+++ b/tests/paper/test_word_refusal_messages.py
@@ -15,7 +15,7 @@ import pytest
 
 import docx
 import docx.opc.pkgreader as pkgreader_module
-from docx.errors import PackageLimitError
+from docx.errors import MalformedPackageError
 from docx.opc.pkgreader import _SerializedRelationships
 
 _RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
@@ -37,7 +37,7 @@ def _relationships_xml(second_target: str) -> bytes:
 
 
 def _refusal(callable_, *args) -> str:
-    with pytest.raises(PackageLimitError) as exc_info:
+    with pytest.raises(MalformedPackageError) as exc_info:
         callable_(*args)
     return str(exc_info.value)
 


### PR DESCRIPTION
Stacked on #29 (which is stacked on the #23 → #24 → #25 → #13 → #22 chain), so this reviews as a delta on that stack.

Four rounds of Word for Mac verdicts on 2026-08-18 found paper-docx wrong in **both** directions. #24 removed the resource caps and #29 closed the byte-zero rule. This closes the remaining nine findings.

## Leniency — the fork accepted shapes Word refuses

| Shape | Before | Word |
|---|---|---|
| `my image.png` (literal space) | accepted | **refuses** |
| `imagé1.png` (raw non-ASCII, NFC) | accepted | **refuses** |
| `imag%C3%A91.png` (escaped non-ASCII) | accepted | **refuses** |
| zero-length `word` beside `word/…`, no attributes | accepted | **refuses** |

**Part names** are now restricted to ASCII characters legal in a URI path, with percent-escapes accepted only where they encode an ASCII byte. This replaces an NFC-normalization check that caught exactly one of the four spellings Word rejects — normalization was never the defect, non-ASCII is.

The rule is a **single pass** that consumes `%XX` as a unit. It has to be: `%` is not itself a legal URI-path character, so a separate literal check would refuse `my%20image.png`, which Word opens. The two-pass form reproduces 6 of 7 verdicts; the single pass reproduces 7 of 7.

`[Content_Types].xml` is exempt — a reserved package item rather than an OPC part name, and the only member in any real document carrying `[` or `]`. Without the exemption the rule refuses every document.

**Directory-prefix collisions** are refused whatever the member's attributes. The check runs as a pre-pass over the whole member-name set, because the collision is only visible from the deeper name: inside the per-member loop, the shallow member is reached first and its attribute check reports the wrong defect for two of the three shapes. Both existing attribute checks are deliberately kept — removing them would not remove the unmeasured refusal it appears to, and would silently flip an uncovered case.

## Over-strict — the fork refused what Word permits

**Media content types.** Word opens a displayed image declared `application/octet-stream`. It constrains *core* part types, not media types, so the `RT.IMAGE` branch is gone and `_KNOWN_RELATIONSHIP_CONTENT_TYPES` is now the sole mechanism. Core-part strictness is unchanged — three separate verdicts confirm it.

**The protection gate** read "is protection enforced" and refused, so all five restriction modes behaved identically at every call site. Word's rules are per-mode *and* per-operation-class:

| `w:edit` | comment | form field | body |
|---|---|---|---|
| `readOnly` | refuse ✓ | refuse ✓ | refuse ✓ |
| `comments` | **permit** ✓ | refuse | refuse ✓ |
| `trackedChanges` | **permit** ✓ | refuse | **permit** (unmeasured) |
| `forms` | refuse ✓ | **permit** ✓ | refuse ✓ |
| formatting-only | **permit** ✓ | **permit** | **permit** (unmeasured) |

✓ = measured in Word. `comments` exists precisely to allow commenting while forbidding body edits; `forms` exists to allow filling a form field. The fork refused both.

Two body-content cells are unmeasured and **ship permissive**, marked as such in the matrix and pinned by a test. A refusal with no verdict behind it has no justification, and this gate mirrors Word's UI rather than guarding against corruption — permitting cannot produce a file Word refuses. `acknowledge_protection()` remains the override for what stays refused.

An unrecognised `w:edit` token refuses for every class.

## Messages

- A duplicate `Default` declaration is no longer called *ambiguous* — two entries declaring the same type are duplicated, not contradictory.
- The footer refusal names the defect and a remedy without blaming an appended tail for a file that was merely truncated. That branch also fires for truncated, empty, and declared-but-absent-comment files.
- A redundant relationship id now reads differently from a contradictory one. Both stay refused, but one says "delete the repeated element" and the other "give the second relationship an Id of its own".

## Verification

Replaying five recorded-verdict fixture sets against this build produces **exactly seven status movements** and nothing else:

| fixture | before | after |
|---|---|---|
| `1-refused-inputs/07-nfc-member-name` | accepted | refused |
| `4-followups/02-space-in-member-name` | accepted | refused |
| `4-followups/03-pct-nfc-member-name` | accepted | refused |
| `4-followups/04-pct-nfd-member-name` | accepted | refused |
| `5-encoding/03-space-in-member-name` | accepted | refused |
| `1-refused-inputs/10-prefix-collision-plain` | accepted | refused |
| `1-refused-inputs/22-image-octet-stream` | refused | **accepted** |

Those seven are unchanged by the rename and the main-document deferral: replaying the same five sets after those commits moves **no** fixture between accepted and refused, and every difference is `PackageLimitError` -> `MalformedPackageError`.

Suite: **2754 passed**, 7 skipped, plus the 9 pre-existing `tests/opc/test_phys_pkg.py` collection errors (a pytest deprecation about class-scoped fixtures, unrelated). `ruff` unchanged at 97 repo-wide, with every file touched here clean. `pyright` on the changed source improved from 255 to 253.

A coverage assertion walks the source tree and fails if any gate call site is added without an operation class, so the census cannot go stale.

## Exception type and name

`PackageLimitError` is renamed **`MalformedPackageError`**, across 112 raise sites, the tests
and the user-facing docs. Nothing the class raises for is a limit any more: #24 removed all
eight size, count and ratio ceilings once Word was measured opening documents past them, and
rewrote the docstring to "corrupt, encrypted, or malformed" without renaming the class. The
name contradicted every remaining raise site.

**No alias, and it is not a migration hazard.** `docx.errors` does not exist in upstream
python-docx and neither does this class, so no caller migrating from python-docx has ever
referenced the name. The only code that can break is a paper-docx 0.1.x caller.

The class docstring is rewritten to say what it now means, and to state plainly that it does
not mean the file is too large.

## The main-document content type goes back to upstream's error

`RT.OFFICE_DOCUMENT` is removed from `_KNOWN_RELATIONSHIP_CONTENT_TYPES`, along with the
now-dead `_OFFICE_DOCUMENT_CONTENT_TYPES` table.

`api.Document` already checks the main part's content type and raises `ValueError` naming the
file and the type it found — and unlike the other exception-type divergences, **that one is
deliberate upstream code, not a leaked lookup failure**. `api.py` is byte-identical to upstream
in this fork; the load-time check simply fired first, inside `Package.open()`, so execution
never reached it. Validating the same condition twice only pre-empted upstream's error with a
different type.

Measured after the change, identical character for character:

```
paper-docx  ValueError: file 'x.docx' is not a Word file, content type is 'application/xml'
upstream    ValueError: file 'x.docx' is not a Word file, content type is 'application/xml'
```

The three other exception-type divergences from upstream stay as they are — a dangling
relationship, a bad `TargetMode` and an undeclared referenced part all leak a raw `KeyError`
upstream, which a caller cannot tell apart from a bug in their own code. Those are what the
typed refusal is for.

## Still outstanding, deliberately

Not fixed here because Word has not been asked:

- **The reachability gap** — an unreferenced part with an undeclared content type, a top-level `.DS_Store`, and a `__MACOSX/._word` sidecar all still open.
- **Three protection cells** — body text under `trackedChanges` and formatting-only, and formatting under formatting-only.
- **The rendering axis** — numbering, tracked revisions, fields, `compare()`. A different question: not "did it open" but "did Word draw what the library claims".

Fixtures exist for the first two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide changes to package loading, a breaking exception rename, and protection behavior across many mutating APIs; incorrect matrix or validation rules would accept packages Word rejects or block legitimate edits.
> 
> **Overview**
> Aligns ZIP/OPC validation and Restrict Editing with measured Word behavior, and renames **`PackageLimitError`** to **`MalformedPackageError`** (no alias).
> 
> **Package read path:** Member names must be ASCII URI-path characters in one pass (`%XX` only for ASCII bytes); **`[Content_Types].xml`** is exempt. A **pre-pass** rejects directory-prefix collisions (e.g. a file `word` beside `word/…`) regardless of ZIP attributes. Preflight still refuses archives that do not start at offset zero (placed after central-directory scan). **Core** relationship content types stay strict; the **`RT.IMAGE`** branch is removed so images with generic types (e.g. `application/octet-stream`) open. **`RT.OFFICE_DOCUMENT`** is no longer validated at load so wrong main-part types surface upstream’s **`ValueError`** instead of a fork exception.
> 
> **Protection:** `_refuse_if_protected` takes **`operation_class`** (`OP_COMMENT`, `OP_FORM_FIELD`, `OP_BODY`) and applies a per-`w:edit` matrix—e.g. commenting under `comments`/`trackedChanges`, form values under `forms`. Two body cells under `trackedChanges` and formatting-only ship **permissive** (unmeasured). Refusal text frames the block as Word UI policy, not file damage.
> 
> **Messages:** Clearer duplicate-`Default`, missing-archive-footer, and duplicate-vs-conflicting relationship Id wording.
> 
> Docs, proposal notes, and Word-verdict tests cover part names, prefix collisions, media types, protection matrix, and messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3286a07d1cce287970448f455b7616c810dfd42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ZIP/OPC validation and Restrict Editing with Word, and renames `PackageLimitError` to `MalformedPackageError`. Previously we accepted packages Word refuses and enforced protection uniformly; now name legality, prefix-collision checks, media/core content types, and per-mode protection match Word.

- Part names: ASCII URI-path only; percent escapes only for ASCII; `[Content_Types].xml` exempt. Pre-pass rejects directory-prefix collisions. Clearer messages for duplicate `<Default>` entries and reused relationship Ids.
- Content types: constrain only core parts; media may be generic (e.g., images as `application/octet-stream` open). Main-document content-type check defers to upstream `ValueError`.
- Protection: add operation classes (`OP_COMMENT`, `OP_FORM_FIELD`) and a per-`w:edit` × operation-class matrix. Permit commenting under `comments` and `trackedChanges`; permit form-field edits under `forms`. Two unmeasured body cells ship permissive; unknown `w:edit` refuses. `acknowledge_protection()` still overrides.

**Migration**
- Replace `PackageLimitError` with `MalformedPackageError`.
- Expect `ValueError` from `Document(...)` for a wrong main-document content type.

<sup>Written for commit a3286a07d1cce287970448f455b7616c810dfd42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-docx/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

