### PR TITLE
ci: keep LibreOffice smoke out of the merge gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,19 +155,3 @@ jobs:
           "$matrix_root/unsafe-uninstall/bin/python" -m pip uninstall \
             --yes python-docx
           expect_failure "$matrix_root/unsafe-uninstall/bin/paper-docx-doctor"
-
-  required:
-    name: Required
-    if: always()
-    needs: [test, docs, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require every quality job
-        env:
-          TEST_RESULT: ${{ needs.test.result }}
-          DOCS_RESULT: ${{ needs.docs.result }}
-          BUILD_RESULT: ${{ needs.build.result }}
-        run: |
-          test "$TEST_RESULT" = success
-          test "$DOCS_RESULT" = success
-          test "$BUILD_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -69,8 +73,7 @@ jobs:
           python-version: "3.13"
       - name: Install LibreOffice Writer
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes libreoffice-writer
+          sudo apt-get install --yes --no-install-recommends libreoffice-writer
           command -v soffice
           soffice --version
       - name: Install package and test dependencies
@@ -156,17 +159,15 @@ jobs:
   required:
     name: Required
     if: always()
-    needs: [test, libreoffice, docs, build]
+    needs: [test, docs, build]
     runs-on: ubuntu-latest
     steps:
       - name: Require every quality job
         env:
           TEST_RESULT: ${{ needs.test.result }}
-          LIBREOFFICE_RESULT: ${{ needs.libreoffice.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
           BUILD_RESULT: ${{ needs.build.result }}
         run: |
           test "$TEST_RESULT" = success
-          test "$LIBREOFFICE_RESULT" = success
           test "$DOCS_RESULT" = success
           test "$BUILD_RESULT" = success


### PR DESCRIPTION
## Summary
- Stop treating the LibreOffice contract job as a merge blocker. It still runs and reports.
- Add a workflow concurrency group with `cancel-in-progress` so a new push (and duplicate check suites on the same SHA) cancels the previous run.
- Skip `apt-get update` and install LibreOffice with `--no-install-recommends`.
- Remove the `Required` aggregator job. Branch protection no longer requires any status check, so that job was only a merge bottleneck.

## Test plan
- [ ] Confirm this PR does not show a `Required` check
- [ ] Confirm `LibreOffice contract` still runs and reports
- [ ] Confirm a new push cancels the previous Test workflow
- [ ] After merge, existing PRs pick up the new workflow on the next synchronize/re-run