### PR TITLE
chore: bump paper-docx to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ and model priors.
 
 - GitHub repository / PyPI distribution: **`paper-docx`**
 - Python import: **`docx`**
-- Fork sentinel: `docx.__paper_version__ = "0.1.2"`
+- Fork sentinel: `docx.__paper_version__ = "0.2.0"`
 
 ## Installation
 

--- a/src/docx/_version.py
+++ b/src/docx/_version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, distribution
 
-__paper_version__ = "0.1.2"
+__paper_version__ = "0.2.0"
 
 
 def assert_distribution_identity() -> None:


### PR DESCRIPTION
## Summary
- Bump the fork sentinel and distribution version from `0.1.2` to `0.2.0` so a post-merge `v0.2.0` tag will publish the current mainline (Word-oracle validation/protection alignment and the stack beneath it) without a premature publish.
- Update the README fork-sentinel string that would otherwise ship stale (`0.1.2`) in the wheel.
- Does **not** create or push a tag. `release.yaml` only publishes on `v*` tags that are already ancestors of `origin/main`; tag `v0.2.0` on `main` after this stack merges.

## Test plan
- `uv build` produced `paper_docx-0.2.0-py3-none-any.whl` and `paper_docx-0.2.0.tar.gz`
- `uvx --from twine==6.1.0 twine check --strict dist/*` PASSED for both artifacts
- Isolated wheel install: `docx.__paper_version__` and `importlib.metadata.version("paper-docx")` both report `0.2.0`
- Isolated wheel `paper-docx-doctor: OK (paper-docx 0.2.0)`; sdist smoke reports `0.2.0`
- `uv run python -m pytest -q tests/paper/test_distribution_doctor.py` — 12 passed
- Confirmed `git tag --list v0.2.0` is empty

## Checklist
- [x] Distribution doctor tests pass (`uv run python -m pytest -q tests/paper/test_distribution_doctor.py`)
- [x] Wheel identity matches `0.2.0` (`uv build` + isolated install + `paper-docx-doctor`)
- [x] Lint clean on the version module (`uv run ruff check src/docx/_version.py`)
- [x] No tag created or pushed

Stacked on #30. After #30 and this PR merge to `main`, tag the merge commit `v0.2.0` and push the tag to publish.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `paper-docx` distribution version and fork sentinel from 0.1.2 to 0.2.0 to align package identity for the next release. No functional changes; only `docx.__paper_version__` and the README example are updated.

**Rollout**
- After merge to `main`, tag the merge commit `v0.2.0` and push to publish; this PR does not create a tag.

<sup>Written for commit 5a76569d660a21393d3a7a6670ff096faecada7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-docx/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

