### PR TITLE
docs: say what the paper APIs refuse and when to use them

### DIFF
--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -161,13 +161,12 @@ def compare(
     granularity: str = "word",
     materialize: Optional[str] = None,
 ) -> CompareResult:
-    """A new document: `original` + tracked changes that produce `revised`.
+    """A `CompareResult`: `original` plus tracked changes producing `revised`.
 
-    `original`/`revised` are .docx paths. Inputs carrying pending revisions
-    refuse unless `materialize` ("accept" | "reject") routes them through
-    resolution on in-memory working copies first (the files on disk are
-    never touched). `granularity`: "word" (token-level edits inside matched
-    paragraphs) or "block" (whole-paragraph del+ins only).
+    Takes paths or bytes. `granularity` is "word" or "block". Inputs carrying pending
+    revisions refuse unless `materialize` ("accept" | "reject") resolves them on in-memory
+    copies, leaving the files on disk untouched. Refuses any edit it cannot express as a
+    clean redline.
     """
     import docx as _docx
 
@@ -534,7 +533,12 @@ def _verify_compare_algebra(
 def _assert_packages_match(
     actual_bytes: bytes, expected_bytes: bytes, *, outcome: str
 ) -> None:
-    """Compare every part, allowing only inert run fragmentation in stories."""
+    """Compare every part, allowing only inert differences in stories.
+
+    Canonicalization strips `w:proofErr`, drops empty `w:pPr` and `w:rPr`, merges adjacent
+    `w:t`, and normalizes `xml:space`, so run fragmentation and those artifacts pass.
+    Non-story parts compare semantically rather than byte for byte.
+    """
     import docx as _docx
     from docx._paperpkg import (
         _parts_semantically_equal,
@@ -1329,13 +1333,13 @@ def _iso(stamp: "dt.datetime") -> str:
 def _replace_paragraph_text(
     ctx: _Ctx, paragraph: "_Element", text_o: str, text_r: str
 ) -> None:
-    """Token-level tracked edits inside one matched paragraph; whole-block
-    del+ins fallback when the span machinery refuses a region.
+    """Token-level tracked edits inside one matched paragraph.
 
-    A refusal can arrive AFTER earlier regions already emitted revisions;
-    falling back on the half-redlined paragraph would nest fresh w:del
-    inside w:del — so the pristine paragraph is swapped back in before the
-    fallback runs."""
+    A refusal can arrive after earlier regions already emitted revisions, so the paragraph is
+    restored to its pristine state and the refusal re-raised rather than left half-redlined
+    with fresh `w:del` nested inside existing markup. No caller catches it, so the compare
+    fails as a whole.
+    """
     regions = _token_regions(text_o, text_r)
     pristine = copy.deepcopy(paragraph)
     try:

--- a/src/docx/_paperpkg.py
+++ b/src/docx/_paperpkg.py
@@ -287,9 +287,9 @@ class PackageDiff:
 def diff_package(path_a: _PathLike, path_b: _PathLike) -> PackageDiff:
     """Part-by-part diff of the OPC packages at `path_a` and `path_b`.
 
-    XML parts (`*.xml`, `*.rels`) are compared semantically; binary parts by
-    bytes. A byte-changed XML part that fails to parse counts as semantically
-    changed — never silently equal.
+    XML parts (`*.xml`, `*.rels`) compare semantically, binary parts by bytes. A
+    byte-changed XML part that fails to parse counts as semantically changed, never
+    silently equal. Raises `MalformedPackageError` when either package will not open.
     """
     a_parts, a_order = _read_zip(Path(path_a))
     b_parts, b_order = _read_zip(Path(path_b))
@@ -482,12 +482,11 @@ class PackageDiagnosis:
 
 
 def diagnose(path: _PathLike) -> PackageDiagnosis:
-    """Say what the file at `path` is and why it can or cannot be opened.
+    """Why the file at `path` can or cannot be opened, as a `PackageDiagnosis`.
 
-    The upstream `docx.Document()` entry point raises raw, untyped errors on
-    encrypted, macro-enabled, template, or corrupt input; its behavior is
-    frozen, so triage ships as this additive API instead: call it when
-    an open fails (or before opening untrusted input).
+    Returns instead of raising, so you can triage untrusted input before opening it.
+    `Document()` refuses corrupt and encrypted packages with `MalformedPackageError` but
+    still raises a bare `ValueError` for macro-enabled and template files.
     """
     file_path = Path(path)
 
@@ -584,18 +583,19 @@ def patch_save(
 ) -> PatchSaveResult:
     """Save `document` to `out_path`, restoring original bytes wherever possible.
 
-    The document is serialized normally, then every XML part that is
-    semantically identical to its counterpart in `original_path` gets that
-    counterpart's exact original bytes back — a narrow save that keeps
-    unrelated parts byte-stable through the open/edit/save cycle. When
-    nothing changed at all, `out_path` becomes a verbatim copy of the
-    original file, so a no-op round trip is byte-identical.
+    The document is serialized normally, then every XML part semantically identical to its
+    counterpart in `original_path` gets that counterpart's exact original bytes back, a
+    narrow save that keeps unrelated parts byte-stable through the open/edit/save cycle.
+    When nothing changed, `out_path` becomes a verbatim copy of the original.
 
-    `original_path == out_path` is permitted; the original bytes are read up
-    front and the write is atomic (temp file + rename), so the original
-    survives any mid-write failure. An existing destination keeps its current
-    permission bits; a newly created destination inherits `original_path`'s
-    permission bits.
+    `original_path == out_path` is permitted; the original bytes are read up front and the
+    write is atomic (temp file + rename), so the original survives a mid-write failure. An
+    existing destination keeps its permission bits; a new one inherits `original_path`'s.
+    Creates the destination's parent directory when it is missing.
+
+    Returns a `PatchSaveResult` naming what it restored and what it rewrote. Raises
+    `MalformedPackageError` when `original_path`, the serialized document, or the finished
+    output fails to reparse, and `OSError` when a destination symlink moves mid-save.
     """
     original_file = Path(original_path)
     output_file = Path(out_path)

--- a/src/docx/_textdiff.py
+++ b/src/docx/_textdiff.py
@@ -101,8 +101,13 @@ def text_diff(path_a: _PathLike, path_b: _PathLike, *, view: str = "current") ->
 
 
 def pending_changes(path: _PathLike) -> TextDiff:
-    """What the document's pending revisions would change if all were accepted
-    (its "original" view diffed against its "current" view)."""
+    """What the document's pending revisions would change if all were accepted.
+
+    Diffs the "original" view against the "current" view, so an empty `TextDiff` means no
+    visible TEXT change rather than a clean document: formatting-only, table-structure and
+    same-place move revisions produce no diff lines. Ask `Document.revisions` whether markup
+    remains.
+    """
     import docx
 
     document = docx.Document(str(path))

--- a/src/docx/_transaction.py
+++ b/src/docx/_transaction.py
@@ -321,7 +321,11 @@ def _same_items(
 def _reachable_package_objects(
     package: "OpcPackage",
 ) -> "Tuple[Tuple[OpcPackage | Part, ...], Tuple[Part, ...]]":
-    """Return every package-owned part without materializing lazy state."""
+    """(owners, parts) reachable from the package, without materializing lazy state.
+
+    `owners` includes the package itself. Only parts behind already-materialized rels are
+    seen, so a part the caller never touched is absent.
+    """
     owners: "List[OpcPackage | Part]" = [package]
     parts: "List[Part]" = []
     seen: "set[int]" = set()

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -475,11 +475,11 @@ def insert_section_after(
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> BlockEditResult:
-    """Insert a heading plus body paragraphs after `anchor`.
+    """Insert a heading plus body paragraphs after `anchor`, and return a `BlockEditResult`.
 
-    With `tracked=True` every inserted paragraph is a real Word insertion
-    (content wrapped in `w:ins`, paragraph mark stamped) attributed to
-    `author` (required) and `date` (default: the injectable clock).
+    With `tracked=True` each inserted paragraph is a real Word insertion attributed to
+    `author` (required) and `date`. Refuses a protected document, an undefined heading
+    style, and an anchor that is missing, ambiguous, foreign or stale.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
@@ -526,11 +526,12 @@ def tracked_delete_paragraphs(
     author: str,
     date: Optional[dt.datetime] = None,
 ) -> BlockEditResult:
-    """Mark a paragraph range deleted with real tracked changes.
+    """Mark a paragraph range deleted with real tracked changes; returns a `BlockEditResult`.
 
-    Each paragraph's runs move into `w:del` with their formatting intact and
-    the paragraph mark is stamped deleted, so accept removes the paragraphs
-    and reject restores them exactly.
+    Runs move into `w:del` with formatting intact and the paragraph mark is stamped, so
+    accepting removes the paragraphs and rejecting restores them exactly. Refuses a
+    protected document, a range crossing stories or parents, a bookmarked or non-plain run,
+    and an open field.
     """
     if not author:
         raise ValueError("author is required")
@@ -568,7 +569,12 @@ def tracked_replace_paragraphs(
     author: str,
     date: Optional[dt.datetime] = None,
 ) -> BlockEditResult:
-    """Tracked-delete a paragraph range and tracked-insert replacements after it."""
+    """Tracked-delete a paragraph range and tracked-insert replacements after it.
+
+    Returns a `BlockEditResult`. Replacements land after the last deleted paragraph. Carries
+    the same refusals as `tracked_delete_paragraphs`: protection, a range crossing stories,
+    bookmarked or non-plain runs, an open field.
+    """
     if not author:
         raise ValueError("author is required")
     _validate_tracked_identity(author, date)
@@ -757,14 +763,12 @@ def insert_blocks_after(
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> BlockEditResult:
-    """Insert a typed block list after `anchor`.
+    """Insert a typed block list after `anchor`, and return a `BlockEditResult`.
 
-    `blocks` mixes |RichParagraph| (styled runs), |ListBlock| (REAL bullet or
-    decimal lists — the numbering definition is created on demand), and
-    |TableBlock| (simple rectangular tables). This is deliberately a small
-    vocabulary: rich enough for a report section, small enough to stay safe.
-    Tracked mode covers paragraphs and lists; tracked TABLE insertion refuses
-    (Word's row-revision vocabulary is a later phase).
+    `blocks` mixes `RichParagraph` (styled runs), `ListBlock` (real bullet or decimal lists,
+    numbering definition created on demand) and `TableBlock` (rectangular tables). Reach for
+    this when you want structure rather than raw XML. Refuses a protected document, and an
+    anchor that is missing, ambiguous, foreign or stale.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")

--- a/src/docx/bookmarks.py
+++ b/src/docx/bookmarks.py
@@ -176,10 +176,12 @@ def _revision_wrapper_between(left: "_Element", right: "_Element") -> bool:
 
 
 def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkInfo:
-    """Bookmark exactly `span`'s text under `name` (unique, Word-legal).
+    """Bookmark exactly `span`'s text under `name`, and return its `BookmarkInfo`.
 
-    Boundary runs are split so the markers wrap precisely the span's
-    characters — the same isolation the comment-range machinery uses.
+    Use this to give a span a stable target that survives later edits; cross-references and
+    `add_reference_field` ride on bookmarks. Splits boundary runs so the markers wrap the
+    span's characters exactly. Refuses a protected document, a foreign or stale span, and a
+    name Word rejects or the document already uses.
     """
     require_span_owner(document, span)
     _refuse_if_protected(document, "create a bookmark")
@@ -234,9 +236,12 @@ def create_bookmark(document: "Document", span: "Span", name: str) -> BookmarkIn
 
 
 def delete_bookmark(document: "Document", name: str) -> None:
-    """Remove `name`'s markers (the text stays). Refuses while any field
-    instruction still references the name — a dangling REF/PAGEREF renders
-    'Error! Reference source not found.' in Word."""
+    """Remove `name`'s markers, leaving the text in place.
+
+    Use this to retire a bookmark without touching content. Refuses while a field
+    instruction still references the name, since a dangling REF renders "Error! Reference
+    source not found." in Word. Refuses a protected document and an unknown name.
+    """
     _refuse_if_protected(document, "delete a bookmark")
     matching_names = {
         start.get(_NAME) or ""

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -537,7 +537,11 @@ def _entry_for(root: "_Element", para_id: str, *, create: bool) -> "Optional[_El
 
 
 def is_resolved(document: "Document", comment: "Comment") -> bool:
-    """Whether `comment` is marked resolved (`w15:done`)."""
+    """Whether `comment`'s thread is marked resolved.
+
+    Reads `commentsExtended`, where Word keeps resolution state. Refuses a stale or foreign
+    comment, and a malformed `commentsExtended` part.
+    """
     comment_elm = _comment_element(document, comment)
     root = _comments_extended_root(document, create=False)
     if root is None:
@@ -550,7 +554,11 @@ def is_resolved(document: "Document", comment: "Comment") -> bool:
 
 
 def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) -> None:
-    """Mark `comment` resolved (or reopened) the way Word does."""
+    """Mark `comment`'s thread resolved, or reopen it with `resolved=False`.
+
+    Word keeps resolution in `commentsExtended` rather than on the comment, so this writes
+    that part. Refuses a protected document, and a stale or foreign comment.
+    """
     comment_elm = _comment_element(document, comment)
     _refuse_if_protected(document, "resolve a comment", operation_class=OP_COMMENT)
     # Validate a pre-existing extension part before adding a paraId to the
@@ -564,7 +572,10 @@ def resolve(document: "Document", comment: "Comment", *, resolved: bool = True) 
 
 
 def parent_of(document: "Document", comment: "Comment") -> Optional[int]:
-    """The comment-id this comment replies to, or None for a top-level one."""
+    """The comment `comment` replies to, or None when it starts a thread.
+
+    Refuses a stale or foreign comment, and a malformed `commentsExtended` part.
+    """
     comment_elm = _comment_element(document, comment)
     root = _comments_extended_root(document, create=False)
     if root is None:
@@ -625,7 +636,11 @@ def _anchor_elements(document: "Document", comment_id: int):
 
 
 def anchored_text(document: "Document", comment: "Comment") -> str:
-    """The document text `comment` is anchored to (its range marks' span)."""
+    """The document text `comment` is anchored to, taken from its range marks.
+
+    Refuses a stale or foreign comment, and a comment whose range marks are missing or
+    crossed.
+    """
     _comment_element(document, comment)
     start, end, _ = _anchor_elements(document, comment.comment_id)
     if start is None or end is None:
@@ -665,7 +680,12 @@ def reply(
     initials: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> "Comment":
-    """Add a threaded reply to `comment`, anchored to the same text range."""
+    """Add a threaded reply to `comment`, anchored to the same range; returns the new `Comment`.
+
+    Creates `commentsExtended` on first use, since Word keeps threading outside `w:comment`.
+    Refuses a protected document, a stale or foreign comment, and a comments part that is
+    missing or ambiguous.
+    """
     if not author:
         raise ValueError("author is required")
     from docx.search import _validate_xml_characters
@@ -740,8 +760,12 @@ def reply(
 
 
 def comment_thread(document: "Document") -> Tuple[dict, ...]:
-    """Every comment with its thread state: (id, author, text, resolved,
-    parent_id, anchored_text where available)."""
+    """Every comment with its thread state: id, author, text, resolved, parent id, and anchored
+    text where available.
+
+    Use it to read a whole discussion in one pass rather than walking replies. Refuses a
+    stale comment and a malformed `commentsExtended` part.
+    """
     from docx.opc.constants import RELATIONSHIP_TYPE as RT
 
     _preflight_comment_add(document)
@@ -805,7 +829,11 @@ def _remove_comment_anchors(document: "Document", comment_id: int) -> None:
 
 
 def delete_comment(document: "Document", comment: "Comment") -> None:
-    """Remove one comment and its replies. Anchored document text stays."""
+    """Delete `comment` and its replies, removing their range marks from the text.
+
+    Refuses a protected document, a stale or foreign comment, and a comments part that is
+    missing or ambiguous.
+    """
     _comment_element(document, comment)
     _refuse_if_protected(document, "delete a comment", operation_class=OP_COMMENT)
     _preflight_comment_add(document)

--- a/src/docx/comments.py
+++ b/src/docx/comments.py
@@ -90,24 +90,10 @@ class Comments:
     def add_comment(self, text: str = "", author: str = "", initials: str | None = "") -> Comment:
         """Add a new comment to the document and return it.
 
-        The comment is added to the end of the comments collection and is assigned a unique
-        comment-id.
-
-        If `text` is provided, it is added to the comment. This option provides for the common
-        case where a comment contains a modest passage of plain text. Multiple paragraphs can be
-        added using the `text` argument by separating their text with newlines (`"\\\\n"`).
-        Between newlines, text is interpreted as it is in `Document.add_paragraph(text=...)`.
-
-        The default is to place a single empty paragraph in the comment, which is the same
-        behavior as the Word UI when you add a comment. New runs can be added to the first
-        paragraph in the empty comment with `comments.paragraphs[0].add_run()` to adding more
-        complex text with emphasis or images. Additional paragraphs can be added using
-        `.add_paragraph()`.
-
-        `author` is a required attribute, set to the empty string by default.
-
-        `initials` is an optional attribute, set to the empty string by default. Passing |None|
-        for the `initials` parameter causes that attribute to be omitted from the XML.
+        Assigns a unique id and writes the modern identity parts (`commentsIds`,
+        `commentsExtensible`, a `w14:paraId`) that Word needs to thread replies. Refuses a
+        protected document, a collection whose part was removed or replaced, and an ambiguous
+        comments relationship.
         """
         if self._comments_elm is not self._comments_part._element:
             raise TargetNotFoundError(
@@ -151,15 +137,9 @@ class Comments:
 class Comment(BlockItemContainer):
     """Proxy for a single comment in the document.
 
-    Provides methods to access comment metadata such as author, initials, and date.
-
-    A comment is also a block-item container, similar to a table cell, so it can contain both
-    paragraphs and tables and its paragraphs can contain rich text, hyperlinks and images,
-    although the common case is that a comment contains a single paragraph of plain text like a
-    sentence or phrase.
-
-    Note that certain content like tables may not be displayed in the Word comment sidebar due to
-    space limitations. Such "over-sized" content can still be viewed in the review pane.
+    Reads author, initials, date and body content, and adds paragraphs or tables. Every
+    mutation revalidates that the comment is still live first, so a proxy whose part was
+    removed or replaced refuses instead of writing into a detached tree.
     """
 
     def __init__(self, comment_elm: CT_Comment, comments_part: CommentsPart):
@@ -179,11 +159,11 @@ class Comment(BlockItemContainer):
         return document
 
     def add_paragraph(self, text: str = "", style: str | ParagraphStyle | None = None) -> Paragraph:
-        """Return paragraph newly added to the end of the content in this container.
+        """Append a paragraph to this comment's body and return it.
 
-        The paragraph has `text` in a single run if present, and is given paragraph style `style`.
-        When `style` is |None| or ommitted, the "CommentText" paragraph style is applied, which is
-        the default style for comments.
+        Re-keys the comment's `commentEx`, its replies' `paraIdParent`, and its `commentsIds` row
+        onto the new last paragraph, so appending rewrites thread and resolution state. Refuses a
+        protected document, and a proxy whose part was removed or replaced.
         """
         document = self._validate_live("edit a comment")
         previous_last = None
@@ -219,7 +199,11 @@ class Comment(BlockItemContainer):
             return add()
 
     def add_table(self, rows: int, cols: int, width: Length) -> Table:
-        """Return a table appended to this comment."""
+        """Append a table to this comment's body and return it.
+
+        Re-keys thread and resolution state onto the new last paragraph, as `add_paragraph` does.
+        Refuses a protected document, and a proxy whose part was removed or replaced.
+        """
         document = self._validate_live("edit a comment")
         previous_last = None
         if document is not None:
@@ -260,6 +244,11 @@ class Comment(BlockItemContainer):
 
     @author.setter
     def author(self, value: str):
+        """Read/write. The recorded author of this comment.
+
+        Required, but may be the empty string. Assigning refuses a protected document, and a
+        comment whose part was removed or replaced.
+        """
         self._validate_live("edit a comment")
         with rollback_xml_on_error(self._comment_elm):
             self._comment_elm.author = value
@@ -280,6 +269,11 @@ class Comment(BlockItemContainer):
 
     @initials.setter
     def initials(self, value: str | None):
+        """Read/write. The recorded initials of the comment author.
+
+        Optional in the XML; returns None when unset, and assigning None removes it. Assigning
+        refuses a protected document, and a comment whose part was removed or replaced.
+        """
         self._validate_live("edit a comment")
         with rollback_xml_on_error(self._comment_elm):
             self._comment_elm.initials = value

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -161,13 +161,12 @@ def insert_blocks_from(
     count: int = 1,
     styles: str = "match_by_name",
 ) -> CompositionReport:
-    """Copy a contiguous block range from `source`'s body after `anchor` in
-    `document`, reconciling styles, numbering, media, and bookmarks.
+    """Copy a block range from `source` after `anchor`, and return a `CompositionReport`.
 
-    `start_anchor`/`end_anchor` address SOURCE body paragraphs (str needle,
-    Block, Anchor or Span — blocks.py semantics); with no `end_anchor`,
-    `count` blocks are taken (tables between the endpoints come along).
-    `anchor` addresses the DESTINATION paragraph to insert after.
+    Reconciles styles, numbering, media and bookmarks so the copy keeps its appearance.
+    `start_anchor`/`end_anchor` address SOURCE body paragraphs. Refuses a protected
+    destination, an anchor that is missing or ambiguous, and source content this package
+    cannot carry over: revisions, comments, OLE objects, EMF/WMF images.
     """
     _validate_styles_mode(styles)
     require_anchor_owner(source, start_anchor, argument="start_anchor")
@@ -188,15 +187,13 @@ def append_document(
     styles: str = "match_by_name",
     headers: str = "destination",
 ) -> CompositionReport:
-    """Append `source`'s whole body to `document`.
+    """Append `source`'s whole body to `document`, and return a `CompositionReport`.
 
-    Keeps the destination's headers/footers by default and authors no new
-    `w:sectPr`: `section="new_page"` prefixes the appended content with a
-    page break; `"continuous"` appends flush. Pass `headers="source"` to
-    copy the source letterhead onto the destination's last section.
-    First-page headers cannot target the appended content (they apply to
-    that section's first page, which already holds destination body) and
-    are skipped.
+    Keeps the destination's headers and footers by default and authors no new `w:sectPr`:
+    `section="new_page"` prefixes a page break, `"continuous"` appends flush.
+    `headers="source"` overwrites the destination's last-section header and footer and flips
+    the document-wide even/odd setting. Refuses a protected document and an empty body on
+    either side.
     """
     _validate_styles_mode(styles)
     if section not in ("new_page", "continuous"):

--- a/src/docx/controls.py
+++ b/src/docx/controls.py
@@ -458,12 +458,12 @@ class Control:
     # -- writing ----------------------------------------------------------
 
     def set_value(self, value: "Union[str, bool, dt.date, dt.datetime]") -> None:
-        """Set the control's value type-correctly; validate-fully-then-mutate.
+        """Set the control's value, validating fully before mutating anything.
 
-        Text/rich-text: replaces the content with one run (first run's
-        formatting kept, placeholder state cleared). Checkbox: bool.
-        Dropdown/combo: must match a listItem (dropdown) — combos accept free
-        text. Date: date/datetime (stamps `w:fullDate`) or display string.
+        Text and rich-text controls take a string, checkboxes a bool, dropdowns a value from
+        their `w:listItem` choices, dates an ISO date. Refuses a protected document, a stale or
+        foreign control, a locked or data-bound surface, a picture, group or building-block
+        control, a dropdown value outside its choices, and an unsupported date format.
         """
         self._validate_ownership()
         _refuse_if_protected(
@@ -870,5 +870,9 @@ def set_control_value(
     tag: Optional[str] = None,
     alias: Optional[str] = None,
 ) -> None:
-    """Find one control by tag/alias and set its value (see Control.set_value)."""
+    """Set the value of the control that `tag` names.
+
+    Refuses when no control carries the tag and when several do, plus every refusal
+    `Control.set_value` raises.
+    """
     get_control(document, tag=tag, alias=alias).set_value(value)

--- a/src/docx/document.py
+++ b/src/docx/document.py
@@ -47,34 +47,12 @@ class Document(ElementProxy):
         author: str = "",
         initials: str | None = "",
     ) -> Comment:
-        """Add a comment to the document, anchored to the specified runs.
+        """Add a comment anchored to `runs`, and return it.
 
-        `runs` can be a single `Run` object or a non-empty sequence of `Run` objects. Only the
-        first and last run of a sequence are used, it's just more convenient to pass a whole
-        sequence when that's what you have handy, like `paragraph.runs` for example. When `runs`
-        contains a single `Run` object, that run serves as both the first and last run.
-
-        A comment can be anchored only on an even run boundary, meaning the text the comment
-        "references" must be a non-zero integer number of consecutive runs. The runs need not be
-        _contiguous_ per se, like the first can be in one paragraph and the last in the next
-        paragraph, but all runs between the first and the last will be included in the reference.
-
-        The comment reference range is delimited by placing a `w:commentRangeStart` element before
-        the first run and a `w:commentRangeEnd` element after the last run. This is why only the
-        first and last run are required and why a single run can serve as both first and last.
-        Word works out which text to highlight in the UI based on these range markers.
-
-        `text` allows the contents of a simple comment to be provided in the call, providing for
-        the common case where a comment is a single phrase or sentence without special formatting
-        such as bold or italics. More complex comments can be added using the returned `Comment`
-        object in much the same way as a `Document` or (table) `Cell` object, using methods like
-        `.add_paragraph()`, .add_run()`, etc.
-
-        The `author` and `initials` parameters allow that metadata to be set for the comment.
-        `author` is a required attribute on a comment and is the empty string by default.
-        `initials` is optional on a comment and may be omitted by passing |None|, but Word adds an
-        `initials` attribute by default and we follow that convention by using the empty string
-        when no `initials` argument is provided.
+        Pass one `Run` or a sequence; only the first and last are used, so handing over
+        `paragraph.runs` works. Reach for `Span.comment` instead when the anchor should match
+        exact text rather than whole runs. Refuses a protected document, runs belonging to
+        another document, and a comments part that is missing or ambiguous.
         """
         # -- normalize `runs` to a sequence of runs --
         runs = [runs] if isinstance(runs, Run) else runs

--- a/src/docx/drawing/__init__.py
+++ b/src/docx/drawing/__init__.py
@@ -64,10 +64,11 @@ class Drawing(Parented):
         return image_part.image
 
     def replace_picture(self, image_descriptor: str | IO[bytes]) -> None:
-        """Swap this drawing's image bytes. Display size and position stay.
+        """Swap this drawing's image bytes, keeping display size and position.
 
-        Always writes a new image part so other shapes that shared the old
-        part are unchanged.
+        Always writes a new image part, so other shapes sharing the old part are unchanged;
+        the old relationship stays behind. Refuses a drawing with no picture, a linked picture
+        whose bytes live outside the package, and a protected document.
         """
         if not self.has_picture:
             raise ValueError("drawing does not contain a picture")

--- a/src/docx/fields.py
+++ b/src/docx/fields.py
@@ -91,7 +91,11 @@ def _simple_field(instr: str, placeholder: str) -> "_Element":
 
 
 def add_page_number_field(paragraph: "Paragraph") -> None:
-    """Append a PAGE field (typically to a footer paragraph)."""
+    """Append a PAGE field, typically to a footer paragraph.
+
+    Writes the field, not a number, so Word computes the page on open. Refuses a protected
+    document.
+    """
     document = _document_of_paragraph(paragraph)
     _refuse_if_protected(document, "insert a field")
     with rollback_on_error(document):
@@ -100,7 +104,11 @@ def add_page_number_field(paragraph: "Paragraph") -> None:
 
 
 def add_page_count_field(paragraph: "Paragraph") -> None:
-    """Append a NUMPAGES field (typically to a footer paragraph)."""
+    """Append a NUMPAGES field, typically to a footer paragraph.
+
+    Writes the field, not a number, so Word computes the count on open. Refuses a protected
+    document.
+    """
     document = _document_of_paragraph(paragraph)
     _refuse_if_protected(document, "insert a field")
     with rollback_on_error(document):
@@ -109,9 +117,11 @@ def add_page_count_field(paragraph: "Paragraph") -> None:
 
 
 def add_date_field(paragraph: "Paragraph", *, date_format: Optional[str] = None) -> None:
-    """Append a DATE field; `date_format` is Word's \\@ picture (e.g.
-    'MMMM d, yyyy'). The result stays a placeholder until a renderer opens
-    the file — this package never computes dates into results."""
+    """Append a DATE field; `date_format` is Word's \\@ picture, for example 'MMMM d, yyyy'.
+
+    The result stays a placeholder until a renderer opens the file; this package never
+    computes a date into the result. Refuses a protected document.
+    """
     document = _document_of_paragraph(paragraph)
     _refuse_if_protected(document, "insert a field")
     instr = " DATE "
@@ -126,8 +136,12 @@ def add_date_field(paragraph: "Paragraph", *, date_format: Optional[str] = None)
 def add_reference_field(
     paragraph: "Paragraph", *, bookmark: str, kind: str = "text"
 ) -> None:
-    """Append a cross-reference to `bookmark`: its text (`kind="text"`), its
-    page (`"page"`), or its paragraph number (`"number"`)."""
+    """Append a cross-reference to `bookmark`: its text (`kind="text"`), page (`"page"`), or
+    paragraph number (`"number"`).
+
+    Writes a REF field, so Word recomputes it on open. Refuses a protected document and an
+    unknown bookmark name.
+    """
     if kind not in _REFERENCE_KINDS:
         raise ValueError(
             f"kind must be one of {sorted(_REFERENCE_KINDS)}, got {kind!r}"
@@ -153,10 +167,11 @@ def add_caption(
     label: str = "Figure",
     description: str = "",
 ) -> None:
-    """Append a SEQ caption (`Figure 1`, `Table 1`, …) to `paragraph`.
+    """Append a SEQ caption (`Figure 1`, `Table 1`) to `paragraph`.
 
-    Word recomputes the number on open. This package writes the field, not
-    the displayed integer.
+    Writes the field rather than the displayed integer, so Word recomputes the number on
+    open. Sets the paragraph style to "Caption" without checking that the style exists.
+    Refuses a protected document and an unknown label.
     """
     if not label:
         raise ValueError("label must be a non-empty caption name")
@@ -181,9 +196,12 @@ def add_caption(
 def insert_toc_after(
     document: "Document", anchor, *, levels: Tuple[int, int] = (1, 3)
 ) -> None:
-    """Insert a TOC complex field (begin / instrText / separate / placeholder
-    / end) in a new paragraph after `anchor`, marked dirty so the renderer
-    builds the real table on open. Heading `levels` maps to \\o "1-3"."""
+    """Insert a TOC field in a new paragraph after `anchor`.
+
+    Marked dirty so the renderer builds the real table on open; heading `levels` maps to the
+    \\o "1-3" switch. Refuses a protected document, and an anchor that is missing, ambiguous
+    or foreign.
+    """
     from docx.blocks import _insert_after, _resolve_anchor_paragraph
 
     low, high = levels

--- a/src/docx/formatting.py
+++ b/src/docx/formatting.py
@@ -87,12 +87,11 @@ _UNRESOLVED = (
 
 @dataclass(frozen=True)
 class ResolvedValue:
-    """One property's effective value plus WHERE it came from.
+    """One property's effective value and where it came from.
 
-    `source`: "direct", "character_style:<id>", "paragraph_style:<id>",
-    "doc_defaults", "toggle_xor" (multiple toggle layers combined — the
-    contributing layers are in `chain`), "mixed" (a span whose runs
-    disagree), or "none" (nothing specifies it).
+    `source` is "direct", "character_style:<id>", "paragraph_style:<id>", "doc_defaults",
+    "toggle_xor", "agreeing_layers", "mixed", or "none". `chain` holds the contributing
+    layers.
     """
 
     value: object
@@ -128,13 +127,12 @@ class EffectiveFormat:
 
 
 def format_of(target) -> EffectiveFormat:
-    """The effective formatting of a |Run|, |Paragraph| or |Span|.
+    """The effective formatting of a `Run`, `Paragraph` or `Span`.
 
-    Runs resolve the supported run-property subset in ``properties``;
-    paragraphs resolve alignment and style plus the supported run defaults
-    their style chain implies. Spans resolve every run they touch and report
-    disagreeing properties as "mixed". Omitted categories are named in
-    ``unresolved`` rather than implicitly reported as absent.
+    Read-only and provenance-bearing: each `ResolvedValue` says where its value came from.
+    Runs resolve the supported run-property subset; paragraphs resolve alignment and style
+    plus the run defaults their style chain implies; spans resolve every run they touch and
+    report "mixed" where runs disagree. Raises `TypeError` for anything else.
     """
     from docx.search import Span
     from docx.text.paragraph import Paragraph
@@ -159,12 +157,11 @@ def format_of(target) -> EffectiveFormat:
 
 
 def surrounding_format(document: "Document", anchor) -> EffectiveFormat:
-    """The effective format AT an anchor — what inserted content should
-    match to adopt its neighbors' look (the insertion helper used when
-    adopting a neighbor's formatting).
+    """The effective format AT an anchor, for content you are about to insert.
 
-    Resolves the anchor paragraph's first text run; an empty paragraph
-    resolves the paragraph itself.
+    Use it so inserted text adopts its neighbours' look. Resolves the anchor paragraph's
+    first text run; an empty paragraph resolves the paragraph's own properties. Refuses an
+    anchor that is missing or ambiguous.
     """
     from docx.blocks import _locate_anchor_paragraph
 

--- a/src/docx/links.py
+++ b/src/docx/links.py
@@ -95,8 +95,10 @@ def _part_for_span(document: "Document", span: "Span"):
 def add_hyperlink(document: "Document", span: "Span", address: str) -> Hyperlink:
     """Wrap `span`'s runs in a hyperlink pointing at `address`.
 
-    The span must lie in a single paragraph. Visible text stays; Word
-    shows it as a link after the file opens.
+    Visible text stays; Word shows it in the Hyperlink character style, which this defines
+    when the document lacks it. Refuses a protected document, a stale or foreign span, a span
+    crossing paragraphs, a field result, an existing hyperlink, and a data-bound, locked or
+    plain-text control surface.
     """
     if not address:
         raise ValueError("address must be a non-empty URL")

--- a/src/docx/notes.py
+++ b/src/docx/notes.py
@@ -206,10 +206,20 @@ def _insert_after_span(runs, mark: "_Element") -> None:
 
 
 def add_footnote(document: "Document", span: "Span", text: str) -> int:
-    """Insert a footnote mark after `span` and create the note body."""
+    """Attach a footnote to `span` and return its note id.
+
+    Creates the footnotes part on first use. Refuses a protected document, a stale or foreign
+    span, a span outside the main body, and one inside a text box, a field result, or a
+    data-bound, locked or plain-text control.
+    """
     return _insert_note(document, span, text, endnote=False)
 
 
 def add_endnote(document: "Document", span: "Span", text: str) -> int:
-    """Insert an endnote mark after `span` and create the note body."""
+    """Attach an endnote to `span` and return its note id.
+
+    Creates the endnotes part on first use. Same refusals as `add_footnote`: protection, a
+    stale or foreign span, a span outside the main body, and one inside a text box, a field
+    result, or a data-bound, locked or plain-text control.
+    """
     return _insert_note(document, span, text, endnote=True)

--- a/src/docx/numbering.py
+++ b/src/docx/numbering.py
@@ -222,7 +222,12 @@ def _effective_paragraph_numbering(
 
 
 def list_numbering(document: "Document") -> NumberingReport:
-    """Every numbering definition and every numbered paragraph in `document`."""
+    """Every numbering definition and every numbered paragraph in `document`.
+
+    Walks all story parts and reports text in the "current" view. Refuses when a paragraph
+    resolves to a definition the document does not define, or to a level that definition
+    omits.
+    """
     definitions = _definitions(_numbering_root(document))
     definitions_by_id = {definition.num_id: definition for definition in definitions}
     numbered = []
@@ -356,10 +361,9 @@ def _document_of_paragraph(paragraph: "Paragraph") -> "Document":
 def apply_numbering(paragraph: "Paragraph", *, num_id: int, level: int = 0) -> None:
     """Give `paragraph` the existing numbering definition `num_id` at `level`.
 
-    The definition must exist in word/numbering.xml and define `level` —
-    otherwise |TargetNotFoundError|; this API never fabricates definitions
-    (create one deliberately with `ensure_bullet_definition` /
-    `ensure_decimal_definition`).
+    Writes `w:numPr` into the paragraph's `w:pPr`. This never fabricates a definition; create
+    one deliberately with `ensure_bullet_definition` or `ensure_decimal_definition`. Refuses a
+    protected document, and a numId or level the document does not define.
     """
     document = _document_of_paragraph(paragraph)
     _refuse_if_protected(document, "apply numbering")
@@ -400,14 +404,10 @@ def _style_numbering_binding(document: "Document", style_name: str) -> Optional[
 
 
 def apply_list_style(paragraph: "Paragraph", style_name: str) -> None:
-    """Apply the existing paragraph style named `style_name` (e.g. a list
-    style like "List Bullet") — |TargetNotFoundError| when undefined.
+    """Apply the existing paragraph style `style_name` to `paragraph`.
 
-    When the style binds a numbering definition, that definition must
-    actually resolve in word/numbering.xml; otherwise this call refuses
-    rather than producing the classic FAKE bullet (a list-styled paragraph
-    that renders with no marker). Styles with no
-    numbering binding apply as plain styles.
+    Refuses a protected document, a style the document does not define, and a style whose
+    numbering binding does not resolve.
     """
     document = _document_of_paragraph(paragraph)
     _refuse_if_protected(document, "apply a list style")
@@ -611,27 +611,32 @@ def _ensure_definition(document: "Document", kind: str) -> int:
 
 
 def ensure_bullet_definition(document: "Document") -> int:
-    """The numId of a real bullet-list definition, creating one when the
-    document has none. Idempotent: repeated calls return the same
-    definition."""
+    """The numId of a canonical bullet-list definition, creating it when absent.
+
+    Creates `/word/numbering.xml` and its relationship on first use. Reuse requires an exactly
+    canonical definition, so a hand-edited one of the same name is left alone and a new
+    definition is appended. Refuses a protected document.
+    """
     _refuse_if_protected(document, "author a numbering definition")
     return _ensure_definition(document, "bullet")
 
 
 def ensure_decimal_definition(document: "Document") -> int:
-    """The numId of a real decimal-list definition, created on demand.
-    Idempotent, like `ensure_bullet_definition`."""
+    """The numId of a canonical decimal-list definition, creating it when absent.
+
+    Same creation and exact-shape reuse rules as `ensure_bullet_definition`. Refuses a
+    protected document.
+    """
     _refuse_if_protected(document, "author a numbering definition")
     return _ensure_definition(document, "decimal")
 
 
 def restart_numbering(document: "Document", *, num_id: int) -> int:
-    """A NEW numId continuing `num_id`'s formatting but restarting at 1.
+    """A NEW numId continuing `num_id`'s formatting but restarting the count at 1.
 
-    Word models restarts as a fresh `w:num` referencing the same abstract
-    definition with a level-0 `w:startOverride`; paragraphs re-point at the
-    returned numId. Anything fancier (mid-list overrides, custom level text)
-    stays out of scope and refuses via the ordinary numId validation.
+    Paragraphs are not re-pointed; re-point them yourself with `apply_numbering`. Refuses a
+    protected document, an unknown numId, a malformed `w:numId`, and a definition carrying
+    `w:lvlOverride`.
     """
     _refuse_if_protected(document, "restart numbering")
     numbering = _numbering_root(document)

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -162,9 +162,16 @@ class OpcPackage:
         return Relationships(PACKAGE_URI.baseURI)
 
     def save(self, pkg_file: str | IO[bytes]):
-        """Save this package to `pkg_file`.
+        """Save this package to `pkg_file`, a path or a stream positioned at byte zero.
 
-        `pkg_file` can be either a file-path or a file-like object.
+        Serializes to a sibling temp file, reparses it to confirm it opens, then replaces the
+        destination. A failed save leaves the original untouched and never leaves behind a
+        package Word cannot open. An existing destination keeps its permission bits. A symlink
+        destination is followed and its target replaced.
+
+        Raises `MalformedPackageError` when the serialized output will not reparse, and
+        `OSError` for a stream in append mode, a stream positioned past byte zero, or a
+        destination symlink that moves mid-save.
         """
         parts = self.parts
         for part in parts:

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -137,9 +137,10 @@ class _ZipPkgReader(PhysPkgReader):
             raise
 
     def blob_for(self, pack_uri):
-        """Return blob corresponding to `pack_uri`.
+        """The bytes of the member `pack_uri` names.
 
-        Raises |ValueError| if no matching member is present in zip archive.
+        Member names are matched case-insensitively, since Word accepts packages whose parts
+        disagree with the relationship in case. Raises `ValueError` when no member matches.
         """
         actual_name = self._member_name_by_fold[pack_uri.membername.casefold()]
         return self._guarded_reader.read(actual_name)

--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -26,7 +26,13 @@ class PackageReader:
 
     @staticmethod
     def from_file(pkg_file):
-        """Return a |PackageReader| instance loaded with contents of `pkg_file`."""
+        """A `PackageReader` loaded from `pkg_file`, with the package graph already validated.
+
+        This is the read path behind `Document()`, so a malformed file is caught here rather
+        than carried into the object model. Raises `MalformedPackageError` for a corrupt or
+        ambiguous archive, a relationship targeting a missing part, a part with no declared
+        content type, or a content type that contradicts its relationship.
+        """
         phys_reader = PhysPkgReader(pkg_file)
         try:
             content_types = _ContentTypeMap.from_xml(phys_reader.content_types_xml)

--- a/src/docx/opc/pkgwriter.py
+++ b/src/docx/opc/pkgwriter.py
@@ -29,8 +29,9 @@ class PackageWriter:
 
     @staticmethod
     def write(pkg_file, pkg_rels, parts):
-        """Write a physical package (.pptx file) to `pkg_file` containing `pkg_rels` and
-        `parts` and a content types stream based on the content types of the parts."""
+        """Write `parts` and `pkg_rels` to `pkg_file` as a .docx package, with a content-types
+        stream derived from the parts.
+        """
         phys_writer = PhysPkgWriter(pkg_file)
         try:
             PackageWriter._write_content_types_stream(phys_writer, parts)

--- a/src/docx/protection.py
+++ b/src/docx/protection.py
@@ -192,6 +192,12 @@ class ProtectionStatus:
 
     @property
     def blocks_paper_edits(self) -> bool:
+        """True when protection is enforced and has not been acknowledged.
+
+        Not a prediction of whether a call will refuse: it ignores the operation class, so it
+        reports True under trackedChanges or formatting-only protection where the gate still
+        permits body edits and comments. Call `acknowledge_protection` to proceed deliberately.
+        """
         return self.enforced and not self.acknowledged
 
     def to_dict(self) -> dict:

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -227,8 +227,13 @@ class Revision:
             )
 
     def accept(self) -> None:
-        """Apply this change to the document. Tracked moves resolve as a
-        PAIR: accepting either site accepts both."""
+        """Apply this change to the document.
+
+        Tracked moves resolve as a PAIR: accepting either site accepts both. Resolution can
+        remove paragraphs, rows, tables, comments and note bodies along with the markup.
+        Refuses a protected document, and revision types this package cannot resolve, leaving
+        the document untouched.
+        """
         self._refuse_unresolvable("accept")
         self._refuse_if_stale("accept")
         if self._document is not None:
@@ -247,8 +252,12 @@ class Revision:
         _resolve_one(self._element, accept=True, document=None)
 
     def reject(self) -> None:
-        """Undo this change, restoring the pre-change content. Tracked moves
-        resolve as a PAIR: rejecting either site rejects both."""
+        """Undo this change, restoring the pre-change content.
+
+        Tracked moves resolve as a PAIR: rejecting either site rejects both. Restores `w:delText`
+        back to `w:t`. Refuses a protected document, and revision types this package cannot
+        resolve, leaving the document untouched.
+        """
         self._refuse_unresolvable("reject")
         self._refuse_if_stale("reject")
         if self._document is not None:
@@ -300,20 +309,19 @@ class Revisions(Sequence[Revision]):
         return iter(self._items)
 
     def accept_all(self, *, author: Optional[str] = None) -> int:
-        """Apply every selected revision (optionally only `author`'s).
+        """Apply every selected revision (optionally only `author`'s) and return the count.
 
-        Validates the WHOLE selected set first: if it contains revision types
-        this package cannot resolve, the call refuses atomically — it never
-        half-resolves and reports success while
-        Word still shows pending changes. Returns the resolved count; check
-        `remaining_unsupported()` before inferring "the document is clean".
+        Validates the whole selected set first, so a set holding types this package cannot
+        resolve refuses atomically instead of half-resolving and reporting success while Word
+        still shows changes. Refuses a protected document and a stale snapshot. Check
+        `remaining_unsupported()` before concluding the document is clean.
         """
         return self._resolve_all(accept=True, author=author)
 
     def reject_all(self, *, author: Optional[str] = None) -> int:
-        """Undo every selected revision (optionally only `author`'s).
+        """Undo every selected revision (optionally only `author`'s) and return the count.
 
-        Same selected-set validation and census semantics as `accept_all`.
+        Same whole-set validation, refusals and census semantics as `accept_all`.
         """
         return self._resolve_all(accept=False, author=author)
 
@@ -920,11 +928,12 @@ _MARKUP_SCAN_TAGS = tuple(_REVISION_TYPES) + tuple(
 
 
 def _remaining_markup(document: "Document") -> dict:
-    """{local-tag-name: count} of ALL revision markup left ANYWHERE — the
-    full serialized space, including mc:Fallback branches (which traversal
-    skips but a saved file still carries). The invariant oracle: after a
-    successful `accept_all()`/`reject_all()` this is empty — "resolved"
-    while markup remains anywhere would be false state.
+    """{local-tag-name: count} of ALL revision markup left anywhere in the serialized space,
+    including `mc:Fallback` branches that traversal skips.
+
+    The clean-document oracle: empty after an unfiltered `accept_all()`/`reject_all()`. An
+    author-filtered call legitimately leaves other authors' markup, so empty is not the
+    expectation there.
     """
     counts: dict = {}
     for _story, root in _story_elements(document):

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -1534,9 +1534,9 @@ def replace_all(
     """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
 
     One scan finds all matches, then replacements apply in reverse document order within each
-    story, so no pending match shifts. A refusal aborts the batch: replacements already
-    applied are rolled back, making the call all-or-nothing. Matches already equal to
-    `new_text` are skipped.
+    story, so no pending match shifts. A refusal on one match is recorded in `refused` and the
+    rest proceed; a stale span aborts the batch instead, rolling back every replacement already
+    applied. Matches already equal to `new_text` are skipped.
     """
     from docx.errors import PaperRefusal
 

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -331,7 +331,12 @@ def _normalized_with_map(value: str) -> Tuple[str, List[int]]:
 
 @dataclass(frozen=True)
 class ReplaceResult:
-    """Outcome of a `Span.replace` call."""
+    """Outcome of a `Span.replace` call.
+
+    `deleted_text` and `inserted_text` cover the whole span for an untracked replace but only
+    the affix-trimmed middle for a tracked one, so comparing them against `Span.text` is
+    wrong for tracked edits.
+    """
 
     story: str
     deleted_text: str
@@ -404,11 +409,12 @@ class Span:
         initials: Optional[str] = None,
         date: Optional[dt.datetime] = None,
     ) -> "object":
-        """Anchor a new comment to exactly this span's text.
+        """Anchor a new comment to exactly this span's text, and return the upstream `Comment`.
 
-        Returns the upstream |Comment|. The comment range marks wrap the
-        span's runs; `date` defaults to the injectable clock. Comments can
-        only be anchored in the main document story.
+        Reach for this over `Document.add_comment` when the anchor must match exact text rather
+        than whole runs. Splits boundary runs, and creates `/word/comments.xml` on first use.
+        Only the main document story carries comments. Refuses a protected document, a stale
+        span, and a locked or data-bound control surface.
         """
         if not author:
             raise ValueError("author is required")
@@ -851,17 +857,11 @@ class Span:
     ) -> ReplaceResult:
         """Replace this span's text, preserving run formatting.
 
-        Untracked: surgical in-place edit — untouched runs keep their `rPr`
-        byte-identical; the replacement renders with the start run's
-        formatting. Tracked: emits a minimal `w:del`/`w:ins` pair (common
-        prefix/suffix trimmed) stamped with `author`, `date` (default: the
-        injectable clock) and a unique revision id.
-
-        Filling a content control that still shows placeholder text clears
-        the placeholder state (`w:showingPlcHdr` + `PlaceholderText` style)
-        so Word treats the control as genuinely filled.
-
-        All refusal conditions are checked before any mutation.
+        Untracked, this edits in place: untouched runs keep their `rPr` byte-identical, the
+        replacement takes the start run's formatting, and the span stays usable. Tracked, it
+        emits a minimal `w:del`/`w:ins` pair and CONSUMES the span. Refuses a protected document,
+        a stale or foreign span, a span crossing a field or control boundary, and a tracked
+        no-op.
         """
         if tracked and not author:
             raise ValueError("author is required when tracked=True")
@@ -1531,14 +1531,12 @@ def replace_all(
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> ReplaceAllResult:
-    """Replace every match of `needle` in one pass.
+    """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
 
-    Pinned invalidation semantics: one scan finds all matches, then
-    replacements apply in REVERSE document order within each story, so no
-    replacement can shift the offsets of one still pending — matches sharing
-    a run stay valid without re-finding. Matches that refuse individually
-    (field results, revision overlaps, bookmark hollowing, …) are reported in
-    `refused` with their reason; the rest proceed.
+    One scan finds all matches, then replacements apply in reverse document order within each
+    story, so no pending match shifts. A refusal aborts the batch: replacements already
+    applied are rolled back, making the call all-or-nothing. Matches already equal to
+    `new_text` are skipped.
     """
     from docx.errors import PaperRefusal
 
@@ -1622,9 +1620,9 @@ def find_one(
 ) -> Span:
     """The single span matching `needle`, or a typed refusal.
 
-    Zero matches raise |TargetNotFoundError|; more than one (after `nth`,
-    `near`, `story` disambiguation) raises |AmbiguousTargetError| — the
-    library never guesses which occurrence you meant.
+    Zero matches raise `TargetNotFoundError`. Two or more raise `AmbiguousTargetError`:
+    `nth` and `story` narrow the set, while `near` only ranks `find_text` results and never
+    reduces them.
     """
     matches = find_text(document, needle, nth=nth, near=near, story=story, view=view)
     if not matches:

--- a/src/docx/story.py
+++ b/src/docx/story.py
@@ -450,8 +450,11 @@ def _iter_block_elements(
 
 
 def _count_fldchar_delta(element: "_Element") -> int:
-    """Net change in open complex-field depth across `element`'s traversal
-    space (begins minus ends, floored at closing more than opened)."""
+    """Net change in open complex-field depth across `element`: begins minus ends.
+
+    Goes negative when a block closes more fields than it opens; `iter_blocks` clamps at the
+    call site.
+    """
     delta = 0
 
     def walk(node: "_Element") -> None:

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -235,11 +235,13 @@ def update_cell(
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> ReplaceResult:
-    """Replace the visible text of one cell (0-based `row`/`column`).
+    """Replace one cell's visible text and return a `ReplaceResult` (0-based `row`,
+    layout-grid `column`).
 
-    Routed through `Span.replace`: the first run's formatting carries the new
-    text, other formatting is untouched, and `tracked=True` produces a real
-    revision. Complex tables and multi-paragraph cells are refused.
+    Runs through `Span.replace`, so the first run's formatting carries the text. Guards are
+    cell-wise: a merged header elsewhere in the table does not block a plain target cell.
+    Refuses a protected document, an out-of-range address, and a merged, multi-paragraph or
+    nested target.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
@@ -340,8 +342,12 @@ def insert_row_after(
     *,
     copy_format_from: Optional[int] = None,
 ) -> None:
-    """Insert a new row after `row` (0-based), copying formatting from
-    `copy_format_from` (default: the anchor row) and filling `values`."""
+    """Insert a row after `row` (0-based), copying formatting from `copy_format_from` and
+    filling `values`.
+
+    Refuses a protected document, an out-of-range index, and a target row that is merged or
+    holds a nested table.
+    """
     _refuse_if_protected(_document_of(table), "insert a table row")
     rows = table.rows
     if not 0 <= row < len(rows):
@@ -418,8 +424,11 @@ def _set_cell_text_keeping_format(cell: "_Cell", text: str) -> None:
 
 
 def delete_row(table: "Table", row: int) -> None:
-    """Delete row `row` (0-based). The last remaining row is refused —
-    a rowless table is not valid WordprocessingML."""
+    """Delete row `row` (0-based).
+
+    Refuses the last remaining row, since a rowless table is not valid WordprocessingML.
+    Refuses a protected document, an out-of-range index, and a merged or nested target.
+    """
     _refuse_if_protected(_document_of(table), "delete a table row")
     rows = table.rows
     if not 0 <= row < len(rows):

--- a/src/docx/text/hyperlink.py
+++ b/src/docx/text/hyperlink.py
@@ -49,7 +49,11 @@ class Hyperlink(Parented):
 
     @address.setter
     def address(self, value: str) -> None:
-        """Point this hyperlink at a new external URL."""
+        """Point this hyperlink at a new external URL.
+
+        Clears `fragment`, so retargeting an internal jump turns it into an external
+        link. Refuses an empty address and a protected document.
+        """
         document = self.part.package.main_document_part.document
         _refuse_if_protected(document, "retarget a hyperlink")
         if not value:

--- a/src/docx/text/run.py
+++ b/src/docx/text/run.py
@@ -176,9 +176,11 @@ class Run(StoryChild):
                 yield Drawing(item, self)
 
     def mark_comment_range(self, last_run: Run, comment_id: int) -> None:
-        """Mark the range of runs from this run to `last_run` (inclusive) as belonging to a comment.
+        """Mark the runs from this one to `last_run` as a comment range for `comment_id`.
 
-        `comment_id` identfies the comment that references this range.
+        Called by the comment-anchoring machinery; prefer `Document.add_comment` or
+        `Span.comment`. Refuses when the two runs belong to different documents, leaving the
+        XML unchanged.
         """
         root = self._r.getroottree().getroot()
         if root is not last_run._r.getroottree().getroot():


### PR DESCRIPTION
Stacked on #30.

Docstrings ship in the wheel and are the only documentation that reaches an agent working
offline, so a wrong one is an authoritative wrong answer with nothing to contradict it. The
published reference is generated from the same text.

I audited all **683 definitions paper-docx adds or changes** against the `paper-base` tag
(python-docx 1.2.0). 477 needed work, and one cause explains most of them: **refusals are
raised in helpers, and the reasons are written into exception messages and helper docstrings
while the public verb stays silent.** `_refuse_if_protected` documents itself clearly and
none of its ~20 public callers repeated that, so `DocumentProtectedError` read as a crash
from every mutating verb in the package.

This PR lands the 72 findings where the docstring was **false** or **hid a refusal**.

## Thirteen said something the code contradicts

| Symbol | The claim |
| --- | --- |
| `find_one` | Presented `near` as a disambiguator. It only ranks, so `find_one(..., near=x)` still raises `AmbiguousTargetError`. |
| `OpcPackage.save` | "either a file-path or a file-like object" — append-mode streams and streams past byte zero are refused. |
| `tableops.update_cell` | "Complex tables are refused" — the guard is cell-wise, so a merged header elsewhere does not block a plain target cell. |
| `compare` | Said it returns "a new document"; it returns a `CompareResult`, and it accepts bytes as well as paths. |
| `diagnose` | Justified itself by saying `Document()` raises untyped errors. The package-validation work made that false for corrupt and encrypted input. |
| `ResolvedValue` | Gave a closed list of `source` values missing `"agreeing_layers"`. |
| `PackageWriter.write` | Said it writes "a .pptx file". |
| `_remaining_markup` | Stated an invariant that fails for an author-filtered call — and it is the clean-document oracle `_compare.py` and four test modules rely on. |
| `_assert_packages_match`, `_replace_paragraph_text`, `_reachable_package_objects`, `_count_fldchar_delta`, `_ZipPkgReader.blob_for` | Contracts other modules depend on, each contradicted by the code. |

## The rest name the refusals

Refusal sets were **derived by walking each function's call graph across module boundaries**,
not read off the body — the body is exactly where they are not. A same-file walk reports
`apply_numbering` as raising only `TargetNotFoundError` and misses the
`DocumentProtectedError` that is the whole point.

## Concision

Public mutating verbs land at or under 70 words; everything else is shorter. `add_comment`
came down from 328 words. Four stay long on purpose, because each loses a rule if trimmed:
`OpcPackage.save` and `patch_save` (atomicity, byte-stability, what survives a failure),
`xml_equivalent` (the comparison semantics `patch_save` depends on), and
`_has_end_of_central_directory` (the measured counterexample that stops someone simplifying
it back into a bug).

## Verification

- **Docstrings only.** Every one of the 28 changed files is AST-identical to its parent once
  docstrings are stripped. A docs PR has no business touching code and that is not checkable
  by eye across 68 docstrings.
- `pytest`: 2760 passed, 7 skipped, and the same 9 pre-existing `tests/opc/test_phys_pkg.py`
  errors the parent commit has.
- `behave`: 650 scenarios passed.
- `ruff`: unchanged at 16 pre-existing findings; no file newly fails `ruff format`.
- Zero syntax warnings across `src/docx`.

## Not in this PR

- **P3, 79 public symbols with no docstring at all** — six frozen dataclasses that are the
  JSON contract, ten properties, twenty `to_dict` methods. Blank entries in the reference.
- **P4, 333 internal helpers.**
- **A gate.** Nothing in `AGENTS.md` states the contract and no test enforces it, which is how
  284 definitions reached main undocumented. Proposed: `test_docstring_contract.py` asserting
  a docstring exists, fits the budget, and names a refusal when the body raises a
  `PaperRefusal` subclass — deriving the refusal list from `errors.py` by AST, since
  `PackageLimitError` became `MalformedPackageError` on this branch and a hardcoded list
  would have gone quiet instead of failing.

## Two things needing a decision, not a docstring

- **`errors.RelationshipPolicyError` is never raised anywhere in `src/docx`.** It exists only
  in the pinned API-surface test and the docs, so the reference promises a refusal the code
  cannot produce.
- **`controls.py`'s module docstring is wrong**: it says dropdowns *and* combos validate
  against their `w:listItem` choices. Only dropdowns do, and `set_value` says the opposite.
  Left alone here because the fix is a behaviour question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no executable logic touched; risk is limited to doc drift if future code changes are not reflected in docstrings.
> 
> **Overview**
> **Docstrings only** across ~28 modules in `src/docx` — no runtime or API behavior changes. The wheel ships these strings as the offline reference for agents and humans.
> 
> Public **paper** APIs get shorter, accurate contracts: return types (`CompareResult`, `BlockEditResult`, `PackageDiagnosis`), when to prefer one entry point over another (`Span.comment` vs `Document.add_comment`), and explicit **refusal** conditions (protected documents, stale/foreign anchors, ambiguous targets) that previously lived only in helper messages.
> 
> **Corrected misleading docs** where the old text disagreed with code — e.g. `compare` (paths/bytes, `CompareResult`), `find_one` (`near` ranks only), `pending_changes` (empty diff ≠ no revision markup), `tableops.update_cell` (cell-wise guards), `OpcPackage.save` / `diagnose` / `PackageWriter.write`, `ResolvedValue.source`, and internal oracles like `_remaining_markup` and `_assert_packages_match`.
> 
> Verbose upstream-style narratives (especially comments and `add_comment`) are replaced with bounded summaries; long saves (`patch_save`, `OpcPackage.save`) and comparison helpers stay detailed on purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da6b10690e3af0e7250d72d7275e2c72f5120867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies 72 docstrings to state refusal conditions and correct false statements; behavior is unchanged but the documentation contract now matches enforcement.

- Public APIs now name protection, stale/foreign object, story/control boundary, bookmark-reference, numbering-definition, and comments extension refusals where applicable.
- Examples corrected: `compare` returns `CompareResult` and accepts paths or bytes; `find_one`’s `near` ranks but does not disambiguate; `replace_all` aborts and rolls back only on a stale span while other refusals are collected and the rest proceed; `OpcPackage.save` only accepts a path or a stream at byte zero and guarantees atomic, byte-stable saves; `update_cell` guards per cell, not per table; `pending_changes` does not imply a clean document when empty; `ResolvedValue.source` includes "agreeing_layers".

**Review notes**
- Docstrings-only: all 28 files are AST-identical once docstrings are stripped; unit and behavior tests are unchanged and passing.
- Longer docstrings kept intentionally for `OpcPackage.save` and `patch_save` due to atomicity and byte-stability guarantees.
- Generated reference will reflect the clarified refusal sets and usage guidance.

**Migration**
- Handle `CompareResult` from `compare` instead of a document.
- Do not rely on `near` to reduce matches in `find_one`; use `nth` or `story`.
- Prepare for `MalformedPackageError` and `OSError` from `OpcPackage.save`; pass a path or a stream positioned at byte zero.
- Update any enum checks to accept `ResolvedValue.source == "agreeing_layers"`.
- Treat an empty `pending_changes` as “no visible text changes,” not “no revisions”; consult `Document.revisions`.

<sup>Written for commit 14b58df40f7bbd8c79ee09ad4d5232b458b3b13c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-docx/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

