### PR TITLE
docs: left-align the README and match the paper-xlsx format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,37 @@
 <div align="center">
   <a href="https://github.com/paper-instruments/paper-docx">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset=".github/assets/logo-dark.svg">
-      <img alt="paper-docx logo" src=".github/assets/logo-light.svg" height="128">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/paper-instruments/paper-docx/main/.github/assets/logo-dark.svg">
+      <img alt="paper-docx logo" src="https://raw.githubusercontent.com/paper-instruments/paper-docx/main/.github/assets/logo-light.svg" height="128">
     </picture>
   </a>
   <h1>paper-docx</h1>
 
 [![PyPI](https://img.shields.io/pypi/v/paper-docx.svg)](https://pypi.org/project/paper-docx/)
 [![Python versions](https://img.shields.io/pypi/pyversions/paper-docx.svg)](https://pypi.org/project/paper-docx/)
-[![License](https://img.shields.io/pypi/l/paper-docx.svg)](LICENSE)
-[![CI](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml/badge.svg)](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml)
-[![Downloads](https://img.shields.io/pypi/dm/paper-docx.svg)](https://pypi.org/project/paper-docx/)
+[![Test](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml/badge.svg)](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml)
 
 </div>
 
-<div align="center">
-  <a href="https://github.com/paper-instruments/paper-docx">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset=".github/assets/logo-dark.svg">
-      <img alt="paper-docx logo" src=".github/assets/logo-light.svg" height="128">
-    </picture>
-  </a>
-  <h1>paper-docx</h1>
+**An import-compatible, agent-safe fork of python-docx designed to prevent silent corruption when editing existing Word documents.**
 
-[![PyPI](https://img.shields.io/pypi/v/paper-docx.svg)](https://pypi.org/project/paper-docx/)
-[![Python versions](https://img.shields.io/pypi/pyversions/paper-docx.svg)](https://pypi.org/project/paper-docx/)
-[![License](https://img.shields.io/pypi/l/paper-docx.svg)](LICENSE)
-[![CI](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml/badge.svg)](https://github.com/paper-instruments/paper-docx/actions/workflows/test.yml)
-
-`paper-docx` is an agent-first Python library for safely inspecting, editing,
-reviewing, and composing existing Microsoft Word (`.docx`) documents. It is a
-strict-superset hard fork of
-[`python-docx`](https://github.com/python-openxml/python-docx) and a drop-in
-replacement. The distribution is renamed; the import name stays `docx`, so
-existing code keeps working unchanged.
+`paper-docx` is a strict-superset hard fork of [python-docx](https://github.com/python-openxml/python-docx) for safely inspecting, editing, reviewing, and composing existing Microsoft Word (`.docx`) documents. It keeps python-docx's package layer, XML mapping, and object model. It adds typed inspection of what a document actually contains, edits that survive Word's run fragmentation, and refusals in place of guesses.
 
 ```python
-import docx                       # the import name is unchanged
-doc = docx.Document("contract.docx")
+import docx   # the import name is unchanged — see "Drop-in by design"
 ```
 
-## Why it exists
+Every added operation either does exactly what it claims or refuses atomically. Gates such as Restrict-Editing are checked before anything is touched, and compound edits capture the live package first and restore it if they raise. A refusal raises a typed `PaperRefusal` and leaves the document byte-for-byte unchanged in memory and on disk.
 
-`python-docx` is excellent at *creating* documents. Its lossless package layer,
-disciplined XML mapping, and years of absorbed edge cases are why this fork
-builds on it.
+---
 
-The harder problem is changing a contract or other real-world document without
-losing formatting, revisions, fields, or content outside the body. Hand-edited
-XML can produce **silent corruption**: a file that opens fine and is quietly
-wrong. An agent cannot eyeball the result, so it needs the document's structure
-and every edit outcome as typed, machine-readable data. It also needs the
-library to refuse rather than guess.
+## Why paper-docx exists
 
-## Safety contract
+`python-docx` is excellent at *creating* documents. Its lossless package layer, disciplined XML mapping, and years of absorbed edge cases are why this fork builds on it.
 
-Every added operation either does exactly what it claims or refuses atomically.
-Gates such as Restrict-Editing are checked before anything is touched, and
-compound edits capture the live package first and restore it if they raise. If
-an operation cannot proceed safely, it raises a typed `PaperRefusal` and leaves
-the document byte-for-byte unchanged in memory and on disk. Callers can catch `PaperRefusal`
-separately from programmer errors, which remain plain `ValueError` or
-`TypeError`. Comparison and rewrite paths preserve meaningful whitespace,
-including trailing spaces inside runs.
+The harder problem is changing a contract or other real-world document without losing formatting, revisions, fields, or content outside the body. Hand-edited XML can produce **silent corruption**: a file that opens fine and is quietly wrong. An agent cannot eyeball the result, so it needs the document's structure and every edit outcome as typed, machine-readable data. It also needs the library to refuse rather than guess.
 
-## A short example
+## Quick start
 
 Create a native Word redline from two document versions:
 
@@ -90,68 +56,42 @@ result.document.paragraphs[0].text
 # 'Payment is due within thirty business days of the invoice date.'
 ```
 
-`compare` emits markup Word renders as tracked changes. Before returning, it
-accepts and rejects private copies and verifies both outcomes. If a difference
-cannot be represented safely as a redline, such as a style or package-part
-change, it raises a typed refusal instead of returning an incomplete result.
+`compare` emits markup Word renders as tracked changes. Before returning, it accepts and rejects private copies and verifies both outcomes. If a difference cannot be represented safely as a redline, such as a style or package-part change, it raises a typed refusal instead of returning an incomplete result.
 
-## What it adds
+## What paper-docx adds
 
 ### Reading and editing one document
 
-- **`docx.story`** traverses the body, headers, footers, footnotes, endnotes,
-  comments, tracked insertions, content controls, and text boxes. Callers can
-  view the document as it stands, before pending revisions, or all at once.
-- **`docx.search`** finds normalized text across Word's run fragmentation. A
-  returned `Span` can replace the matched text while preserving unaffected
-  runs, emit the replacement as a tracked change, or anchor a comment.
-- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to
-  a text anchor, plainly or as a tracked change.
-- **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that
-  refuse on unsafe structures such as merged cells, nested tables, or undefined
-  numbering.
-- **`docx.controls`** fills content controls with the correct value type and
-  clears placeholder state so Word treats them as filled.
-- **`docx.bookmarks` / `docx.fields`** create bookmarks over a span and author
-  page numbers, dates, cross-references, captions, and tables of contents as
-  fields with placeholder results.
-- **`docx.notes` / `docx.links`** anchor real footnotes, endnotes, and
-  hyperlinks to a matched span, so they compose with `docx.search` rather than
-  needing their own targeting.
-- **`Drawing.replace_picture`** swaps the image behind a drawing in place,
-  leaving its size, position, and identity alone.
-- **`docx.formatting`** resolves effective formatting through document defaults,
-  styles, and direct formatting, with provenance for each value.
+- **`docx.story`** traverses the body, headers, footers, footnotes, endnotes, comments, tracked insertions, content controls, and text boxes. Callers can view the document as it stands, before pending revisions, or all at once.
+- **`docx.search`** finds normalized text across Word's run fragmentation. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
+- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to a text anchor, plainly or as a tracked change.
+- **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that refuse on unsafe structures such as merged cells, nested tables, or undefined numbering.
+- **`docx.controls`** fills content controls with the correct value type and clears placeholder state so Word treats them as filled.
+- **`docx.bookmarks` / `docx.fields`** create bookmarks over a span and author page numbers, dates, cross-references, captions, and tables of contents as fields with placeholder results.
+- **`docx.notes` / `docx.links`** anchor real footnotes, endnotes, and hyperlinks to a matched span, so they compose with `docx.search` rather than needing their own targeting.
+- **`Drawing.replace_picture`** swaps the image behind a drawing in place, leaving its size, position, and identity alone.
+- **`docx.formatting`** resolves effective formatting through document defaults, styles, and direct formatting, with provenance for each value.
 
 ### Reviewing
 
-- **`doc.revisions`** enumerates and resolves tracked changes across every part:
-  insertions, deletions, run and paragraph format changes, table-row revisions,
-  and moves. Unresolvable markup is listed by name.
-- **`docx.comments` / `docx.commentops`** read comments and delete one by
-  identity, keeping the modern comment identity parts consistent.
-- **`docx.protection`** reads, sets, and respects Restrict-Editing. Mutating
-  operations refuse on a protected document unless the caller explicitly
-  overrides, and the setting is preserved in the document.
+- **`doc.revisions`** enumerates and resolves tracked changes across every part: insertions, deletions, run and paragraph format changes, table-row revisions, and moves. Unresolvable markup is listed by name.
+- **`docx.comments` / `docx.commentops`** read comments and delete one by identity, keeping the modern comment identity parts consistent.
+- **`docx.protection`** reads, sets, and respects Restrict-Editing. Mutating operations refuse on a protected document unless the caller explicitly overrides, and the setting is preserved in the document.
 
 ### Working across documents
 
-- **`docx.package.compare`** generates a native tracked-change redline from two
-  documents, with the accept/reject round-trip shown above.
-- **`docx.package.patch_save` / `diff_package` / `text_diff`** keeps unchanged
-  parts byte-identical and reports changed parts and text. `diagnose` explains
-  why an unreadable file cannot be opened.
-- **`docx.composition`** copies formatted content between documents, reconciles
-  styles, numbering, media, hyperlinks, and bookmarks, and reports every part
-  touched.
+- **`docx.package.compare`** generates a native tracked-change redline from two documents, with the accept/reject round-trip shown above.
+- **`docx.package.patch_save` / `diff_package` / `text_diff`** keeps unchanged parts byte-identical and reports changed parts and text. `diagnose` explains why an unreadable file cannot be opened.
+- **`docx.composition`** copies formatted content between documents, reconciles styles, numbering, media, hyperlinks, and bookmarks, and reports every part touched.
 - **`docx.errors`** exposes typed refusals, distinct from programmer errors.
 
-## Drop-in and name map
+## Safety contract
 
-Only the distribution and repository are renamed. The importable package stays
-`docx`. This is the same distribution/import split as Pillow
-(`pip install pillow`, `import PIL`), and it preserves existing code, snippets,
-and model priors.
+Callers can catch `PaperRefusal` separately from programmer errors, which remain plain `ValueError` or `TypeError`. The subclasses say what went wrong: `DocumentProtectedError`, `MalformedPackageError`, `TargetNotFoundError`, `AmbiguousTargetError`, `UnsupportedStructureError`, `RelationshipPolicyError`, and `BoundaryViolationError`. Comparison and rewrite paths preserve meaningful whitespace, including trailing spaces inside runs.
+
+## Drop-in by design
+
+Only the distribution and repository are renamed. The importable package stays `docx`. This is the same distribution/import split as Pillow (`pip install pillow`, `import PIL`), and it preserves existing code, snippets, and model priors.
 
 - GitHub repository / PyPI distribution: **`paper-docx`**
 - Python import: **`docx`**
@@ -166,9 +106,7 @@ python -m pip uninstall -y python-docx paper-docx
 python -m pip install paper-docx
 ```
 
-The clean uninstall is required when migrating from `python-docx`. Both
-distributions use the frozen `docx` import package, and pip cannot safely
-overlay or uninstall two distributions that own the same files.
+The clean uninstall is required when migrating from `python-docx`. Both distributions use the frozen `docx` import package, and pip cannot safely overlay or uninstall two distributions that own the same files.
 
 Confirm the install:
 
@@ -176,34 +114,38 @@ Confirm the install:
 paper-docx-doctor
 ```
 
-Pip does not treat `paper-docx` as satisfying another package's declared
-dependency on `python-docx`. That dependency will reinstall upstream and
-overwrite shared `docx` files. Replace or remove the dependency, or run that
-package in a separate environment.
+Pip does not treat `paper-docx` as satisfying another package's declared dependency on `python-docx`. That dependency will reinstall upstream and overwrite shared `docx` files. Replace or remove the dependency, or run that package in a separate environment.
 
-In a controlled deployment, a constraint containing `python-docx<0` makes pip
-reject direct or transitive attempts to install upstream. The constraint must
-be applied to every install in that environment.
+In a controlled deployment, a constraint containing `python-docx<0` makes pip reject direct or transitive attempts to install upstream. The constraint must be applied to every install in that environment.
 
 ## Documentation
 
-The Sphinx docs extend the upstream python-docx documentation to cover the
-fork's additions: start with `docs/user/paper-additions.rst` and the
-`docs/api/paper-*.rst` reference pages. Everything inherited from python-docx
-works as documented at the
-[python-docx documentation](https://python-docx.readthedocs.io/).
+The Sphinx docs extend the upstream python-docx documentation to cover the fork's additions: start with `docs/user/paper-additions.rst` and the `docs/api/paper-*.rst` reference pages. Everything inherited from python-docx works as documented at the [python-docx documentation](https://python-docx.readthedocs.io/).
 
-## How it's tested
+## Testing
 
-- Upstream's pytest and behave suites run on every commit to check compatibility
-  with existing behavior.
-- A frozen, hash-pinned fixture corpus spans generated and LibreOffice-authored
-  documents.
-- The contract harness checks refusal atomicity and validates the fixture corpus
-  with a headless LibreOffice load smoke.
+- Upstream's pytest and behave suites run on every commit to check compatibility with existing behavior.
+- A frozen, hash-pinned fixture corpus spans generated and LibreOffice-authored documents.
+- The contract harness checks refusal atomicity and validates the fixture corpus with a headless LibreOffice load smoke.
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](https://github.com/paper-instruments/paper-docx/blob/main/CONTRIBUTING.md) for the engineering discipline this fork runs on. The short version: the upstream suite must remain green; persistence changes need saved-and-reopened assertions and exact package-delta checks; guarded refusals must be atomic and leave bytes unchanged; and a refusal message must name what was found, why it is unsafe, and what to do about it.
+
+Useful non-code contributions include real-world fixtures authored by desktop Word under the provenance rules in [CONTRIBUTING.md](https://github.com/paper-instruments/paper-docx/blob/main/CONTRIBUTING.md).
+
+## Community
+
+- **Bugs and feature requests**: [GitHub Issues](https://github.com/paper-instruments/paper-docx/issues)
+- **Questions and ideas**: [GitHub Discussions](https://github.com/paper-instruments/paper-docx/discussions)
+- **Security**: see [SECURITY.md](https://github.com/paper-instruments/paper-docx/blob/main/SECURITY.md)
+
+## Acknowledgments
+
+paper-docx exists because python-docx's package layer and XML mapping are excellent. Thanks to Steve Canny and the python-docx contributors for the work this project builds on. Upstream python-docx lives at [github.com/python-openxml/python-docx](https://github.com/python-openxml/python-docx).
+
+If you reference this project in writing, cite it as *paper-docx* (Paper Instruments, Inc.), a fork of *python-docx* by Steve Canny and contributors, and link to this repository.
 
 ## License
 
-MIT, inherited from python-docx. Original work © Steve Canny and the python-docx
-contributors; fork additions © Paper Instruments, Inc. This fork preserves the
-upstream license and attribution. See [`LICENSE`](LICENSE).
+MIT, inherited from python-docx. Original work © Steve Canny and the python-docx contributors; fork additions © Paper Instruments, Inc. This fork preserves the upstream license and attribution. See [LICENSE](https://github.com/paper-instruments/paper-docx/blob/main/LICENSE).


### PR DESCRIPTION
## The bug

When #11 was rebased, the logo header block was duplicated and the second `<div align="center">` was never closed. `main` today has **two opening divs and one closing div**, so every section from line 18 down renders centered.

```
$ grep -n '<div\|</div>' README.md
1:<div align="center">
16:</div>
18:<div align="center">      <-- never closed
```

That is my error from the rebase conflict resolution in #11, not something that came from `main`.

## The fix

Rewrites the README to the paper-xlsx shape rather than just closing the tag, since the two should match:

- one centered header block that closes, then everything left-aligned
- bold tagline, import fence, a single `---`, then sections
- section names aligned to their xlsx counterparts: **Quick start**, **What paper-docx adds**, **Drop-in by design**, **Testing**
- **Contributing**, **Community**, and **Acknowledgments** added, pointing at the `CONTRIBUTING.md` and `SECURITY.md` that #11 landed

| README | Lines | `<div>` / `</div>` |
|---|---|---|
| paper-xlsx `main` | 189 | 1 / 1 |
| paper-docx `main` | 209 | **2 / 1** |
| this PR | 151 | 1 / 1 |

## Two fixes that come with matching xlsx

Neither is cosmetic:

- **Absolute URLs.** Logo sources were `.github/assets/logo-light.svg` and the license link was `LICENSE`. Relative paths render on GitHub and **break on PyPI**, which is why xlsx uses `raw.githubusercontent.com` for images and `blob/main` for repo files. All image sources and repo links are absolute now.
- **Badge set matches xlsx**: PyPI, Python versions, Test. License and Downloads dropped.

## Content preserved

Checked rather than eyeballed. Of **44 substantive claims** in main's README, **43 appear in the rewrite**. The 44th, "import name stays `docx`", is reworded: the import fence says `# the import name is unchanged` and Drop-in by design says "The importable package stays `docx`".

Prose is reflowed to one-line paragraphs, as xlsx does, which is where most of the 209 → 151 reduction comes from.

## Verified against the package

- The Quick start example was executed; both commented outputs match exactly
- `docx.__paper_version__` is `0.2.0`, matching Drop-in by design
- All seven refusal classes named in the safety contract exist in `docx.errors`
- One `<div>`, one `</div>`, nothing centered after the header, one horizontal rule, fences balanced, zero relative links

No claim about what Word accepts or refuses was added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 036714da3ee962e91d1f09bde402bcea1596907c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes README rendering by removing a duplicated, unclosed centered header. Old: all sections after the header rendered centered; new: one closed header block, then left‑aligned sections that mirror the `paper-xlsx` README.

- Rewrites structure: bold tagline, import fence, single horizontal rule; renames sections to match `paper-xlsx`; adds Contributing, Community, and Acknowledgments.
- Switches logo and repository links to absolute URLs so PyPI renders images and file links correctly.
- Updates badges to match `paper-xlsx` (PyPI, Python versions, Test); drops License and Downloads.
- No package or API changes; no migration required. Content is preserved and import remains `docx`.

<sup>Written for commit 036714da3ee962e91d1f09bde402bcea1596907c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-docx/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

