### PR TITLE
feat: control composition range endpoints

### DIFF
--- a/docs/api/paper-composition.rst
+++ b/docs/api/paper-composition.rst
@@ -10,6 +10,60 @@ remapping numbering, recreating media and hyperlinks, and renaming bookmarks
 with cross-reference remapping. The returned |CompositionReport| declares every
 part the operation touched.
 
+Range endpoints
+---------------
+
+``start_anchor`` and ``end_anchor`` address top-level source body blocks. Both
+are included by default. With an end anchor, the four combinations are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - ``include_start``
+     - ``include_end``
+     - Selected range
+   * - ``True``
+     - ``True``
+     - Start through end, including both blocks.
+   * - ``False``
+     - ``True``
+     - The block after start through end.
+   * - ``True``
+     - ``False``
+     - Start through the block before end.
+   * - ``False``
+     - ``False``
+     - Only blocks strictly between the anchors.
+
+With no ``end_anchor``, ``count`` selects exactly that many blocks beginning
+at the start block, or at the next block when ``include_start=False``.
+``include_end=False`` therefore requires an end anchor and otherwise raises
+:exc:`ValueError`. When an end anchor is present, ``count`` must still be at
+least one but does not limit the anchor-bounded range. An exclusion that leaves
+no blocks raises |TargetNotFoundError| before the destination changes.
+
+For example, a source containing ``Opening boundary``, two content blocks, and
+``Closing boundary`` can copy only its interior without first discovering the
+interior text:
+
+.. code-block:: python
+
+   insert_blocks_from(
+       destination,
+       source,
+       "Opening boundary",
+       end_anchor="Closing boundary",
+       include_start=False,
+       include_end=False,
+       anchor="Insert after this paragraph",
+   )
+
+Top-level content controls count as one logical block. The selected logical
+endpoints are translated to the existing physical body slice, so unsupported
+children between them still reach composition preflight and refuse rather
+than disappearing silently.
+
 .. currentmodule:: docx.composition
 
 

--- a/docs/api/paper-composition.rst
+++ b/docs/api/paper-composition.rst
@@ -13,8 +13,11 @@ part the operation touched.
 Range endpoints
 ---------------
 
-``start_anchor`` and ``end_anchor`` address top-level source body blocks. Both
-are included by default. With an end anchor, the four combinations are:
+``start_anchor`` and ``end_anchor`` identify source paragraphs whose containing
+top-level body blocks form the range endpoints. A direct body paragraph or a
+paragraph in a top-level content control can serve as an endpoint. Paragraphs
+in tables, table cells, and text boxes cannot. Both endpoints are included by
+default. With an end anchor, the four combinations are:
 
 .. list-table::
    :header-rows: 1

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -160,21 +160,36 @@ def insert_blocks_from(
     end_anchor=None,
     count: int = 1,
     styles: str = "match_by_name",
+    include_start: bool = True,
+    include_end: bool = True,
 ) -> CompositionReport:
     """Copy a block range from `source` after `anchor`, and return a `CompositionReport`.
 
     Reconciles styles, numbering, media and bookmarks so the copy keeps its appearance.
-    `start_anchor`/`end_anchor` address SOURCE body paragraphs. Refuses a protected
-    destination, an anchor that is missing or ambiguous, and source content this package
-    cannot carry over: revisions, comments, OLE objects, EMF/WMF images.
+    `start_anchor`/`end_anchor` address SOURCE top-level body blocks. Both endpoints are included
+    by default; setting either inclusion flag false excludes that endpoint's block. With no
+    `end_anchor`, `count` blocks are copied beginning at the start block or the following block
+    when `include_start=False`. With an `end_anchor`, `count` is validated but does not limit the
+    range. `include_end=False` without an end anchor raises `ValueError`. Refuses an empty
+    adjusted range, a protected destination, an anchor that is missing or ambiguous, and source
+    content this package cannot carry over: revisions, comments, OLE objects, EMF/WMF images.
     """
     _validate_styles_mode(styles)
+    if end_anchor is None and not include_end:
+        raise ValueError("include_end=False requires end_anchor")
     require_anchor_owner(source, start_anchor, argument="start_anchor")
     if end_anchor is not None:
         require_anchor_owner(source, end_anchor, argument="end_anchor")
     require_anchor_owner(document, anchor)
     _refuse_if_protected(document, "compose content into the document")
-    range_elements = _source_range(source, start_anchor, end_anchor, count)
+    range_elements = _source_range(
+        source,
+        start_anchor,
+        end_anchor,
+        count,
+        include_start=include_start,
+        include_end=include_end,
+    )
     with rollback_on_error(document):
         return _compose(document, source, range_elements, anchor, styles)
 
@@ -321,7 +336,15 @@ def _defined_header_footer(hf):
     return None
 
 
-def _source_range(source: "Document", start_anchor, end_anchor, count: int) -> "List[_Element]":
+def _source_range(
+    source: "Document",
+    start_anchor,
+    end_anchor,
+    count: int,
+    *,
+    include_start: bool,
+    include_end: bool,
+) -> "List[_Element]":
     from docx.blocks import _locate_anchor_paragraph
 
     if count < 1:
@@ -351,7 +374,15 @@ def _source_range(source: "Document", start_anchor, end_anchor, count: int) -> "
         end_index = blocks.index(end_block)
         if end_index < start_index:
             raise TargetNotFoundError("end anchor precedes start anchor in the source body")
+        if not include_start:
+            start_index += 1
+        if not include_end:
+            end_index -= 1
+        if start_index > end_index:
+            raise TargetNotFoundError("the adjusted source range is empty")
     else:
+        if not include_start:
+            start_index += 1
         end_index = start_index + count - 1
         if end_index >= len(blocks):
             raise TargetNotFoundError(

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -166,13 +166,16 @@ def insert_blocks_from(
     """Copy a block range from `source` after `anchor`, and return a `CompositionReport`.
 
     Reconciles styles, numbering, media and bookmarks so the copy keeps its appearance.
-    `start_anchor`/`end_anchor` address SOURCE top-level body blocks. Both endpoints are included
-    by default; setting either inclusion flag false excludes that endpoint's block. With no
-    `end_anchor`, `count` blocks are copied beginning at the start block or the following block
-    when `include_start=False`. With an `end_anchor`, `count` is validated but does not limit the
-    range. `include_end=False` without an end anchor raises `ValueError`. Refuses an empty
-    adjusted range, a protected destination, an anchor that is missing or ambiguous, and source
-    content this package cannot carry over: revisions, comments, OLE objects, EMF/WMF images.
+    `start_anchor` and `end_anchor` identify SOURCE paragraphs whose containing top-level body
+    blocks form the range endpoints. A direct body paragraph or a paragraph in a top-level
+    content control can serve as an endpoint; paragraphs in tables, table cells, and text boxes
+    cannot. Both endpoints are included by default; setting either inclusion flag false excludes
+    that endpoint's block. With no `end_anchor`, `count` blocks are copied beginning at the start
+    block or the following block when `include_start=False`. With an `end_anchor`, `count` is
+    validated but does not limit the range. `include_end=False` without an end anchor raises
+    `ValueError`. Refuses an empty adjusted range, a protected destination, an anchor that is
+    missing or ambiguous, and source content this package cannot carry over: revisions,
+    comments, OLE objects, EMF/WMF images.
     """
     _validate_styles_mode(styles)
     if end_anchor is None and not include_end:

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -189,7 +189,7 @@ APPROVED_SIGNATURES = [
         "docx.composition",
         "insert_blocks_from",
         "(document, source, start_anchor, *, anchor, end_anchor=None,"
-        " count=1, styles='match_by_name')",
+        " count=1, styles='match_by_name', include_start=True, include_end=True)",
     ),
     (
         "docx.composition",

--- a/tests/paper/test_audit_composition_safety.py
+++ b/tests/paper/test_audit_composition_safety.py
@@ -7,7 +7,7 @@ import pytest
 import docx
 from docx.composition import insert_blocks_from
 from docx.enum.style import WD_STYLE_TYPE
-from docx.errors import UnsupportedStructureError
+from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.numbering import apply_numbering, ensure_decimal_definition
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -59,6 +59,125 @@ def _append_style_reference(paragraph, tag: str, style_id: str) -> None:
     reference = OxmlElement(tag)
     reference.set(qn("w:val"), style_id)
     properties.append(reference)
+
+
+def _clear_body(document) -> None:
+    body = document.element.body
+    for child in list(body):
+        if child.tag != qn("w:sectPr"):
+            body.remove(child)
+
+
+def _insert_before_section_properties(document, element) -> None:
+    section_properties = document.element.body.find(qn("w:sectPr"))
+    if section_properties is None:
+        document.element.body.append(element)
+    else:
+        section_properties.addprevious(element)
+
+
+def _top_level_control(text: str):
+    control = OxmlElement("w:sdt")
+    content = OxmlElement("w:sdtContent")
+    paragraph = OxmlElement("w:p")
+    run = OxmlElement("w:r")
+    run.add_t(text)
+    paragraph.append(run)
+    content.append(paragraph)
+    control.append(content)
+    return control
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "include_start", "include_end", "count"),
+    [
+        pytest.param("Block A", "Block A", False, True, 1, id="same-exclude-start"),
+        pytest.param("Block A", "Block A", True, False, 1, id="same-exclude-end"),
+        pytest.param("Block A", "Block B", False, False, 1, id="adjacent-exclude-both"),
+        pytest.param("Block B", "Block A", True, True, 1, id="reversed"),
+        pytest.param("Block C", None, False, True, 1, id="adjusted-out-of-bounds"),
+    ],
+)
+def it_refuses_empty_reversed_and_out_of_bounds_adjusted_ranges_atomically(
+    start: str,
+    end: str | None,
+    include_start: bool,
+    include_end: bool,
+    count: int,
+) -> None:
+    source = docx.Document()
+    for text in ("Block A", "Block B", "Block C"):
+        source.add_paragraph(text)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(TargetNotFoundError):
+        insert_blocks_from(
+            destination,
+            source,
+            start,
+            end_anchor=end,
+            count=count,
+            include_start=include_start,
+            include_end=include_end,
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
+
+
+@pytest.mark.parametrize("include_control", [True, False])
+def it_treats_a_top_level_control_as_one_includable_endpoint(
+    include_control: bool,
+) -> None:
+    source = docx.Document()
+    _clear_body(source)
+    source.add_paragraph("Selected paragraph")
+    _insert_before_section_properties(source, _top_level_control("Control boundary"))
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        "Selected paragraph",
+        end_anchor="Control boundary",
+        include_end=include_control,
+        anchor="Destination anchor",
+    )
+
+    copied_controls = destination.element.body.findall(qn("w:sdt"))
+    assert report.inserted_blocks == (2 if include_control else 1)
+    assert len(copied_controls) == int(include_control)
+
+
+def it_preserves_unsupported_physical_children_inside_an_adjusted_slice() -> None:
+    source = docx.Document()
+    _clear_body(source)
+    source.add_paragraph("Start boundary")
+    first = source.add_paragraph("First selected block")
+    source.add_paragraph("Second selected block")
+    source.add_paragraph("End boundary")
+    unsupported = OxmlElement("w:customXml")
+    unsupported.append(OxmlElement("w:p"))
+    first._p.addnext(unsupported)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError, match="customXml"):
+        insert_blocks_from(
+            destination,
+            source,
+            "Start boundary",
+            end_anchor="End boundary",
+            include_start=False,
+            include_end=False,
+            anchor="Destination anchor",
+        )
+
+    assert _package_state(destination) == before
 
 
 def it_refuses_a_chart_relationship_before_copying_stale_rids() -> None:

--- a/tests/paper/test_composition.py
+++ b/tests/paper/test_composition.py
@@ -11,7 +11,6 @@ import docx
 from docx.composition import append_document, insert_blocks_from
 from docx.errors import (
     DocumentProtectedError,
-    TargetNotFoundError,
     UnsupportedStructureError,
 )
 
@@ -40,6 +39,13 @@ def _source_with_styles():
     source.add_paragraph("Indemnity: the supplier shall hold harmless.")
     source.add_heading("Payment Terms", level=2)
     source.add_paragraph("Payment falls due after thirty days.")
+    return source
+
+
+def _source_with_named_blocks():
+    source = docx.Document()
+    for name in ("Block A", "Block B", "Block C", "Block D"):
+        source.add_paragraph(name)
     return source
 
 
@@ -79,6 +85,117 @@ class DescribeInsertBlocksFrom:
             anchor="Second body paragraph",
         )
         assert report.inserted_blocks == 4
+        out = _saved(destination, tmp_path / "inclusive-defaults.docx")
+        reopened = docx.Document(str(out))
+        expected = [
+            "Clause Library",
+            "Indemnity: the supplier shall hold harmless.",
+            "Payment Terms",
+            "Payment falls due after thirty days.",
+        ]
+        assert [p.text for p in reopened.paragraphs if p.text in expected] == expected
+
+    @pytest.mark.parametrize(
+        ("include_start", "include_end", "expected"),
+        [
+            pytest.param(
+                True,
+                True,
+                ["Block A", "Block B", "Block C", "Block D"],
+                id="both",
+            ),
+            pytest.param(
+                False,
+                True,
+                ["Block B", "Block C", "Block D"],
+                id="exclude-start",
+            ),
+            pytest.param(
+                True,
+                False,
+                ["Block A", "Block B", "Block C"],
+                id="exclude-end",
+            ),
+            pytest.param(
+                False,
+                False,
+                ["Block B", "Block C"],
+                id="exclude-both",
+            ),
+        ],
+    )
+    def it_controls_endpoint_inclusion_and_ignores_count_with_an_end_anchor(
+        self,
+        include_start: bool,
+        include_end: bool,
+        expected: list[str],
+        tmp_path: Path,
+    ):
+        source = _source_with_named_blocks()
+        destination = docx.Document()
+        destination.add_paragraph("Destination anchor")
+
+        report = insert_blocks_from(
+            destination,
+            source,
+            "Block A",
+            end_anchor="Block D",
+            count=99,
+            include_start=include_start,
+            include_end=include_end,
+            anchor="Destination anchor",
+        )
+
+        assert report.inserted_blocks == len(expected)
+        out = _saved(destination, tmp_path / "endpoint-range.docx")
+        reopened = docx.Document(str(out))
+        assert [
+            paragraph.text
+            for paragraph in reopened.paragraphs
+            if paragraph.text.startswith("Block")
+        ] == expected
+
+    def it_excludes_the_count_based_start_without_consuming_the_count(
+        self, tmp_path: Path
+    ):
+        source = _source_with_named_blocks()
+        destination = docx.Document()
+        destination.add_paragraph("Destination anchor")
+
+        report = insert_blocks_from(
+            destination,
+            source,
+            "Block A",
+            count=2,
+            include_start=False,
+            anchor="Destination anchor",
+        )
+
+        assert report.inserted_blocks == 2
+        out = _saved(destination, tmp_path / "count-range.docx")
+        reopened = docx.Document(str(out))
+        assert [
+            paragraph.text
+            for paragraph in reopened.paragraphs
+            if paragraph.text.startswith("Block")
+        ] == ["Block B", "Block C"]
+
+    def it_requires_an_end_anchor_to_exclude_the_end(self):
+        source = _source_with_named_blocks()
+        destination = docx.Document()
+        destination.add_paragraph("Destination anchor")
+        before = destination.element.xml
+
+        with pytest.raises(ValueError, match="requires end_anchor"):
+            insert_blocks_from(
+                destination,
+                source,
+                "Block A",
+                include_end=False,
+                anchor="Destination anchor",
+            )
+
+        assert destination.element.xml == before
 
     def it_imports_missing_style_definitions(self, tmp_path: Path):
         from docx.enum.style import WD_STYLE_TYPE
@@ -132,7 +249,8 @@ class DescribeInsertBlocksFrom:
         assert copied.style.name == "HouseTerm (imported)"
         assert copied.style.font.size.pt == 16
         original = {s.name for s in reopened.styles}
-        assert "HouseTerm" in original and "HouseTerm (imported)" in original
+        assert "HouseTerm" in original
+        assert "HouseTerm (imported)" in original
 
     def it_remaps_numbering_to_fresh_restarted_definitions(self, tmp_path: Path):
         from docx.numbering import apply_numbering, ensure_decimal_definition, list_numbering
@@ -181,8 +299,8 @@ class DescribeInsertBlocksFrom:
 
     def it_recreates_external_hyperlinks(self, tmp_path: Path):
         from docx.opc.constants import RELATIONSHIP_TYPE as RT
-        from docx.oxml.parser import parse_xml
         from docx.oxml.ns import nsdecls
+        from docx.oxml.parser import parse_xml
 
         source = docx.Document()
         paragraph = source.add_paragraph("Visit ")
@@ -209,8 +327,8 @@ class DescribeInsertBlocksFrom:
         assert "https://paper.example/terms" in external
 
     def it_renames_colliding_bookmarks_and_remaps_refs(self, tmp_path: Path):
-        from docx.oxml.parser import parse_xml
         from docx.oxml.ns import nsdecls
+        from docx.oxml.parser import parse_xml
 
         w = nsdecls("w")
         source = docx.Document()
@@ -281,8 +399,8 @@ class DescribeInsertBlocksFrom:
             )
 
     def it_refuses_embedded_objects(self):
-        from docx.oxml.parser import parse_xml
         from docx.oxml.ns import nsdecls
+        from docx.oxml.parser import parse_xml
 
         source = docx.Document()
         p = source.add_paragraph("Embedded thing: ")


### PR DESCRIPTION
## Summary
- add include_start and include_end with inclusive defaults
- support sentinel-bounded interior copies and count-based start exclusion
- retain the physical body slice so unsupported children still reach preflight
- leave _compose and all reconciliation behavior unchanged

## Verification
- 120 focused API and composition tests
- targeted Ruff checks
- warning-free Sphinx build

## PR stack
- [#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)
- [#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)
- [#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)
- [#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)
- **[#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)**
- [#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public composition API and source-range selection change; empty/out-of-bounds cases now refuse atomically, but incorrect endpoint math could copy the wrong blocks. Reconciliation (`_compose`) is unchanged.
> 
> **Overview**
> Lets `insert_blocks_from` copy interior ranges by excluding sentinel endpoints, without changing style/numbering/media reconciliation.
> 
> Adds keyword-only `include_start` and `include_end` (both default `True`). With an `end_anchor`, the four inclusion combinations select start-through-end, after-start, before-end, or strictly between; `count` is still validated but does not cap that range. With no end anchor, `include_start=False` starts `count` blocks after the start block; `include_end=False` requires an end anchor. Empty adjusted ranges raise `TargetNotFoundError` before the destination is mutated. Top-level content controls remain one logical endpoint, and the physical body slice is kept so unsupported children still hit preflight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dee7215000cadc5606d7223b93530ead3e16d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->