### PR TITLE
test: pin threaded reply conformance

### DIFF
--- a/docs/api/paper-commentops.rst
+++ b/docs/api/paper-commentops.rst
@@ -8,6 +8,13 @@ Comment operations
 extended vocabulary. Read a comment's anchored text, walk reply threads, reply
 to a comment, and mark a thread resolved or reopened.
 
+A reply has its own ``commentRangeStart``, ``commentRangeEnd``, and
+``commentReference`` around the same selected text. Its comment-body paragraph
+has its own paragraph ID, while ``w15:paraIdParent`` in ``commentsExtended``
+stores the parent comment's final paragraph ID. The reply does not reuse the
+parent's marker ID. Consequently, adding a reply intentionally changes the main
+document story as well as the comment parts.
+
 .. currentmodule:: docx.commentops
 
 

--- a/src/docx/commentops.py
+++ b/src/docx/commentops.py
@@ -680,11 +680,13 @@ def reply(
     initials: Optional[str] = None,
     date: Optional[dt.datetime] = None,
 ) -> "Comment":
-    """Add a threaded reply to `comment`, anchored to the same range; returns the new `Comment`.
+    """Add a threaded reply to `comment` and return the new `Comment`.
 
-    Creates `commentsExtended` on first use, since Word keeps threading outside `w:comment`.
-    Refuses a protected document, a stale or foreign comment, and a comments part that is
-    missing or ambiguous.
+    The reply gets its own comment-range start, range end, and reference around the same
+    selected text. Its `w15:paraIdParent` names the parent's final comment-body paragraph; the
+    reply does not reuse the parent's marker id. Creates `commentsExtended` on first use, since
+    Word keeps threading outside `w:comment`. Refuses a protected document, a stale or foreign
+    comment, and a comments part that is missing or ambiguous.
     """
     if not author:
         raise ValueError("author is required")

--- a/tests/paper/test_audit_commentops.py
+++ b/tests/paper/test_audit_commentops.py
@@ -6,6 +6,7 @@ import pytest
 
 import docx
 from docx.commentops import (
+    COMMENTS_EXTENDED_RELATIONSHIP_TYPE,
     anchored_text,
     comment_thread,
     is_resolved,
@@ -24,6 +25,10 @@ from docx.shared import Inches
 
 from .harness.contract import assert_refusal_atomic
 
+_W15_NS = "http://schemas.microsoft.com/office/word/2012/wordml"
+_W15_PARA_ID = f"{{{_W15_NS}}}paraId"
+_W15_PARA_ID_PARENT = f"{{{_W15_NS}}}paraIdParent"
+
 
 def _commented_document():
     document = docx.Document()
@@ -32,6 +37,53 @@ def _commented_document():
         "Parent", author="Reviewer"
     )
     return document, comment
+
+
+def _assert_parent_reply_topology(document, parent_id: int, child_id: int):
+    comments = {comment.comment_id: comment for comment in document.comments}
+    assert set(comments) == {parent_id, child_id}
+    assert anchored_text(document, comments[parent_id]) == "comment target"
+    assert anchored_text(document, comments[child_id]) == "comment target"
+
+    marker_order = [
+        (marker.tag.rsplit("}", 1)[-1], int(marker.get(qn("w:id"))))
+        for marker in document.element.body.iter(
+            qn("w:commentRangeStart"),
+            qn("w:commentRangeEnd"),
+            qn("w:commentReference"),
+        )
+    ]
+    assert marker_order == [
+        ("commentRangeStart", parent_id),
+        ("commentRangeStart", child_id),
+        ("commentRangeEnd", child_id),
+        ("commentRangeEnd", parent_id),
+        ("commentReference", parent_id),
+        ("commentReference", child_id),
+    ]
+
+    comments_root = document.part.part_related_by(RT.COMMENTS)._element  # noqa: SLF001
+    comment_elements = {
+        int(element.get(qn("w:id"))): element for element in comments_root
+    }
+    para_ids = {
+        comment_id: list(comment_elements[comment_id].iter(qn("w:p")))[-1].get(
+            qn("w14:paraId")
+        )
+        for comment_id in (parent_id, child_id)
+    }
+    assert all(para_ids.values())
+
+    extended_root = document.part.part_related_by(
+        COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+    )._element  # noqa: SLF001
+    entries = {entry.get(_W15_PARA_ID): entry for entry in extended_root}
+    assert entries[para_ids[parent_id]].get(_W15_PARA_ID_PARENT) is None
+    assert (
+        entries[para_ids[child_id]].get(_W15_PARA_ID_PARENT)
+        == para_ids[parent_id]
+    )
+    return para_ids[parent_id], para_ids[child_id]
 
 
 class DescribeCommentRelationshipOwnership:
@@ -125,6 +177,30 @@ class DescribeCommentInspection:
 
 
 class DescribeCommentAnchorIds:
+    def it_retains_conformant_parent_and_reply_anchors_after_round_trip(
+        self, tmp_path
+    ):
+        document, parent = _commented_document()
+        child = reply(document, parent, "Reply", author="Second Reviewer")
+        assert parent.comment_id != child.comment_id
+
+        # Microsoft's pinned SDK test gives each threaded comment its own
+        # anchor triple and links the child through CommentEx.ParaIdParent:
+        # https://github.com/dotnet/Open-XML-SDK/blob/431ab05cf160248cc3885a4a766026d4f8243792/test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/TestEntities.cs#L89-L115
+        para_ids = _assert_parent_reply_topology(
+            document, parent.comment_id, child.comment_id
+        )
+
+        output = tmp_path / "threaded-comments.docx"
+        document.save(str(output))
+        reopened = docx.Document(str(output))
+        assert (
+            _assert_parent_reply_topology(
+                reopened, parent.comment_id, child.comment_id
+            )
+            == para_ids
+        )
+
     def it_compares_anchor_marker_ids_numerically(self):
         document, comment = _commented_document()
         comment._comment_elm.set(qn("w:id"), "1")  # noqa: SLF001

--- a/tests/paper/test_audit_revisions.py
+++ b/tests/paper/test_audit_revisions.py
@@ -12,6 +12,7 @@ import pytest
 import docx
 from docx.commentops import (
     COMMENTS_EXTENDED_RELATIONSHIP_TYPE,
+    COMMENTS_EXTENSIBLE_RELATIONSHIP_TYPE,
     COMMENTS_IDS_RELATIONSHIP_TYPE,
     reply,
     resolve,
@@ -30,6 +31,8 @@ from .harness.paths import fixture_path
 TRACKED_MOVES = "generated/feature-isolated/tracked-moves.docx"
 NOTES = "generated/feature-isolated/footnotes-endnotes.docx"
 _W15_NS = "http://schemas.microsoft.com/office/word/2012/wordml"
+_W16CID_NS = "http://schemas.microsoft.com/office/word/2016/wordml/cid"
+_W16CEX_NS = "http://schemas.microsoft.com/office/word/2018/wordml/cex"
 
 
 def _revision(tag: str, inner_xml: str, revision_id: int):
@@ -366,7 +369,8 @@ class DescribeDiscardCleanup:
         )
         last_para_id = list(comment_elm.iter(qn("w:p")))[-1].get(qn("w14:paraId"))
         top_para_id = comment_elm.findall(qn("w:p"))[-1].get(qn("w14:paraId"))
-        assert last_para_id and last_para_id != top_para_id
+        assert last_para_id
+        assert last_para_id != top_para_id
         reference = next(
             node
             for node in document.element.iter(qn("w:commentReference"))
@@ -386,7 +390,7 @@ class DescribeDiscardCleanup:
         }
         assert last_para_id not in remaining_identity
 
-    def it_removes_an_entire_discarded_comment_thread(self):
+    def it_removes_an_entire_discarded_comment_thread(self, tmp_path: Path):
         from docx.blocks import tracked_delete_paragraphs
 
         document = docx.Document()
@@ -394,8 +398,70 @@ class DescribeDiscardCleanup:
         parent = document.add_comment(
             paragraph.runs, text="parent", author="Audit"
         )
-        reply(document, parent, "reply", author="Audit")
+        child = reply(document, parent, "reply", author="Audit")
         assert len(document.comments) == 2
+
+        comment_ids = {parent.comment_id, child.comment_id}
+        comments_root = document.part.part_related_by(RT.COMMENTS)._element  # noqa: SLF001
+        comment_elements = {
+            int(element.get(qn("w:id"))): element for element in comments_root
+        }
+        para_ids = {
+            list(comment_elements[comment_id].iter(qn("w:p")))[-1].get(
+                qn("w14:paraId")
+            )
+            for comment_id in comment_ids
+        }
+        assert None not in para_ids
+        ids_root = document.part.part_related_by(
+            COMMENTS_IDS_RELATIONSHIP_TYPE
+        )._element  # noqa: SLF001
+        durable_ids = {
+            entry.get(f"{{{_W16CID_NS}}}durableId")
+            for entry in ids_root
+            if entry.get(f"{{{_W16CID_NS}}}paraId") in para_ids
+        }
+        assert None not in durable_ids
+        assert len(durable_ids) == 2
+
+        def assert_thread_absent(candidate):
+            assert comment_ids.isdisjoint(
+                comment.comment_id for comment in candidate.comments
+            )
+            assert comment_ids.isdisjoint(
+                int(marker.get(qn("w:id")))
+                for marker in candidate.element.body.iter(
+                    qn("w:commentRangeStart"),
+                    qn("w:commentRangeEnd"),
+                    qn("w:commentReference"),
+                )
+            )
+
+            extended_root = candidate.part.part_related_by(
+                COMMENTS_EXTENDED_RELATIONSHIP_TYPE
+            )._element  # noqa: SLF001
+            assert para_ids.isdisjoint(
+                entry.get(f"{{{_W15_NS}}}paraId") for entry in extended_root
+            )
+            assert para_ids.isdisjoint(
+                entry.get(f"{{{_W15_NS}}}paraIdParent")
+                for entry in extended_root
+            )
+
+            candidate_ids_root = candidate.part.part_related_by(
+                COMMENTS_IDS_RELATIONSHIP_TYPE
+            )._element  # noqa: SLF001
+            assert para_ids.isdisjoint(
+                entry.get(f"{{{_W16CID_NS}}}paraId")
+                for entry in candidate_ids_root
+            )
+            candidate_extensible_root = candidate.part.part_related_by(
+                COMMENTS_EXTENSIBLE_RELATIONSHIP_TYPE
+            )._element  # noqa: SLF001
+            assert durable_ids.isdisjoint(
+                entry.get(f"{{{_W16CEX_NS}}}durableId")
+                for entry in candidate_extensible_root
+            )
 
         tracked_delete_paragraphs(
             document,
@@ -405,8 +471,8 @@ class DescribeDiscardCleanup:
         )
         assert document.revisions.accept_all() > 0
 
-        assert len(document.comments) == 0
-        extended_root = document.part.part_related_by(
-            COMMENTS_EXTENDED_RELATIONSHIP_TYPE
-        )._element  # noqa: SLF001
-        assert len(extended_root) == 0
+        assert_thread_absent(document)
+
+        output = tmp_path / "discarded-comment-thread.docx"
+        document.save(str(output))
+        assert_thread_absent(docx.Document(str(output)))


### PR DESCRIPTION
## Summary
- add a generated parent/reply topology regression based on the Microsoft Open XML conformance shape
- verify complete cleanup of reply anchors, bodies, extension rows, identities, and durable IDs
- document that replies have distinct anchors linked by paraIdParent
- leave commentops.reply behavior unchanged

## Verification
- 47 focused comment and revision tests
- warning-free Sphinx documentation build

## PR stack
- **[#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)**
- [#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)
- [#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)
- [#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)
- [#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)
- [#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests and documentation only; production comment-reply logic is not changed.
> 
> **Overview**
> Pins Microsoft Open XML **parent/reply comment topology**: each reply has its own range markers and reference, linked via `w15:paraIdParent`, and that shape survives save/reload.
> 
> Documents that replies do not reuse the parent marker id and therefore rewrite the main story as well as comment parts. `reply()` behavior is unchanged; only the docstring is clarified.
> 
> Tightens discard-cleanup coverage so accepting a tracked delete of a threaded comment removes both comments, body anchors, `commentsExtended` rows, identity paraIds, and durable IDs, including after round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0958ffa0a1424e25f46eede982e68366b5079e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->