### PR TITLE
refactor: add replacement planning substrate

### DIFF
--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -343,6 +343,8 @@ class ReplaceResult:
     inserted_text: str
     tracked: bool
     revision_ids: Tuple[int, ...]
+    preserved_structure: bool = False
+    preserved_revision_ids: Tuple[int, ...] = ()
 
     def to_dict(self) -> dict:
         return {
@@ -353,7 +355,18 @@ class ReplaceResult:
             "inserted_text": self.inserted_text,
             "tracked": self.tracked,
             "revision_ids": list(self.revision_ids),
+            "preserved_structure": self.preserved_structure,
+            "preserved_revision_ids": list(self.preserved_revision_ids),
         }
+
+
+@dataclass(frozen=True)
+class _TextAssignment:
+    """One preflighted text-only mutation for a replacement plan."""
+
+    element: "_Element"
+    before: str
+    after: str
 
 
 @dataclass
@@ -688,7 +701,8 @@ class Span:
     def _validate_fresh(self) -> None:
         if self._consumed:
             raise TargetNotFoundError(
-                "span was consumed by a tracked replace; re-find the text"
+                "span was consumed by a tracked or structure-preserving"
+                " replace; re-find the text"
             )
         if self._current_slice() != self.text:
             raise TargetNotFoundError(
@@ -863,6 +877,28 @@ class Span:
         a stale or foreign span, a span crossing a field or control boundary, and a tracked
         no-op.
         """
+        return self._replace(
+            new_text,
+            tracked=tracked,
+            author=author,
+            date=date,
+            use_transaction=self._freshness_census is None,
+        )
+
+    def _replace(
+        self,
+        new_text: str,
+        *,
+        tracked: bool,
+        author: Optional[str],
+        date: Optional[dt.datetime],
+        use_transaction: bool,
+    ) -> ReplaceResult:
+        """Implementation shared with the already-transactional batch path.
+
+        `use_transaction` is consumed by replacement plans that need multiple
+        assignments; ordinary and tracked paths retain their current behavior.
+        """
         if tracked and not author:
             raise ValueError("author is required when tracked=True")
         if tracked:
@@ -882,8 +918,12 @@ class Span:
             narrowed = self._narrow_to_change(new_text)
             if narrowed is not None:
                 sub_span, sub_new = narrowed
-                return sub_span.replace(
-                    sub_new, tracked=tracked, author=author, date=date
+                return sub_span._replace(
+                    sub_new,
+                    tracked=tracked,
+                    author=author,
+                    date=date,
+                    use_transaction=use_transaction,
                 )
         self._validate_replaceable()
         if not tracked:

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -896,8 +896,8 @@ class Span:
     ) -> ReplaceResult:
         """Implementation shared with the already-transactional batch path.
 
-        `use_transaction` is consumed by replacement plans that need multiple
-        assignments; ordinary and tracked paths retain their current behavior.
+        `use_transaction` is reserved for text-assignment plans layered on this
+        substrate; this commit's ordinary and tracked paths do not consume it.
         """
         if tracked and not author:
             raise ValueError("author is required when tracked=True")

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -7,15 +7,16 @@ break-tolerant replace, hyperlink-interior edits, and batch replace.
 from __future__ import annotations
 
 import datetime as dt
-from pathlib import Path
+from contextlib import contextmanager
 
 import pytest
 
 import docx
+import docx.search as search_module
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
-from docx.oxml.ns import nsdecls, qn
+from docx.oxml.ns import nsdecls
 from docx.oxml.parser import parse_xml
-from docx.search import find_one, find_text, replace_all
+from docx.search import find_one, replace_all
 from docx.story import iter_blocks
 
 from .harness.paths import fixture_path
@@ -213,5 +214,30 @@ class DescribeReplaceAll:
         document = _doc()
         document.add_paragraph("{{y}}")
         payload = replace_all(document, "{{y}}", "z").to_dict()
-        assert payload["schema"] == "paper_replace_all" and payload["version"] == 1
+        assert payload["schema"] == "paper_replace_all"
+        assert payload["version"] == 1
         assert payload["replaced_count"] == 1
+        nested = payload["results"][0]
+        assert nested["schema"] == "paper_replace"
+        assert nested["version"] == 1
+        assert nested["preserved_structure"] is False
+        assert nested["preserved_revision_ids"] == []
+
+    def it_uses_only_the_outer_batch_transaction(self, monkeypatch):
+        document = _doc()
+        document.add_paragraph("token token")
+        transaction_count = 0
+        original = search_module.rollback_on_error
+
+        @contextmanager
+        def counted_transaction(*args, **kwargs):
+            nonlocal transaction_count
+            transaction_count += 1
+            with original(*args, **kwargs):
+                yield
+
+        monkeypatch.setattr(
+            search_module, "rollback_on_error", counted_transaction
+        )
+        replace_all(document, "token", "value")
+        assert transaction_count == 1


### PR DESCRIPTION
## Summary
- add additive replacement evidence fields to existing version-1 serialized result payloads
- introduce the private immutable text-assignment substrate
- split direct and already-transactional batch execution without changing existing behavior
- prove replace_all keeps one outer package transaction

## Verification
- 198 focused replacement compatibility tests
- targeted Ruff checks

## PR stack
- [#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)
- **[#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)**
- [#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)
- [#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)
- [#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)
- [#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of replace plumbing with additive, default-false serialization fields; existing replace behavior is unchanged.
> 
> **Overview**
> Prepares `Span.replace` for later structure-preserving plans without changing current edit behavior.
> 
> `ReplaceResult` (still schema version 1) now serializes `preserved_structure` and `preserved_revision_ids` (defaults false/empty). Adds frozen `_TextAssignment` for planned text-only mutations.
> 
> Public `replace` delegates to `_replace`, passing `use_transaction` from whether a batch freshness census is already in play. Nested narrowing uses that same flag. Ordinary and tracked paths still ignore it; `replace_all` is asserted to keep a single outer `rollback_on_error` transaction. Consumed-span errors now mention structure-preserving replace as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0650cbe1d61e546482e5583252fc7d0c18ba2805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->