### PR TITLE
docs: guide bounded package saves

### DIFF
--- a/docs/api/paper-package.rst
+++ b/docs/api/paper-package.rst
@@ -5,14 +5,30 @@ Package kernel
 ==============
 
 *paper-docx addition.* Compare packages semantically and save edits narrowly.
-``patch_save`` keeps the original bytes for parts you did not semantically
-change, so a file-level diff shows your edit and nothing else. ``diff_package``
-and ``text_diff`` report what changed. ``diagnose`` triages an unopenable file
-into a typed verdict. ``compare`` generates a native tracked-change redline
-that transforms one document into another. It verifies acceptance and
-rejection on private copies before returning and refuses differences it cannot
-encode without loss. These names are the pinned public path
+``patch_save`` keeps original package-part bytes wherever it can prove that
+serialized XML is semantically unchanged. ``diff_package`` and ``text_diff``
+report what changed. ``diagnose`` triages an unopenable file into a typed
+verdict. ``compare`` generates a native tracked-change redline that transforms
+one document into another. It verifies acceptance and rejection on private
+copies before returning and refuses differences it cannot encode without loss.
+These names are the pinned public path
 (``docx.package.*``); the implementation lives in private modules.
+
+Choose a save path
+------------------
+
+Use ordinary ``Document.save()`` for a new document or when normalizing the
+whole package is intentional. For a bounded edit to an existing package, use
+``patch_save(original_path, document, out_path)`` when unrelated part bytes
+must remain untouched. It serializes normally, restores the original bytes of
+semantically unchanged XML parts, and reports restored, changed, added, and
+removed parts.
+
+This is a package-part boundary: ``patch_save`` does not promise byte-range
+identity inside an XML part whose semantics changed, nor does it preserve the
+original ZIP container bytes unless the entire save is a no-op. Use
+``diff_package`` to record package-level change evidence, then reopen the
+output to establish that the saved document is semantically readable.
 
 .. currentmodule:: docx.package
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -15,9 +15,9 @@ Safety contract
 The fork exists to prevent **silent corruption**: a document that opens fine
 and is quietly wrong after direct XML edits. Every added operation either does
 exactly what it claims or refuses atomically. Mutating operations validate fully
-before they touch anything, so a raised |PaperRefusal| leaves the document
-byte-for-byte unchanged in memory and on disk. Callers can handle the refusal
-separately from programmer errors.
+before they touch anything or restore the captured state on failure, so a
+raised |PaperRefusal| leaves the document and supplied live proxies unchanged.
+Callers can handle the refusal separately from programmer errors.
 
 .. contents::
    :local:
@@ -118,13 +118,27 @@ rather than silently editing a locked template. The gate follows Word's per-mode
 rules, so a comments-only restriction still permits commenting.
 
 
+Save a bounded edit
+-------------------
+
+Use ordinary ``Document.save()`` for a new document or when whole-package
+normalization is intentional. For a bounded edit to an existing file,
+``patch_save(original_path, document, out_path)`` is the recommended path when
+unrelated package-part bytes must remain untouched. It restores original bytes
+for semantically unchanged XML parts; it does not preserve byte ranges inside
+an XML part that the edit changed or the original ZIP container bytes after a
+non-no-op save.
+
+Use ``diff_package(original_path, out_path)`` as package-level evidence of the
+changed-part budget, and reopen ``out_path`` as evidence that the saved document
+remains semantically readable.
+
+
 Compose across documents
 ------------------------
 
-:ref:`docx.package <paper_package_api>` is the byte-preserving package layer.
-``patch_save`` writes a compare-based narrow save. Parts you did not
-semantically change keep their original bytes, so a file-level diff shows your
-edit and nothing else. ``compare`` generates a native tracked-change redline
+:ref:`docx.package <paper_package_api>` is the package inspection and compare
+layer. ``compare`` generates a native tracked-change redline
 transforming one document into another. Accepting it yields the revised
 document; rejecting it yields the original. Before returning, ``compare``
 proves both outcomes on private copies. Style, relationship, or package-part


### PR DESCRIPTION
## Summary
- explain when to use ordinary Document.save versus patch_save for bounded edits
- distinguish unchanged package-part bytes from changed XML-part and ZIP-container bytes
- document diff_package plus reopen as package and semantic evidence
- add the executed remediation specification and phase plans for stack traceability

## Verification
- complete suite: 2,812 passed, 7 skipped with inherited pyparsing deprecations filtered
- warning-free Sphinx build
- git diff --check

## PR stack
- [#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)
- [#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)
- [#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)
- [#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)
- [#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)
- **[#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)**

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording of existing save APIs; no runtime or security behavior changes.
> 
> **Overview**
> Clarifies when to use ordinary `Document.save()` versus `patch_save` for bounded edits, and what byte identity `patch_save` actually guarantees.
> 
> User and package API docs now recommend `patch_save` only when unrelated package-part bytes must stay untouched. They state the boundary: original bytes are restored for semantically unchanged XML parts, not for byte ranges inside a changed part or for ZIP container bytes after a non-no-op save. `diff_package` plus reopening the output is the documented evidence path.
> 
> Also tightens the safety-contract wording: refusals restore captured state so live proxies stay unchanged, and `docx.package` is framed as inspection/compare rather than a byte-preserving save layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51cbe4443e27bffcafd62b9069a7156d205a7cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->