### PR TITLE
feat: preserve existing insertion revisions

### DIFF
--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -12,6 +12,25 @@ the matched text; untouched runs keep their formatting byte-for-byte. With
 ``tracked=True``, it emits a minimal genuine ``w:ins``/``w:del`` redline.
 |Span| ``.comment`` anchors a comment to exactly the span.
 
+Correct an existing insertion
+-----------------------------
+
+``span.replace(text, preserve_revision=True)`` corrects a current-view span
+wholly owned by one existing ``w:ins`` without reauthoring or restamping it.
+The text remains attributed to the insertion's recorded author and date, the
+wrapper ID is retained, and accepting or rejecting the revision keeps its
+original meaning. Outside revision markup the option behaves like an ordinary
+untracked edit, so ``replace_all`` can update base text and insertion-owned
+matches in one batch.
+
+The operation refuses deletions, tracked moves, mixed base/insertion text,
+multiple or nested revision wrappers, and non-current views. ``tracked=True``
+cannot be combined with ``preserve_revision=True``. A fully preflighted no-op
+changes nothing and leaves the span reusable. |ReplaceResult|
+``preserved_revision_ids`` reports the existing insertion actually retained;
+``revision_ids`` continues to report only newly authored revisions. Direct and
+batch serialized results retain their schema discriminators and earlier keys.
+
 .. currentmodule:: docx.search
 
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -67,7 +67,10 @@ Edit one document
     span.replace("rate: $85-110/hr")             # formatting intact
 
 The same call, with ``tracked=True``, emits a minimal genuine ``w:ins``/
-``w:del`` redline that Word renders natively. :ref:`docx.blocks
+``w:del`` redline that Word renders natively. Use
+``preserve_revision=True`` instead to correct current-view text wholly inside
+one existing insertion while retaining its ID, attribution, and accept/reject
+behavior. :ref:`docx.blocks
 <paper_blocks_api>` does the clause-level equivalent (insert, delete or
 replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and
 :ref:`docx.numbering <paper_numbering_api>` cover validated table edits and

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -942,11 +942,11 @@ class Span:
                     preserve_revision=preserve_revision,
                     use_transaction=use_transaction,
                 )
-        preservation_noop = preserve_revision and new_text == self.text
-        self._validate_replaceable(validate_bookmarks=not preservation_noop)
         preserved_revision_ids = _preserved_insertion_ids(
             self, authorize=preserve_revision
         )
+        preservation_noop = bool(preserved_revision_ids) and new_text == self.text
+        self._validate_replaceable(validate_bookmarks=not preservation_noop)
         if not tracked:
             for atom in self._atoms:
                 if atom.in_insert and not preserve_revision:
@@ -974,7 +974,7 @@ class Span:
                         " to real content — replace the whole prompt"
                         f" ({prompt!r}) or use docx.controls.set_control_value"
                     )
-        if preserve_revision and new_text == self.text:
+        if preservation_noop:
             return ReplaceResult(
                 story=self.story,
                 deleted_text=self.text,

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -361,7 +361,7 @@ class ReplaceResult:
 
 
 @dataclass(frozen=True)
-class _TextAssignment:
+class _TextAssignment:  # pyright: ignore[reportUnusedClass]
     """One preflighted text-only mutation for a replacement plan."""
 
     element: "_Element"
@@ -785,7 +785,7 @@ class Span:
                 " interval has changed"
             )
 
-    def _validate_replaceable(self) -> None:
+    def _validate_replaceable(self, *, validate_bookmarks: bool = True) -> None:
         for atom in self._atoms:
             if atom.is_synthetic:
                 detail = (
@@ -850,7 +850,11 @@ class Span:
                 "span crosses a hyperlink boundary; edit the linked text and"
                 " the surrounding text separately"
             )
-        hollowed = _hollowed_bookmarks(self._atoms, self._end_offset)
+        hollowed = (
+            _hollowed_bookmarks(self._atoms, self._end_offset)
+            if validate_bookmarks
+            else []
+        )
         if hollowed:
             raise UnsupportedStructureError(
                 f"replacing this span would hollow out bookmark(s) {hollowed}"
@@ -868,20 +872,27 @@ class Span:
         tracked: bool = False,
         author: Optional[str] = None,
         date: Optional[dt.datetime] = None,
+        preserve_revision: bool = False,
     ) -> ReplaceResult:
         """Replace this span's text, preserving run formatting.
 
-        Untracked, this edits in place: untouched runs keep their `rPr` byte-identical, the
+        Untracked, this edits in place: untouched runs retain their run properties, the
         replacement takes the start run's formatting, and the span stays usable. Tracked, it
-        emits a minimal `w:del`/`w:ins` pair and CONSUMES the span. Refuses a protected document,
-        a stale or foreign span, a span crossing a field or control boundary, and a tracked
-        no-op.
+        emits a minimal `w:del`/`w:ins` pair and consumes the span.
+
+        `preserve_revision=True` permits a current-view span wholly owned by one existing
+        `w:ins` to be corrected without changing its id, author, date, or accept/reject meaning.
+        Outside revision markup it behaves like an ordinary untracked edit. The result reports
+        the retained insertion in `preserved_revision_ids`; `revision_ids` remains reserved for
+        newly authored revisions. Refuses mixed, nested, moved, stale, protected, field,
+        control, bookmark, hyperlink, and paragraph-boundary structures before mutation.
         """
         return self._replace(
             new_text,
             tracked=tracked,
             author=author,
             date=date,
+            preserve_revision=preserve_revision,
             use_transaction=self._freshness_census is None,
         )
 
@@ -892,6 +903,7 @@ class Span:
         tracked: bool,
         author: Optional[str],
         date: Optional[dt.datetime],
+        preserve_revision: bool,
         use_transaction: bool,
     ) -> ReplaceResult:
         """Implementation shared with the already-transactional batch path.
@@ -899,6 +911,10 @@ class Span:
         `use_transaction` is reserved for text-assignment plans layered on this
         substrate; this commit's ordinary and tracked paths do not consume it.
         """
+        if tracked and preserve_revision:
+            raise ValueError(
+                "tracked=True cannot be combined with preserve_revision=True"
+            )
         if tracked and not author:
             raise ValueError("author is required when tracked=True")
         if tracked:
@@ -923,12 +939,17 @@ class Span:
                     tracked=tracked,
                     author=author,
                     date=date,
+                    preserve_revision=preserve_revision,
                     use_transaction=use_transaction,
                 )
-        self._validate_replaceable()
+        preservation_noop = preserve_revision and new_text == self.text
+        self._validate_replaceable(validate_bookmarks=not preservation_noop)
+        preserved_revision_ids = _preserved_insertion_ids(
+            self, authorize=preserve_revision
+        )
         if not tracked:
             for atom in self._atoms:
-                if atom.in_insert:
+                if atom.in_insert and not preserve_revision:
                     raise UnsupportedStructureError(
                         "span intersects a pending tracked insertion; an"
                         " untracked edit there would silently rewrite text the"
@@ -953,15 +974,31 @@ class Span:
                         " to real content — replace the whole prompt"
                         f" ({prompt!r}) or use docx.controls.set_control_value"
                     )
+        if preserve_revision and new_text == self.text:
+            return ReplaceResult(
+                story=self.story,
+                deleted_text=self.text,
+                inserted_text=new_text,
+                tracked=False,
+                revision_ids=(),
+                preserved_revision_ids=preserved_revision_ids,
+            )
         if tracked:
             result = self._tracked_replace(new_text, author=author, date=date)  # type: ignore[arg-type]
         else:
-            result = self._plain_replace(new_text)
+            result = self._plain_replace(
+                new_text, preserved_revision_ids=preserved_revision_ids
+            )
         for sdt in placeholder_sdts:
             _clear_placeholder_state(sdt)
         return result
 
-    def _plain_replace(self, new_text: str) -> ReplaceResult:
+    def _plain_replace(
+        self,
+        new_text: str,
+        *,
+        preserved_revision_ids: "Tuple[int, ...]" = (),
+    ) -> ReplaceResult:
         first, last = self._atoms[0], self._atoms[-1]
         if first is last:
             text = first.text
@@ -982,6 +1019,7 @@ class Span:
             inserted_text=new_text,
             tracked=False,
             revision_ids=(),
+            preserved_revision_ids=preserved_revision_ids,
         )
         self.text = new_text
         self._end_offset = self._start_offset + len(new_text)
@@ -1197,6 +1235,72 @@ def _enclosing_insertion(element: "_Element") -> "Optional[_Element]":
             return node
         node = node.getparent()
     return None
+
+
+def _revision_ancestors(element: "_Element") -> "Tuple[_Element, ...]":
+    """Run-level revision wrappers containing `element`, nearest first."""
+    revisions: "List[_Element]" = []
+    node = element.getparent()
+    while node is not None:
+        if node.tag in (_INS, _DEL, _MOVE_FROM, _MOVE_TO):
+            revisions.append(node)
+        node = node.getparent()
+    return tuple(revisions)
+
+
+def _preserved_insertion_ids(
+    span: Span, *, authorize: bool
+) -> "Tuple[int, ...]":
+    """Validate and identify the one insertion explicitly kept by `span`."""
+    if not authorize:
+        return ()
+
+    selected_wrappers = [
+        _enclosing_insertion(atom.element)
+        for atom in span._atoms  # pyright: ignore[reportPrivateUsage]
+    ]
+    if all(wrapper is None for wrapper in selected_wrappers):
+        return ()
+    if span._view != "current":  # pyright: ignore[reportPrivateUsage]
+        raise UnsupportedStructureError(
+            "preserve_revision requires a span selected with view='current'"
+        )
+    if any(wrapper is None for wrapper in selected_wrappers):
+        raise UnsupportedStructureError(
+            "span mixes base text and insertion-owned text; preserve one"
+            " existing insertion at a time"
+        )
+    wrapper = selected_wrappers[0]
+    assert wrapper is not None
+    if wrapper.tag != _INS:
+        raise UnsupportedStructureError(
+            "tracked moves cannot be edited in place; resolve the move first"
+        )
+    if any(candidate is not wrapper for candidate in selected_wrappers[1:]):
+        raise UnsupportedStructureError(
+            "span crosses multiple tracked insertion wrappers; preserve one"
+            " existing insertion at a time"
+        )
+    for element in span._atom_sequence:  # pyright: ignore[reportPrivateUsage]
+        # the captured range covers atoms hidden by the current view too, and
+        # a plain replace writes only the SELECTED ones — so every element in
+        # it must be owned by exactly this insertion and nothing else
+        ancestors = _revision_ancestors(element)
+        if len(ancestors) != 1 or ancestors[0] is not wrapper:
+            raise UnsupportedStructureError(
+                "span contains nested or mixed revision history that cannot be"
+                " edited while preserving one insertion"
+            )
+    value = wrapper.get(_W_ID)
+    try:
+        revision_id = int(value) if value is not None else None
+    except ValueError:
+        revision_id = None
+    if revision_id is None:
+        raise UnsupportedStructureError(
+            "the preserved insertion has a missing or non-decimal w:id"
+        )
+    return (revision_id,)
 
 
 def _run_content_after(run: "Optional[_Element]", element: "_Element"):
@@ -1570,16 +1674,22 @@ def replace_all(
     tracked: bool = False,
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
+    preserve_revision: bool = False,
 ) -> ReplaceAllResult:
     """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
 
     One scan finds all matches, then replacements apply in reverse document order within each
     story, so no pending match shifts. A refusal on one match is recorded in `refused` and the
     rest proceed; a stale span aborts the batch instead, rolling back every replacement already
-    applied. Matches already equal to `new_text` are skipped.
+    applied. Matches already equal to `new_text` are skipped. `preserve_revision` forwards the
+    same existing-insertion contract to every match without adding a transaction per match.
     """
     from docx.errors import PaperRefusal
 
+    if tracked and preserve_revision:
+        raise ValueError(
+            "tracked=True cannot be combined with preserve_revision=True"
+        )
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
     _validate_writable_text(new_text, argument="new_text")
@@ -1625,6 +1735,7 @@ def replace_all(
                                 tracked=tracked,
                                 author=author,
                                 date=date,
+                                preserve_revision=preserve_revision,
                             )
                         )
                     except TargetNotFoundError:

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -90,7 +90,8 @@ APPROVED_SIGNATURES = [
     (
         "docx.search",
         "Span.replace",
-        "(self, new_text, *, tracked=False, author=None, date=None)",
+        "(self, new_text, *, tracked=False, author=None, date=None,"
+        " preserve_revision=False)",
     ),
     # -- block operations ----------------------------------------------------
     (
@@ -137,7 +138,7 @@ APPROVED_SIGNATURES = [
         "docx.search",
         "replace_all",
         "(document, needle, new_text, *, story=None, view='current',"
-        " tracked=False, author=None, date=None)",
+        " tracked=False, author=None, date=None, preserve_revision=False)",
     ),
     (
         "docx.search",

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -241,3 +241,22 @@ class DescribeReplaceAll:
         )
         replace_all(document, "token", "value")
         assert transaction_count == 1
+
+    def it_preserves_revision_identity_only_where_needed(self):
+        document = _doc()
+        document.add_paragraph("base term")
+        document.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:ins {W} w:id="801" w:author="Alice">'
+                "<w:r><w:t>inserted term</w:t></w:r></w:ins>"
+            )
+        )
+        result = replace_all(
+            document, "term", "phrase", preserve_revision=True
+        )
+        assert result.replaced_count == 2
+        assert sorted(item.preserved_revision_ids for item in result.results) == [
+            (),
+            (801,),
+        ]
+        assert document.element.body.xpath('//w:ins[@w:id="801"]')

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -137,6 +137,66 @@ class DescribeConsumedAndDetachedSpans:
             span.replace("lost edit")
 
 
+class DescribePreservedRevisionAncestry:
+    def it_refuses_a_current_match_that_bridges_hidden_nested_history(self):
+        document = _doc()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            parse_xml(
+                f'<w:ins {W} w:id="700" w:author="Alice">'
+                "<w:r><w:t>alpha</w:t></w:r>"
+                '<w:del w:id="701" w:author="Bob">'
+                "<w:r><w:delText>hidden</w:delText></w:r></w:del>"
+                "<w:r><w:t>beta</w:t></w:r></w:ins>"
+            )
+        )
+        span = find_one(document, "alphabeta")
+        before = document.element.xml
+        with pytest.raises(UnsupportedStructureError, match="nested"):
+            span.replace("updated", preserve_revision=True)
+        assert document.element.xml == before
+
+    def it_refuses_a_span_crossing_two_insertions(self):
+        document = _doc()
+        paragraph = document.add_paragraph()._p
+        for revision_id, text in ((710, "alpha"), (711, "beta")):
+            paragraph.append(
+                parse_xml(
+                    f'<w:ins {W} w:id="{revision_id}" w:author="Alice">'
+                    f"<w:r><w:t>{text}</w:t></w:r></w:ins>"
+                )
+            )
+        with pytest.raises(UnsupportedStructureError, match="multiple"):
+            find_one(document, "alphabeta").replace(
+                "updated", preserve_revision=True
+            )
+
+    def it_refuses_move_destinations_and_noncurrent_views(self):
+        moved = _doc()
+        moved.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:moveTo {W} w:id="720" w:author="Alice">'
+                "<w:r><w:t>moved text</w:t></w:r></w:moveTo>"
+            )
+        )
+        with pytest.raises(UnsupportedStructureError, match="moves"):
+            find_one(moved, "moved text").replace(
+                "updated", preserve_revision=True
+            )
+
+        inserted = _doc()
+        inserted.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:ins {W} w:id="721" w:author="Alice">'
+                "<w:r><w:t>inserted text</w:t></w:r></w:ins>"
+            )
+        )
+        with pytest.raises(UnsupportedStructureError, match="view='current'"):
+            find_one(inserted, "inserted text", view="all").replace(
+                "updated", preserve_revision=True
+            )
+
+
 class DescribeLayeredTrackedEdits:
     def it_refuses_spans_straddling_a_pending_insertion(self):
         """A w:del claiming inserted text was base content fabricates

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -21,7 +21,8 @@ from docx.errors import (
     TargetNotFoundError,
     UnsupportedStructureError,
 )
-from docx.oxml.ns import qn
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import parse_xml
 from docx.search import find_one, find_text, normalize_text
 from docx.story import iter_blocks
 
@@ -36,6 +37,7 @@ MINIMAL = "generated/minimal-clean/minimal.docx"
 
 RATE_TEXT = "$75–100/hr on a “full-service” basis"
 FROZEN = dt.datetime(2026, 7, 7, 12, 0, 0, tzinfo=dt.timezone.utc)
+W = nsdecls("w")
 
 
 def _doc(relpath: str):
@@ -78,7 +80,8 @@ class DescribeFindText:
 
     def it_matches_across_a_paragraph_boundary(self):
         spans = find_text(_doc(MINIMAL), "ordinary text. Second body paragraph")
-        assert len(spans) == 1 and spans[0].crosses_paragraphs
+        assert len(spans) == 1
+        assert spans[0].crosses_paragraphs
 
     def it_returns_matches_in_document_order_with_nth_selection(self):
         document = _doc(TRACKED)
@@ -207,6 +210,144 @@ class DescribePlainReplace:
         out = tmp_path / "out.docx"
         docx.package.patch_save(working, document, out)
         assert_changed_parts(working, out, {"word/document.xml"})
+
+
+class DescribeRevisionPreservation:
+    def _insertion_document(self, *, revision_id: str = "41"):
+        document = docx.Document()
+        insertion = parse_xml(
+            f'<w:ins {W} w:id="{revision_id}" w:author="Alice"'
+            ' w:date="2026-07-07T12:00:00Z">'
+            "<w:r><w:t>pending wording</w:t></w:r></w:ins>"
+        )
+        document.add_paragraph()._p.append(insertion)
+        return document, insertion
+
+    def it_preserves_an_existing_insertion_and_its_projections(self, tmp_path: Path):
+        document, insertion = self._insertion_document()
+        attributes = dict(insertion.attrib)
+        original = [b.text for b in iter_blocks(document, view="original")]
+        result = find_one(document, "pending").replace(
+            "revised", preserve_revision=True
+        )
+        assert result.preserved_revision_ids == (41,)
+        assert not result.preserved_structure
+        assert dict(insertion.attrib) == attributes
+        assert [b.text for b in iter_blocks(document, view="original")] == original
+        path = tmp_path / "preserved-insertion.docx"
+        document.save(path)
+        accepted = docx.Document(path)
+        accepted.revisions.accept_all()
+        assert "revised wording" in [b.text for b in iter_blocks(accepted)]
+        rejected = docx.Document(path)
+        rejected.revisions.reject_all()
+        assert "revised wording" not in [b.text for b in iter_blocks(rejected)]
+
+    def it_keeps_safe_insertion_refusal_as_the_default(self):
+        document, _ = self._insertion_document()
+        with pytest.raises(UnsupportedStructureError, match="pending tracked insertion"):
+            find_one(document, "pending").replace("revised")
+
+    def it_refuses_a_base_text_and_insertion_crossing(self):
+        document, insertion = self._insertion_document()
+        insertion.addprevious(parse_xml(f'<w:r {W}><w:t>base </w:t></w:r>'))
+        with pytest.raises(UnsupportedStructureError, match="mixes base text"):
+            find_one(document, "base pending").replace(
+                "combined", preserve_revision=True
+            )
+
+    def it_refuses_a_revision_nested_inside_the_preserved_insertion(self):
+        document = docx.Document()
+        document.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:ins {W} w:id="41" w:author="Alice"'
+                ' w:date="2026-07-07T12:00:00Z">'
+                '<w:r><w:t xml:space="preserve">pending </w:t></w:r>'
+                '<w:del w:id="42" w:author="Bob" w:date="2026-07-07T12:00:00Z">'
+                '<w:r><w:delText xml:space="preserve">dropped </w:delText>'
+                "</w:r></w:del>"
+                "<w:r><w:t>wording</w:t></w:r></w:ins>"
+            )
+        )
+        # the deletion is hidden from the current view but sits BETWEEN the
+        # matched atoms; an in-place edit would leave it stranded
+        with pytest.raises(UnsupportedStructureError, match="nested or mixed"):
+            find_one(document, "pending wording").replace(
+                "revised", preserve_revision=True
+            )
+
+    def it_refuses_a_span_crossing_two_insertions(self):
+        document, insertion = self._insertion_document()
+        insertion.addnext(
+            parse_xml(
+                f'<w:ins {W} w:id="55" w:author="Bob"'
+                ' w:date="2026-07-07T12:00:00Z">'
+                "<w:r><w:t> and more</w:t></w:r></w:ins>"
+            )
+        )
+        with pytest.raises(UnsupportedStructureError, match="crosses multiple"):
+            find_one(document, "wording and more").replace(
+                "revised", preserve_revision=True
+            )
+
+    def it_refuses_a_tracked_move_destination(self):
+        document = docx.Document()
+        document.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:moveTo {W} w:id="9" w:author="Alice"'
+                ' w:date="2026-07-07T12:00:00Z">'
+                "<w:r><w:t>moved wording</w:t></w:r></w:moveTo>"
+            )
+        )
+        with pytest.raises(UnsupportedStructureError, match="tracked moves"):
+            find_one(document, "moved wording").replace(
+                "revised", preserve_revision=True
+            )
+
+    def it_refuses_preservation_outside_the_current_view(self):
+        document, _ = self._insertion_document()
+        span = find_text(document, "pending wording", view="all")[0]
+        with pytest.raises(UnsupportedStructureError, match="view='current'"):
+            span.replace("revised", preserve_revision=True)
+
+    def it_keeps_a_noop_reusable_across_a_bookmark(self):
+        document = docx.Document()
+        insertion = parse_xml(
+            f'<w:ins {W} w:id="42" w:author="Alice">'
+            '<w:r><w:t>outside</w:t></w:r>'
+            '<w:bookmarkStart w:id="11" w:name="target"/>'
+            '<w:r><w:t>inside</w:t></w:r>'
+            '<w:bookmarkEnd w:id="11"/>'
+            "</w:ins>"
+        )
+        document.add_paragraph()._p.append(insertion)
+        span = find_one(document, "outsideinside")
+        before = document.element.xml
+
+        result = span.replace("outsideinside", preserve_revision=True)
+
+        assert result.preserved_revision_ids == (42,)
+        assert document.element.xml == before
+        span.replace("outsideinside", preserve_revision=True)
+
+    @pytest.mark.parametrize("revision_id", ["bad", ""])
+    def it_refuses_unreportable_insertion_ids(self, revision_id: str):
+        document, insertion = self._insertion_document(revision_id=revision_id)
+        if not revision_id:
+            del insertion.attrib[qn("w:id")]
+        with pytest.raises(UnsupportedStructureError, match="w:id"):
+            find_one(document, "pending").replace("current", preserve_revision=True)
+
+    def it_refuses_tracked_revision_preservation(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        with pytest.raises(ValueError, match="preserve_revision"):
+            find_one(document, "target").replace(
+                "changed",
+                tracked=True,
+                author="Editor",
+                preserve_revision=True,
+            )
 
 
 class DescribeReplaceRefusals:

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -330,6 +330,24 @@ class DescribeRevisionPreservation:
         assert document.element.xml == before
         span.replace("outsideinside", preserve_revision=True)
 
+    def it_does_not_apply_the_revision_noop_policy_to_base_text(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("outside")
+        first._r.addnext(
+            parse_xml(f'<w:bookmarkStart {W} w:id="11" w:name="target"/>')
+        )
+        inside = paragraph.add_run("inside")
+        inside._r.addnext(parse_xml(f'<w:bookmarkEnd {W} w:id="11"/>'))
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="hollow"):
+            find_one(document, "outsideinside").replace(
+                "outsideinside", preserve_revision=True
+            )
+
+        assert document.element.xml == before
+
     @pytest.mark.parametrize("revision_id", ["bad", ""])
     def it_refuses_unreportable_insertion_ids(self, revision_id: str):
         document, insertion = self._insertion_document(revision_id=revision_id)


### PR DESCRIPTION
## Summary
- add preserve_revision to Span.replace and replace_all
- validate current-view ownership, insertion identity, revision ancestry, moves, and reportable IDs
- retain author/date attribution plus accept/reject projections
- document mixed base-text and insertion-owned batch behavior

## Verification
- 190 focused API, replacement, regression, batch, and table tests
- warning-free Sphinx build
- changed-source Pyright remains at the clean-main baseline

## PR stack
- [#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)
- [#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)
- **[#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)**
- [#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)
- [#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)
- [#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tracked-change XML identity and accept/reject projections. Validation is strict, but a missed mixed/nested case could rewrite revision history.
> 
> **Overview**
> Adds `preserve_revision=True` to `Span.replace` and `replace_all` so current-view text wholly owned by one existing `w:ins` can be corrected in place without restamping id, author, date, or accept/reject meaning.
> 
> Outside revision markup the flag is a no-op untracked edit, so a batch can update base text and insertion-owned matches together. Results report retained wrappers in `preserved_revision_ids`; `revision_ids` stays reserved for newly authored redlines. Combining with `tracked=True` is refused.
> 
> Preflight rejects mixed base/insertion spans, nested or multiple wrappers, tracked moves, non-current views, and unreportable `w:id`s. Fully preflighted no-ops skip bookmark hollowing checks, change nothing, and leave the span reusable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e2a7b18e623fd57d6435d5eaf0cc9b944ea77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->