### PR TITLE
feat: preserve exact replacement structure

### DIFF
--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -7,29 +7,81 @@ Find and replace
 *paper-docx addition.* Match normalized text across run fragmentation.
 ``find_text`` and ``find_one`` locate visible text the way a person quotes it,
 normalizing smart quotes, dashes, exotic spaces, and case. They return a |Span|
-that maps the match back to its exact runs. |Span| ``.replace`` changes only
-the matched text; untouched runs keep their formatting byte-for-byte. With
-``tracked=True``, it emits a minimal genuine ``w:ins``/``w:del`` redline.
-|Span| ``.comment`` anchors a comment to exactly the span.
+that maps the match back to its concrete text nodes. |Span| ``.replace`` covers
+five replacement intents; |Span| ``.comment`` anchors a comment to exactly the
+span.
 
-Correct an existing insertion
------------------------------
+Choose a replacement policy
+---------------------------
 
-``span.replace(text, preserve_revision=True)`` corrects a current-view span
-wholly owned by one existing ``w:ins`` without reauthoring or restamping it.
-The text remains attributed to the insertion's recorded author and date, the
-wrapper ID is retained, and accepting or rejecting the revision keeps its
-original meaning. Outside revision markup the option behaves like an ordinary
-untracked edit, so ``replace_all`` can update base text and insertion-owned
-matches in one batch.
+All preservation modes are opt-in. Existing calls retain the ordinary
+untracked behavior.
 
-The operation refuses deletions, tracked moves, mixed base/insertion text,
-multiple or nested revision wrappers, and non-current views. ``tracked=True``
-cannot be combined with ``preserve_revision=True``. A fully preflighted no-op
-changes nothing and leaves the span reusable. |ReplaceResult|
-``preserved_revision_ids`` reports the existing insertion actually retained;
-``revision_ids`` continues to report only newly authored revisions. Direct and
-batch serialized results retain their schema discriminators and earlier keys.
+.. list-table::
+   :header-rows: 1
+   :widths: 23 32 45
+
+   * - Intent
+     - Call
+     - Contract
+   * - Ordinary untracked edit
+     - ``span.replace(text)``
+     - The replacement takes the start run's formatting. Untouched runs keep
+       their formatting, but selected text may be redistributed between runs.
+   * - Author a new redline
+     - ``span.replace(text, tracked=True, author=...)``
+     - Emits a minimal ``w:del``/``w:ins`` pair and consumes the span. A direct
+       tracked no-op is refused.
+   * - Correct one existing insertion
+     - ``span.replace(text, preserve_revision=True)``
+     - For a current-view span wholly owned by one ``w:ins``, keeps that
+       insertion's id, author, date, and accept/reject projections. Outside
+       revision markup, behaves like an ordinary untracked edit.
+   * - Preserve exact text topology
+     - ``span.replace(text, preserve_structure=True)``
+     - Changes only existing ``w:t`` values; preserves their attributes,
+       ancestor runs, and intervening transparent markers.
+   * - Correct an insertion and preserve topology
+     - ``span.replace(text, preserve_revision=True,
+       preserve_structure=True)``
+     - Applies both contracts to one existing insertion.
+
+``tracked=True`` cannot be combined with either preservation option. Revision
+preservation does not reauthor or restamp the existing insertion and does not
+support deletions, tracked moves, mixed base/insertion text, or multiple or
+nested revision wrappers. The corrected text remains attributed to the
+existing insertion's recorded author and date. Its outside-revision behavior
+lets ``replace_all`` apply one policy to both base text and insertion-owned
+matches. ``preserve_structure=True`` alone does not authorize an edit inside
+an insertion; request both guarantees for that case.
+
+Exact topology means structural preservation, not preservation of inferred
+formatting intent. Replacement text fills each selected text-node slice from
+left to right up to that slice's original capacity; the final selected node
+receives the remainder. Empty nodes remain present. Existing field,
+content-control, hyperlink, revision, protection, and paragraph-boundary guards
+still apply. The operation also refuses when the result would need an
+``xml:space`` attribute change, hollow a bookmark, or require placeholder
+cleanup. A successful mutation consumes the span because its captured offsets
+no longer describe the same text. A no-op still runs the full preflight and
+reports preservation evidence, but changes nothing and leaves the span
+reusable.
+
+|ReplaceResult| sets ``preserved_structure`` when exact topology was requested
+and satisfied. ``preserved_revision_ids`` contains the existing insertion ID
+only when an insertion was actually retained; it is empty for base text.
+``revision_ids`` continues to identify only newly authored revisions.
+``replace_all`` accepts the same options, records each per-match
+|PaperRefusal| while continuing independent matches, and retains one batch
+transaction. A stale target aborts and rolls back the batch. Matches already
+equal to the replacement are skipped rather than producing no-op results.
+The direct and batch ``to_dict()`` payloads retain their schema discriminators
+and earlier keys.
+
+These contracts describe the edited XML structure. They do not promise raw
+byte identity inside a changed package part; use :func:`docx.package.patch_save`
+and :func:`docx.package.diff_package` when package-level change evidence
+matters.
 
 .. currentmodule:: docx.search
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -57,7 +57,7 @@ naming the layer it came from.
 Edit one document
 -----------------
 
-|Span| replaces matched text while untouched runs keep their formatting byte-for-byte.
+|Span| replaces matched text while untouched runs retain their formatting.
 
 ::
 
@@ -66,13 +66,29 @@ Edit one document
     span = find_one(doc, "rate: $75-100/hr")     # matches “rate: $75–100/hr”
     span.replace("rate: $85-110/hr")             # formatting intact
 
-The same call, with ``tracked=True``, emits a minimal genuine ``w:ins``/
-``w:del`` redline that Word renders natively. Use
-``preserve_revision=True`` instead to correct current-view text wholly inside
-one existing insertion while retaining its ID, attribution, and accept/reject
-behavior. :ref:`docx.blocks
-<paper_blocks_api>` does the clause-level equivalent (insert, delete or
-replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and
+Choose the option that matches the edit's preservation contract:
+
+- Use the default for an ordinary untracked correction. The replacement takes
+  the start run's formatting.
+- Use ``tracked=True`` with ``author=...`` to author a new ``w:ins``/``w:del``
+  redline.
+- Use ``preserve_revision=True`` only to correct current-view text wholly
+  inside one existing insertion while retaining that insertion's attribution
+  and accept/reject behavior. The correction remains attributed to the
+  recorded author and date. Base text encountered by ``replace_all`` still
+  uses the ordinary untracked behavior.
+- Use ``preserve_structure=True`` when the existing text-node and run topology
+  must remain exact. This mode changes only text values and may refuse text
+  whose whitespace cannot be represented without changing ``xml:space``.
+- Combine the two preservation options when both contracts apply. Neither can
+  be combined with ``tracked=True``.
+
+These are text-structure contracts, not a promise that the serialized bytes of
+the changed XML part remain identical. The full refusal rules and result
+evidence are in :ref:`docx.search <paper_search_api>`.
+
+:ref:`docx.blocks <paper_blocks_api>` does the clause-level equivalent (insert,
+delete or replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and
 :ref:`docx.numbering <paper_numbering_api>` cover validated table edits and
 list numbering. :ref:`docx.controls <paper_controls_api>` fills content
 controls, clearing placeholder state so Word treats them as filled.

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -107,12 +107,29 @@ class _Atom:
 
 
 @dataclass(frozen=True)
+class _BookmarkRange:
+    """One named bookmark and the text elements inside its marker pair."""
+
+    name: str
+    text_elements: "Tuple[_Element, ...]"
+
+
+@dataclass(frozen=True)
+class _BookmarkCensus:
+    """Story bookmark ranges indexed by their enclosed text elements."""
+
+    ranges: "Tuple[_BookmarkRange, ...]"
+    by_element: "dict[int, Tuple[int, ...]]"
+
+
+@dataclass(frozen=True)
 class _FreshnessCensus:
     """One story census shared by a synchronous replacement batch."""
 
     atoms: "Tuple[_Atom, ...]"
     by_element: "dict[int, _Atom]"
     positions: "dict[int, int]"
+    bookmarks: "Optional[_BookmarkCensus]" = None
 
 
 _CONTEXT_SCOPE_TAGS = frozenset(
@@ -991,7 +1008,15 @@ class Span:
         if preserve_structure:
             assignments = _exact_text_assignments(self, new_text)
             _refuse_hollowed_bookmarks(
-                _hollowed_bookmarks_after(assignments, self._atoms)
+                _hollowed_bookmarks_after(
+                    assignments,
+                    self._atoms,
+                    census=(
+                        self._freshness_census.bookmarks
+                        if self._freshness_census is not None
+                        else None
+                    ),
+                )
             )
             result = ReplaceResult(
                 story=self.story,
@@ -1572,40 +1597,65 @@ def _apply_text_assignments(assignments: "Sequence[_TextAssignment]") -> None:
 
 
 def _hollowed_bookmarks_after(
-    assignments: "Sequence[_TextAssignment]", atoms: "Sequence[_Atom]"
+    assignments: "Sequence[_TextAssignment]",
+    atoms: "Sequence[_Atom]",
+    *,
+    census: "Optional[_BookmarkCensus]" = None,
 ) -> "List[str]":
     """Non-point bookmarks emptied by the planned exact assignments."""
     paragraph = atoms[0].paragraph
     if paragraph is None:
         return []
+    if census is None:
+        census = _bookmark_census(paragraph.getroottree().getroot())
     planned = {id(item.element): item.after for item in assignments}
-    # A character replacement is same-paragraph, but the bookmark containing
-    # it need not be. Scan the complete story tree so markers in adjacent
-    # paragraphs still protect their sole enclosed text from being emptied.
-    stream = list(paragraph.getroottree().getroot().iter())
-    starts: "dict[Optional[str], Tuple[int, str]]" = {}
-    hollowed: "List[str]" = []
-    for position, node in enumerate(stream):
+    candidates = {
+        range_index
+        for assignment in assignments
+        if assignment.before and not assignment.after
+        for range_index in census.by_element.get(id(assignment.element), ())
+    }
+    return [
+        bookmark.name
+        for range_index, bookmark in enumerate(census.ranges)
+        if range_index in candidates
+        and all(
+            not planned.get(id(element), element.text or "")
+            for element in bookmark.text_elements
+        )
+    ]
+
+
+def _bookmark_census(root: "_Element") -> _BookmarkCensus:
+    """Index non-point bookmark text with one story traversal."""
+    active: "dict[Optional[str], Tuple[str, List[_Element]]]" = {}
+    ranges: "List[_BookmarkRange]" = []
+    for node in root.iter():
         if node.tag == _BOOKMARK_START:
-            starts[node.get(_W_ID)] = (position, node.get(_W_NAME) or "")
+            active[node.get(_W_ID)] = (node.get(_W_NAME) or "", [])
+        elif node.tag in (_T, _DEL_TEXT) and (node.text or ""):
+            for _name, text_elements in active.values():
+                text_elements.append(node)
         elif node.tag == _BOOKMARK_END:
-            entry = starts.get(node.get(_W_ID))
+            entry = active.pop(node.get(_W_ID), None)
             if entry is None:
                 continue
-            start_pos, name = entry
-            if name == "_GoBack":
-                continue
-            text_elements = [
-                inner
-                for inner in stream[start_pos + 1 : position]
-                if inner.tag in (_T, _DEL_TEXT) and (inner.text or "")
-            ]
-            if text_elements and all(
-                not planned.get(id(inner), inner.text or "")
-                for inner in text_elements
-            ):
-                hollowed.append(name)
-    return hollowed
+            name, text_elements = entry
+            if name != "_GoBack" and text_elements:
+                ranges.append(
+                    _BookmarkRange(name=name, text_elements=tuple(text_elements))
+                )
+    by_element_lists: "dict[int, List[int]]" = {}
+    for range_index, bookmark in enumerate(ranges):
+        for element in bookmark.text_elements:
+            by_element_lists.setdefault(id(element), []).append(range_index)
+    return _BookmarkCensus(
+        ranges=tuple(ranges),
+        by_element={
+            element_id: tuple(range_indexes)
+            for element_id, range_indexes in by_element_lists.items()
+        },
+    )
 
 
 def _refuse_hollowed_bookmarks(hollowed: "Sequence[str]") -> None:
@@ -1871,6 +1921,7 @@ def replace_all(
             positions={
                 id(atom.element): index for index, atom in enumerate(atoms)
             },
+            bookmarks=_bookmark_census(root) if preserve_structure else None,
         )
         for span in story_spans:
             span._freshness_census = census

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -361,8 +361,8 @@ class ReplaceResult:
 
 
 @dataclass(frozen=True)
-class _TextAssignment:  # pyright: ignore[reportUnusedClass]
-    """One preflighted text-only mutation for a replacement plan."""
+class _TextAssignment:
+    """One preflighted text-only mutation for exact-structure replacement."""
 
     element: "_Element"
     before: str
@@ -850,17 +850,9 @@ class Span:
                 "span crosses a hyperlink boundary; edit the linked text and"
                 " the surrounding text separately"
             )
-        hollowed = (
-            _hollowed_bookmarks(self._atoms, self._end_offset)
-            if validate_bookmarks
-            else []
-        )
-        if hollowed:
-            raise UnsupportedStructureError(
-                f"replacing this span would hollow out bookmark(s) {hollowed}"
-                " — the targets of REF/PAGEREF cross-references and TOC"
-                " entries; narrow the span to inside the bookmark, or remove"
-                " the bookmark deliberately first"
+        if validate_bookmarks:
+            _refuse_hollowed_bookmarks(
+                _hollowed_bookmarks(self._atoms, self._end_offset)
             )
 
     # -- replace ----------------------------------------------------------
@@ -872,26 +864,39 @@ class Span:
         tracked: bool = False,
         author: Optional[str] = None,
         date: Optional[dt.datetime] = None,
+        preserve_structure: bool = False,
         preserve_revision: bool = False,
     ) -> ReplaceResult:
-        """Replace this span's text, preserving run formatting.
+        """Replace this span's text and return machine-readable change evidence.
 
-        Untracked, this edits in place: untouched runs retain their run properties, the
-        replacement takes the start run's formatting, and the span stays usable. Tracked, it
-        emits a minimal `w:del`/`w:ins` pair and consumes the span.
+        The default is an untracked edit: untouched runs retain their run properties, the
+        replacement takes the start run's formatting, and the span stays usable. `tracked=True`
+        instead emits a minimal `w:del`/`w:ins` pair and consumes the span; a direct tracked
+        no-op is refused.
 
-        `preserve_revision=True` permits a current-view span wholly owned by one existing
-        `w:ins` to be corrected without changing its id, author, date, or accept/reject meaning.
-        Outside revision markup it behaves like an ordinary untracked edit. The result reports
-        the retained insertion in `preserved_revision_ids`; `revision_ids` remains reserved for
-        newly authored revisions. Refuses mixed, nested, moved, stale, protected, field,
-        control, bookmark, hyperlink, and paragraph-boundary structures before mutation.
+        `preserve_revision=True` explicitly permits a current-view span wholly owned by one
+        existing `w:ins` to be corrected without changing that insertion's id, author, date,
+        or accept/reject meaning; outside revision markup it behaves like an ordinary untracked
+        edit. The corrected text remains attributed to the existing insertion's author and date.
+        `preserve_structure=True` changes only the selected `w:t` values: each node receives up
+        to its selected original capacity from left to right, and the final node receives the
+        remainder. Text elements, attributes, runs, intervening markers, and empty nodes are
+        retained. A mutating exact-structure edit consumes the span and refuses text that would
+        require changing `xml:space`. A fully preflighted no-op reports preservation evidence
+        but does not consume the span. The two preservation options can be combined, but neither
+        can be combined with `tracked=True`.
+
+        `preserved_structure` and `preserved_revision_ids` report the guarantees applied;
+        `revision_ids` remains reserved for newly authored tracked revisions. Refuses a protected
+        document, a stale or foreign span, and unsafe field, control, revision, bookmark,
+        whitespace, or paragraph-boundary structures before mutation.
         """
         return self._replace(
             new_text,
             tracked=tracked,
             author=author,
             date=date,
+            preserve_structure=preserve_structure,
             preserve_revision=preserve_revision,
             use_transaction=self._freshness_census is None,
         )
@@ -903,18 +908,16 @@ class Span:
         tracked: bool,
         author: Optional[str],
         date: Optional[dt.datetime],
+        preserve_structure: bool,
         preserve_revision: bool,
         use_transaction: bool,
     ) -> ReplaceResult:
-        """Implementation shared with the already-transactional batch path.
-
-        `use_transaction` is reserved for text-assignment plans layered on this
-        substrate; this commit's ordinary and tracked paths do not consume it.
-        """
-        if tracked and preserve_revision:
-            raise ValueError(
-                "tracked=True cannot be combined with preserve_revision=True"
-            )
+        """Implementation shared with the already-transactional batch path."""
+        _validate_replacement_options(
+            tracked=tracked,
+            preserve_structure=preserve_structure,
+            preserve_revision=preserve_revision,
+        )
         if tracked and not author:
             raise ValueError("author is required when tracked=True")
         if tracked:
@@ -926,7 +929,10 @@ class Span:
         _validate_writable_text(new_text, argument="new_text")
         _refuse_if_protected(self._document, "replace text")
         self._validate_fresh()
-        if any(atom.is_synthetic for atom in self._atoms) or self.crosses_paragraphs:
+        if (
+            not preserve_structure
+            and (any(atom.is_synthetic for atom in self._atoms) or self.crosses_paragraphs)
+        ):
             # spans matched ACROSS a tab/break/paragraph boundary may still
             # edit safely when the actual change lies within one segment:
             # narrow to the changed region; if the change itself crosses a
@@ -939,6 +945,7 @@ class Span:
                     tracked=tracked,
                     author=author,
                     date=date,
+                    preserve_structure=False,
                     preserve_revision=preserve_revision,
                     use_transaction=use_transaction,
                 )
@@ -946,7 +953,9 @@ class Span:
             self, authorize=preserve_revision
         )
         preservation_noop = bool(preserved_revision_ids) and new_text == self.text
-        self._validate_replaceable(validate_bookmarks=not preservation_noop)
+        self._validate_replaceable(
+            validate_bookmarks=not preserve_structure and not preservation_noop
+        )
         if not tracked:
             for atom in self._atoms:
                 if atom.in_insert and not preserve_revision:
@@ -958,6 +967,11 @@ class Span:
                     )
         placeholder_sdts = _placeholder_controls_of(self._atoms)
         if placeholder_sdts:
+            if preserve_structure and new_text != self.text:
+                raise UnsupportedStructureError(
+                    "span lies in placeholder prompt text whose successful fill"
+                    " requires structural cleanup; exact structure cannot be preserved"
+                )
             if tracked:
                 raise UnsupportedStructureError(
                     "span lies in a form control still showing PLACEHOLDER"
@@ -974,6 +988,40 @@ class Span:
                         " to real content — replace the whole prompt"
                         f" ({prompt!r}) or use docx.controls.set_control_value"
                     )
+        if preserve_structure:
+            assignments = _exact_text_assignments(self, new_text)
+            _refuse_hollowed_bookmarks(
+                _hollowed_bookmarks_after(assignments, self._atoms)
+            )
+            result = ReplaceResult(
+                story=self.story,
+                deleted_text=self.text,
+                inserted_text=new_text,
+                tracked=False,
+                revision_ids=(),
+                preserved_structure=True,
+                preserved_revision_ids=preserved_revision_ids,
+            )
+            if new_text == self.text:
+                return result
+            if use_transaction:
+                with rollback_on_error(self._document, self):
+                    _apply_text_assignments(assignments)
+                    self.text = new_text
+                    self._consumed = True
+            else:
+                try:
+                    _apply_text_assignments(assignments)
+                except BaseException:
+                    # The batch owns the package transaction. Restore this
+                    # text-only attempt locally so a late PaperRefusal can be
+                    # recorded and an unexpected error can roll back the batch.
+                    for assignment in assignments:
+                        assignment.element.text = assignment.before
+                    raise
+                self.text = new_text
+                self._consumed = True
+            return result
         if preservation_noop:
             return ReplaceResult(
                 story=self.story,
@@ -1481,6 +1529,108 @@ def _hollowed_bookmarks(atoms: "Sequence[_Atom]", end_offset: int) -> "List[str]
     return hollowed
 
 
+def _exact_text_assignments(span: Span, new_text: str) -> "Tuple[_TextAssignment, ...]":
+    """Plan deterministic text-only assignments without changing the tree."""
+    assignments: "List[_TextAssignment]" = []
+    cursor = 0
+    atoms = span._atoms  # pyright: ignore[reportPrivateUsage]
+    last_index = len(atoms) - 1
+    for index, atom in enumerate(atoms):
+        start = span._start_offset if index == 0 else 0  # pyright: ignore[reportPrivateUsage]
+        end = (
+            span._end_offset  # pyright: ignore[reportPrivateUsage]
+            if index == last_index
+            else len(atom.text)
+        )
+        capacity = end - start
+        if index == last_index:
+            replacement_piece = new_text[cursor:]
+        else:
+            piece_length = min(capacity, len(new_text) - cursor)
+            replacement_piece = new_text[cursor : cursor + piece_length]
+            cursor += piece_length
+        after = atom.text[:start] + replacement_piece + atom.text[end:]
+        if (
+            after != atom.text
+            and (after[:1].isspace() or after[-1:].isspace())
+            and atom.element.get(_XML_SPACE) != "preserve"
+        ):
+            raise UnsupportedStructureError(
+                "exact structure would leave significant edge whitespace in a"
+                " w:t without its existing xml:space='preserve' attribute"
+            )
+        assignments.append(
+            _TextAssignment(element=atom.element, before=atom.text, after=after)
+        )
+    return tuple(assignments)
+
+
+def _apply_text_assignments(assignments: "Sequence[_TextAssignment]") -> None:
+    """Apply a fully validated exact-structure assignment collection."""
+    for assignment in assignments:
+        assignment.element.text = assignment.after
+
+
+def _hollowed_bookmarks_after(
+    assignments: "Sequence[_TextAssignment]", atoms: "Sequence[_Atom]"
+) -> "List[str]":
+    """Non-point bookmarks emptied by the planned exact assignments."""
+    paragraph = atoms[0].paragraph
+    if paragraph is None:
+        return []
+    planned = {id(item.element): item.after for item in assignments}
+    # A character replacement is same-paragraph, but the bookmark containing
+    # it need not be. Scan the complete story tree so markers in adjacent
+    # paragraphs still protect their sole enclosed text from being emptied.
+    stream = list(paragraph.getroottree().getroot().iter())
+    starts: "dict[Optional[str], Tuple[int, str]]" = {}
+    hollowed: "List[str]" = []
+    for position, node in enumerate(stream):
+        if node.tag == _BOOKMARK_START:
+            starts[node.get(_W_ID)] = (position, node.get(_W_NAME) or "")
+        elif node.tag == _BOOKMARK_END:
+            entry = starts.get(node.get(_W_ID))
+            if entry is None:
+                continue
+            start_pos, name = entry
+            if name == "_GoBack":
+                continue
+            text_elements = [
+                inner
+                for inner in stream[start_pos + 1 : position]
+                if inner.tag in (_T, _DEL_TEXT) and (inner.text or "")
+            ]
+            if text_elements and all(
+                not planned.get(id(inner), inner.text or "")
+                for inner in text_elements
+            ):
+                hollowed.append(name)
+    return hollowed
+
+
+def _refuse_hollowed_bookmarks(hollowed: "Sequence[str]") -> None:
+    if hollowed:
+        raise UnsupportedStructureError(
+            f"replacing this span would hollow out bookmark(s) {list(hollowed)}"
+            " — the targets of REF/PAGEREF cross-references and TOC entries;"
+            " narrow the span to inside the bookmark, or remove the bookmark"
+            " deliberately first"
+        )
+
+
+def _validate_replacement_options(
+    *, tracked: bool, preserve_structure: bool, preserve_revision: bool
+) -> None:
+    if tracked and preserve_structure:
+        raise ValueError(
+            "tracked=True cannot be combined with preserve_structure=True"
+        )
+    if tracked and preserve_revision:
+        raise ValueError(
+            "tracked=True cannot be combined with preserve_revision=True"
+        )
+
+
 def _set_preserved_text(element: "_Element", text: str) -> None:
     element.text = text
     if text[:1].isspace() or text[-1:].isspace():
@@ -1674,6 +1824,7 @@ def replace_all(
     tracked: bool = False,
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
+    preserve_structure: bool = False,
     preserve_revision: bool = False,
 ) -> ReplaceAllResult:
     """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
@@ -1681,15 +1832,17 @@ def replace_all(
     One scan finds all matches, then replacements apply in reverse document order within each
     story, so no pending match shifts. A refusal on one match is recorded in `refused` and the
     rest proceed; a stale span aborts the batch instead, rolling back every replacement already
-    applied. Matches already equal to `new_text` are skipped. `preserve_revision` forwards the
-    same existing-insertion contract to every match without adding a transaction per match.
+    applied. Matches already equal to `new_text` are skipped. `preserve_structure` and
+    `preserve_revision` have the same contracts as |Span| ``.replace`` and are forwarded to
+    every match without adding a transaction per match.
     """
     from docx.errors import PaperRefusal
 
-    if tracked and preserve_revision:
-        raise ValueError(
-            "tracked=True cannot be combined with preserve_revision=True"
-        )
+    _validate_replacement_options(
+        tracked=tracked,
+        preserve_structure=preserve_structure,
+        preserve_revision=preserve_revision,
+    )
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
     _validate_writable_text(new_text, argument="new_text")
@@ -1735,6 +1888,7 @@ def replace_all(
                                 tracked=tracked,
                                 author=author,
                                 date=date,
+                                preserve_structure=preserve_structure,
                                 preserve_revision=preserve_revision,
                             )
                         )

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -91,7 +91,7 @@ APPROVED_SIGNATURES = [
         "docx.search",
         "Span.replace",
         "(self, new_text, *, tracked=False, author=None, date=None,"
-        " preserve_revision=False)",
+        " preserve_structure=False, preserve_revision=False)",
     ),
     # -- block operations ----------------------------------------------------
     (
@@ -138,7 +138,8 @@ APPROVED_SIGNATURES = [
         "docx.search",
         "replace_all",
         "(document, needle, new_text, *, story=None, view='current',"
-        " tracked=False, author=None, date=None, preserve_revision=False)",
+        " tracked=False, author=None, date=None, preserve_structure=False,"
+        " preserve_revision=False)",
     ),
     (
         "docx.search",

--- a/tests/paper/test_audit_late_failure_atomicity.py
+++ b/tests/paper/test_audit_late_failure_atomicity.py
@@ -10,6 +10,7 @@ from lxml import etree
 
 import docx
 import docx.revision as revision_module
+import docx.search as search_module
 from docx import commentops, composition
 from docx._transaction import rollback_on_error
 from docx.enum.style import WD_STYLE_TYPE
@@ -308,6 +309,38 @@ class DescribeRevisionRollback:
 
         assert deleted_text.tag == qn("w:delText")
         assert deleted_text.getparent() is not None
+
+
+class DescribeExactReplacementRollback:
+    def it_restores_text_nodes_and_the_live_span_after_a_late_failure(
+        self, monkeypatch
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("alpha")
+        paragraph.add_run("beta")
+        span = find_one(document, "alphabeta")
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        original = search_module._apply_text_assignments
+
+        def apply_then_refuse(assignments):
+            assignments[0].element.text = assignments[0].after
+            raise UnsupportedStructureError("forced late refusal")
+
+        monkeypatch.setattr(
+            search_module, "_apply_text_assignments", apply_then_refuse
+        )
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed", preserve_structure=True),
+            UnsupportedStructureError,
+        )
+        assert [element.text for element in elements] == ["alpha", "beta"]
+        assert span.text == "alphabeta"
+        span._validate_fresh()
+
+        monkeypatch.setattr(search_module, "_apply_text_assignments", original)
+        span.replace("changed", preserve_structure=True)
 
 
 class DescribeCommentAuthoringRollback:

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -223,25 +223,6 @@ class DescribeReplaceAll:
         assert nested["preserved_structure"] is False
         assert nested["preserved_revision_ids"] == []
 
-    def it_uses_only_the_outer_batch_transaction(self, monkeypatch):
-        document = _doc()
-        document.add_paragraph("token token")
-        transaction_count = 0
-        original = search_module.rollback_on_error
-
-        @contextmanager
-        def counted_transaction(*args, **kwargs):
-            nonlocal transaction_count
-            transaction_count += 1
-            with original(*args, **kwargs):
-                yield
-
-        monkeypatch.setattr(
-            search_module, "rollback_on_error", counted_transaction
-        )
-        replace_all(document, "token", "value")
-        assert transaction_count == 1
-
     def it_preserves_revision_identity_only_where_needed(self):
         document = _doc()
         document.add_paragraph("base term")
@@ -260,3 +241,83 @@ class DescribeReplaceAll:
             (801,),
         ]
         assert document.element.body.xpath('//w:ins[@w:id="801"]')
+
+    def it_reports_exact_structure_evidence_for_each_successful_match(self):
+        document = _doc()
+        document.add_paragraph("token token")
+        result = replace_all(
+            document, "token", "value", preserve_structure=True
+        )
+        assert result.replaced_count == 2
+        assert all(item.preserved_structure for item in result.results)
+        assert "value value" in [block.text for block in iter_blocks(document)]
+
+    @pytest.mark.parametrize("preserve_structure", [False, True])
+    def it_uses_only_the_outer_batch_transaction(
+        self, monkeypatch, preserve_structure: bool
+    ):
+        document = _doc()
+        document.add_paragraph("token token")
+        transaction_count = 0
+        original = search_module.rollback_on_error
+
+        @contextmanager
+        def counted_transaction(*args, **kwargs):
+            nonlocal transaction_count
+            transaction_count += 1
+            with original(*args, **kwargs):
+                yield
+
+        monkeypatch.setattr(
+            search_module, "rollback_on_error", counted_transaction
+        )
+        replace_all(
+            document,
+            "token",
+            "value",
+            preserve_structure=preserve_structure,
+        )
+        assert transaction_count == 1
+
+    def it_locally_restores_a_late_per_match_refusal(self, monkeypatch):
+        document = _doc()
+        document.add_paragraph("token token")
+        original = search_module._apply_text_assignments
+        calls = 0
+
+        def refuse_second(assignments):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                assignments[0].element.text = "corrupt"
+                raise UnsupportedStructureError("forced late refusal")
+            original(assignments)
+
+        monkeypatch.setattr(
+            search_module, "_apply_text_assignments", refuse_second
+        )
+        result = replace_all(
+            document, "token", "value", preserve_structure=True
+        )
+        assert result.replaced_count == 1
+        assert len(result.refused) == 1
+        assert "token value" in [block.text for block in iter_blocks(document)]
+
+    def it_rolls_back_the_batch_after_an_unexpected_exact_failure(self, monkeypatch):
+        document = _doc()
+        paragraph = document.add_paragraph("token token")
+        original = search_module._apply_text_assignments
+        calls = 0
+
+        def fail_second(assignments):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                assignments[0].element.text = "corrupt"
+                raise RuntimeError("forced unexpected failure")
+            original(assignments)
+
+        monkeypatch.setattr(search_module, "_apply_text_assignments", fail_second)
+        with pytest.raises(RuntimeError, match="forced unexpected"):
+            replace_all(document, "token", "value", preserve_structure=True)
+        assert paragraph.text == "token token"

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -279,6 +279,45 @@ class DescribeReplaceAll:
         )
         assert transaction_count == 1
 
+    def it_reuses_one_bookmark_census_for_an_exact_batch(self, monkeypatch):
+        document = _doc()
+        document.add_paragraph("token token token")
+        census_count = 0
+        original = search_module._bookmark_census
+
+        def counted_census(*args, **kwargs):
+            nonlocal census_count
+            census_count += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(search_module, "_bookmark_census", counted_census)
+        result = replace_all(
+            document, "token", "value", preserve_structure=True
+        )
+
+        assert result.replaced_count == 3
+        assert census_count == 1
+
+    def it_keeps_bookmark_hollowing_checks_per_match_in_an_exact_batch(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        start = parse_xml(
+            f'<w:bookmarkStart {W} w:id="91" w:name="protected"/>'
+        )
+        paragraph._p.append(start)
+        paragraph.add_run("token")
+        paragraph._p.append(parse_xml(f'<w:bookmarkEnd {W} w:id="91"/>'))
+        document.add_paragraph("token")
+
+        result = replace_all(
+            document, "token", "", preserve_structure=True
+        )
+
+        assert result.replaced_count == 1
+        assert len(result.refused) == 1
+        assert result.refused[0]["error"] == "UnsupportedStructureError"
+        assert "token" in [block.text for block in iter_blocks(document)]
+
     def it_locally_restores_a_late_per_match_refusal(self, monkeypatch):
         document = _doc()
         document.add_paragraph("token token")

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -136,6 +136,14 @@ class DescribeConsumedAndDetachedSpans:
         with pytest.raises(TargetNotFoundError, match="removed"):
             span.replace("lost edit")
 
+    def it_consumes_a_span_after_exact_structure_replacement(self):
+        document = _doc()
+        span = find_one(document, "perfectly ordinary")
+        span.replace("thoroughly mundane", preserve_structure=True)
+        with pytest.raises(TargetNotFoundError, match="structure-preserving"):
+            span.replace("again")
+        assert find_one(document, "thoroughly mundane").text == "thoroughly mundane"
+
 
 class DescribePreservedRevisionAncestry:
     def it_refuses_a_current_match_that_bridges_hidden_nested_history(self):
@@ -194,6 +202,19 @@ class DescribePreservedRevisionAncestry:
         with pytest.raises(UnsupportedStructureError, match="view='current'"):
             find_one(inserted, "inserted text", view="all").replace(
                 "updated", preserve_revision=True
+            )
+
+    def it_keeps_structure_preservation_orthogonal_to_revision_authorization(self):
+        document = _doc()
+        document.add_paragraph()._p.append(
+            parse_xml(
+                f'<w:ins {W} w:id="730" w:author="Alice">'
+                "<w:r><w:t>inserted text</w:t></w:r></w:ins>"
+            )
+        )
+        with pytest.raises(UnsupportedStructureError, match="pending tracked insertion"):
+            find_one(document, "inserted text").replace(
+                "updated", preserve_structure=True
             )
 
 

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -12,6 +12,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from lxml import etree
 
 import docx
 import docx._clock
@@ -212,7 +213,7 @@ class DescribePlainReplace:
         assert_changed_parts(working, out, {"word/document.xml"})
 
 
-class DescribeRevisionPreservation:
+class DescribePreservationPolicies:
     def _insertion_document(self, *, revision_id: str = "41"):
         document = docx.Document()
         insertion = parse_xml(
@@ -310,7 +311,95 @@ class DescribeRevisionPreservation:
         with pytest.raises(UnsupportedStructureError, match="view='current'"):
             span.replace("revised", preserve_revision=True)
 
-    def it_keeps_a_noop_reusable_across_a_bookmark(self):
+    def it_preserves_the_exact_text_element_graph_and_distribution(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        for text in ("alpha", " pay", "ment", " terms"):
+            paragraph.add_run(text)
+        paragraph.runs[1].bold = True
+        proofing_marker = parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        paragraph.runs[1]._r.addnext(proofing_marker)
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        runs = tuple(paragraph._p.iter(qn("w:r")))
+        graph = tuple((e, e.tag, tuple(e.attrib.items()), tuple(e)) for e in elements)
+        run_properties = tuple(
+            etree.tostring(run.find(qn("w:rPr")))
+            if run.find(qn("w:rPr")) is not None else None
+            for run in runs
+        )
+        result = find_one(document, "alpha payment terms").replace(
+            "alpha settlement terms", preserve_structure=True
+        )
+        assert result.preserved_structure
+        assert [e.text for e in elements] == ["alpha", " set", "tlem", "ent terms"]
+        assert tuple((e, e.tag, tuple(e.attrib.items()), tuple(e)) for e in elements) == graph
+        assert tuple(paragraph._p.iter(qn("w:r"))) == runs
+        assert proofing_marker.getparent() is paragraph._p
+        assert tuple(
+            etree.tostring(run.find(qn("w:rPr")))
+            if run.find(qn("w:rPr")) is not None else None
+            for run in runs
+        ) == run_properties
+        reopened = save_and_reopen(document, tmp_path / "exact.docx")
+        assert reopened.paragraphs[-1].text == "alpha settlement terms"
+
+    def it_keeps_empty_nodes_and_consumes_a_mutated_exact_span(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        for text in ("ab", "cd", "ef"):
+            paragraph.add_run(text)
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        span = find_one(document, "abcdef")
+        span.replace("x", preserve_structure=True)
+        assert [e.text for e in elements] == ["x", "", ""]
+        with pytest.raises(TargetNotFoundError, match="structure-preserving"):
+            span.replace("again")
+        assert find_one(document, "x").text == "x"
+
+    def it_refuses_exact_edge_whitespace_without_changing_xml_space(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("plain")
+        element = paragraph._p.find(".//" + qn("w:t"))
+        assert element is not None
+        assert element.get(qn("xml:space")) is None
+        before = etree.tostring(paragraph._p)
+        with pytest.raises(UnsupportedStructureError, match="edge whitespace"):
+            find_one(document, "plain").replace(" plain", preserve_structure=True)
+        assert etree.tostring(paragraph._p) == before
+
+    def it_refuses_an_exact_plan_that_would_hollow_a_bookmark(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("outside")
+        start = parse_xml(f'<w:bookmarkStart {W} w:id="9" w:name="target"/>')
+        first._r.addnext(start)
+        inside = paragraph.add_run("inside")
+        end = parse_xml(f'<w:bookmarkEnd {W} w:id="9"/>')
+        inside._r.addnext(end)
+        before = etree.tostring(paragraph._p)
+        with pytest.raises(UnsupportedStructureError, match="hollow"):
+            find_one(document, "outsideinside").replace(
+                "x", preserve_structure=True
+            )
+        assert etree.tostring(paragraph._p) == before
+
+    def it_refuses_hollowing_a_bookmark_whose_markers_span_paragraphs(self):
+        document = docx.Document()
+        first = document.add_paragraph()._p
+        first.append(
+            parse_xml(f'<w:bookmarkStart {W} w:id="10" w:name="target"/>')
+        )
+        document.add_paragraph("inside")
+        last = document.add_paragraph()._p
+        last.append(parse_xml(f'<w:bookmarkEnd {W} w:id="10"/>'))
+        before = document.element.xml
+
+        with pytest.raises(UnsupportedStructureError, match="hollow"):
+            find_one(document, "inside").replace("", preserve_structure=True)
+
+        assert document.element.xml == before
+
+    def it_keeps_a_revision_preserving_noop_reusable_across_a_bookmark(self):
         document = docx.Document()
         insertion = parse_xml(
             f'<w:ins {W} w:id="42" w:author="Alice">'
@@ -348,6 +437,37 @@ class DescribeRevisionPreservation:
 
         assert document.element.xml == before
 
+    def it_leaves_an_exact_noop_reusable(self):
+        document = docx.Document()
+        document.add_paragraph("same")
+        span = find_one(document, "same")
+        before = document.element.xml
+        assert span.replace("same", preserve_structure=True).preserved_structure
+        assert document.element.xml == before
+        span.replace("same", preserve_structure=True)
+
+    def it_combines_revision_and_structure_preservation(self):
+        document, insertion = self._insertion_document()
+        text_element = next(insertion.iter(qn("w:t")))
+        result = find_one(document, "pending").replace(
+            "current", preserve_revision=True, preserve_structure=True
+        )
+        assert result.preserved_structure
+        assert result.preserved_revision_ids == (41,)
+        assert text_element.getparent() is not None
+
+    def it_keeps_an_exact_patch_save_to_the_changed_story(self, tmp_path: Path):
+        source = fixture_path(FRAGMENTED)
+        working = tmp_path / "work.docx"
+        shutil.copyfile(source, working)
+        document = docx.Document(str(working))
+        find_one(document, "$75-100/hr").replace(
+            "$85–110/hr", preserve_structure=True
+        )
+        out = tmp_path / "out.docx"
+        docx.package.patch_save(working, document, out)
+        assert_changed_parts(working, out, {"word/document.xml"})
+
     @pytest.mark.parametrize("revision_id", ["bad", ""])
     def it_refuses_unreportable_insertion_ids(self, revision_id: str):
         document, insertion = self._insertion_document(revision_id=revision_id)
@@ -356,15 +476,13 @@ class DescribeRevisionPreservation:
         with pytest.raises(UnsupportedStructureError, match="w:id"):
             find_one(document, "pending").replace("current", preserve_revision=True)
 
-    def it_refuses_tracked_revision_preservation(self):
+    @pytest.mark.parametrize("policy", ["preserve_structure", "preserve_revision"])
+    def it_refuses_tracked_preservation_combinations(self, policy: str):
         document = docx.Document()
         document.add_paragraph("target")
-        with pytest.raises(ValueError, match="preserve_revision"):
+        with pytest.raises(ValueError, match=policy):
             find_one(document, "target").replace(
-                "changed",
-                tracked=True,
-                author="Editor",
-                preserve_revision=True,
+                "changed", tracked=True, author="Editor", **{policy: True}
             )
 
 


### PR DESCRIPTION
## Summary
- add preserve_structure to direct and batch replacement
- deterministically distribute replacement text while retaining text nodes, runs, attributes, and transparent markers
- preflight whitespace, bookmarks, placeholders, and unsupported boundaries
- add combined preserve_revision plus preserve_structure coverage and atomic rollback tests

## Verification
- 226 focused replacement, API, rollback, batch, and table tests
- targeted Ruff checks
- warning-free Sphinx build
- changed-source Pyright remains at the clean-main baseline

## PR stack
- [#37 Reply conformance](https://github.com/paper-instruments/paper-docx/pull/37)
- [#38 Replacement substrate](https://github.com/paper-instruments/paper-docx/pull/38)
- [#40 Existing insertion preservation](https://github.com/paper-instruments/paper-docx/pull/40)
- **[#41 Exact structure preservation](https://github.com/paper-instruments/paper-docx/pull/41)**
- [#36 Composition endpoints](https://github.com/paper-instruments/paper-docx/pull/36)
- [#39 Bounded-save guidance](https://github.com/paper-instruments/paper-docx/pull/39)

Each PR targets the branch immediately below it so GitHub shows only that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document-mutation and revision/bookmark safety in search/replace. Behavior is opt-in and heavily preflighted, but incorrect topology or rollback would still corrupt Word XML.
> 
> **Overview**
> Adds an opt-in **`preserve_structure=True`** path on `Span.replace` and `replace_all` so replacements can change only existing `w:t` values while keeping runs, attributes, empty nodes, and intervening markers.
> 
> Replacement text is filled left-to-right up to each selected node’s original capacity, with the last node taking the remainder. The mode refuses `xml:space` changes, bookmark hollowing, placeholder cleanup, and combination with `tracked=True`. It can be combined with `preserve_revision=True`; structure-only still does not authorize edits inside a pending insertion.
> 
> Mutating exact-structure edits consume the span. No-ops still preflight and report `preserved_structure` without consuming it. Batch replace reuses one bookmark census and one outer transaction, locally restoring a late per-match refusal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26436ab849c97286110f728c5a6385f43951391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->