### PR TITLE
feat: add explicit text matching policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ result.document.paragraphs[0].text
 ### Reading and editing one document
 
 - **`docx.story`** traverses the body, headers, footers, footnotes, endnotes, comments, tracked insertions, content controls, and text boxes. Callers can view the document as it stands, before pending revisions, or all at once.
-- **`docx.search`** finds normalized text across Word's run fragmentation. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
+- **`docx.search`** finds exact text by default across Word's run fragmentation, with explicit normalized matching when wanted. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
 - **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to a text anchor, as plain edits or as a tracked change.
 - **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that refuse on unsafe structures such as merged cells, nested tables, or undefined numbering.
 - **`docx.controls`** fills content controls with the correct value type and clears placeholder state so Word treats them as filled.

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -4,12 +4,37 @@
 Find and replace
 ================
 
-*paper-docx addition.* Match normalized text across run fragmentation.
-``find_text`` and ``find_one`` locate visible text the way a person quotes it,
-normalizing smart quotes, dashes, exotic spaces, and case. They return a |Span|
-that maps the match back to its concrete text nodes. |Span| ``.replace`` covers
-five replacement intents; |Span| ``.comment`` anchors a comment to exactly the
-span.
+*paper-docx addition.* Match visible text across run fragmentation.
+``find_text`` and ``find_one`` use literal exact matching by default. They
+return a |Span| that maps the match back to its concrete text nodes. |Span|
+``.replace`` covers five replacement intents; |Span| ``.comment`` anchors a
+comment to exactly the span.
+
+Choose a matching policy
+------------------------
+
+Exact matching is the mutation-safe default for ``find_text``, ``find_one``,
+and ``replace_all``. It compares Unicode codepoints literally, including case,
+punctuation, and whitespace. Ordinary Word run boundaries do not insert text,
+so an exact match can cross any number of runs in one paragraph. A paragraph
+boundary is represented in raw search text by exactly one ``"\n"``; a space or
+``"\r"`` does not substitute for it. A candidate consisting only of a paragraph
+separator cannot form a live span because that separator does not belong to a
+text atom. An inline Word line break is itself a visible text atom and also has
+the exact representation ``"\n"``.
+
+Pass ``match="normalized"`` when the caller intentionally wants the previous
+convenience behavior. Normalized matching case-folds, maps smart quotes and
+dashes to their ASCII forms, maps exotic spaces and tabs to spaces, collapses
+whitespace runs, and removes soft hyphens. It still returns the exact document
+characters in ``Span.text`` and the resulting live span remains a valid
+mutation target. The selected policy applies to both ``needle`` and ``near``.
+
+Search-produced spans expose that evidence as ``Span.match_policy``
+(``"exact"`` or ``"normalized"``). Spans derived from already-known live
+offsets have no search policy and report ``None``. Empty needles never match;
+exact whitespace is literal searchable content, while normalized input that
+folds to only whitespace does not match.
 
 Choose a replacement policy
 ---------------------------
@@ -71,7 +96,8 @@ reusable.
 and satisfied. ``preserved_revision_ids`` contains the existing insertion ID
 only when an insertion was actually retained; it is empty for base text.
 ``revision_ids`` continues to identify only newly authored revisions.
-``replace_all`` accepts the same options, records each per-match
+``replace_all`` accepts the same replacement options plus the same exact-by-
+default ``match`` policy, records each per-match
 |PaperRefusal| while continuing independent matches, and retains one batch
 transaction. A stale target aborts and rolls back the batch. Matches already
 equal to the replacement are skipped rather than producing no-op results.

--- a/docs/api/paper-tableops.rst
+++ b/docs/api/paper-tableops.rst
@@ -17,6 +17,8 @@ newlines in exact mode (and may fold as whitespace in normalized mode), while a
 match never crosses between cells. No matching table raises
 |TargetNotFoundError|, one matching table is returned, and multiple matching
 tables raise |AmbiguousTargetError| with guidance to use more specific text.
+An empty or normalization-empty ``near_text`` raises |TargetNotFoundError|
+instead of matching every table.
 
 .. currentmodule:: docx.tableops
 

--- a/docs/api/paper-tableops.rst
+++ b/docs/api/paper-tableops.rst
@@ -9,6 +9,15 @@ that cannot be handled safely, including merged cells and nested tables. Cell
 text routes through the |Span| machinery, so ``tracked=True`` produces a real
 revision.
 
+``find_table()`` searches top-level tables in the main document body. It uses
+literal ``match="exact"`` matching by default; pass ``match="normalized"`` to
+fold case, typography, and whitespace explicitly. The requested text must occur
+within one physical cell: paragraph boundaries inside that cell remain literal
+newlines in exact mode (and may fold as whitespace in normalized mode), while a
+match never crosses between cells. No matching table raises
+|TargetNotFoundError|, one matching table is returned, and multiple matching
+tables raise |AmbiguousTargetError| with guidance to use more specific text.
+
 .. currentmodule:: docx.tableops
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,10 +7,11 @@ Release v\ |version| (:ref:`Installation <install>`)
 *paper-docx* is an agent-first, strict-superset hard fork of `python-docx`_ for
 safely inspecting, editing, reviewing, and composing existing Word documents.
 The distribution is renamed; the import name stays ``docx``, so existing code
-keeps working unchanged. It adds complete document traversal, normalized
-find-and-replace, native tracked changes and their resolution, compare,
-and cross-document composition. Every added operation either does exactly what
-it claims or refuses atomically instead of risking silent corruption. See
+keeps working unchanged. It adds complete document traversal, exact-by-default
+find-and-replace with normalized opt-in, native tracked changes and their
+resolution, compare, and cross-document composition. Every added operation
+either does exactly what it claims or refuses atomically instead of risking
+silent corruption. See
 :ref:`Paper additions <paper_additions>` for the added APIs.
 
 .. _python-docx: https://github.com/python-openxml/python-docx

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -44,10 +44,11 @@ at once (``"all"``). |Outline| reports what it could not read.
     o.blind_region_counts                    # {"tracked_insertions": 2, "text_boxes": 1, ...}
     [b.text for b in o.blocks if b.in_text_box]
 
-:ref:`docx.search <paper_search_api>` normalizes smart quotes, dashes, exotic
-spaces and case, then matches across the multiple runs Word fragments text
-into. The
-returned |Span| maps that text back to the exact runs that hold it.
+:ref:`docx.search <paper_search_api>` matches literal visible text by default,
+across the multiple runs Word fragments text into. Callers can explicitly opt
+into normalization of smart quotes, dashes, exotic spaces, whitespace and
+case. The returned |Span| maps the exact document text back to the runs that
+hold it.
 :ref:`docx.formatting <paper_formatting_api>` answers the complementary
 question: what formatting does this text *actually* carry? It resolves through
 document defaults, the style chain and direct formatting, with every value
@@ -63,8 +64,26 @@ Edit one document
 
     from docx.search import find_one
 
-    span = find_one(doc, "rate: $75-100/hr")     # matches “rate: $75–100/hr”
+    span = find_one(doc, "rate: $75–100/hr")
     span.replace("rate: $85-110/hr")             # formatting intact
+
+Exact targeting is the mutation-safe default. To migrate a convenience lookup
+that intentionally ignores typography or case, opt in once and pass the
+resulting live span to the mutation API:
+
+::
+
+    span = find_one(
+        doc,
+        'rate: $75-100/hr on a "full-service" basis',
+        match="normalized",
+    )
+    span.text                                    # preserves the smart punctuation
+    span.replace("rate: $85-110/hr")
+
+The normalized span is an intentional mutation target, not an inspection-only
+result. APIs outside ``docx.search`` do not repeat the ``match`` keyword; use
+this explicit preselection workflow when they need normalized targeting.
 
 Choose the option that matches the edit's preservation contract:
 

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -1448,5 +1448,6 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
         _atoms=list(span_atoms),
         _start_offset=start_offset,
         _end_offset=end_offset + 1,
-        _norm_start=0,
+        _raw_start=0,
+        _match_start=0,
     )

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -1,12 +1,11 @@
-"""Normalized text search over visibility-complete traversal.
+"""Exact and normalized text search over visibility-complete traversal.
 
-`find_text` matches the way people (and models) actually quote documents:
-smart quotes, dashes, exotic spaces and case differences are normalized away
-(`normalize_text`), and matches assemble across Word's fragmented runs and
+`find_text` matches exact visible text by default, or explicitly normalized
+text when requested. Both policies assemble across Word's fragmented runs and
 across paragraph boundaries. The returned |Span| is the pivotal object of the
-editing surface: it maps a visible-text interval back to the concrete
-`w:t` text atoms that hold it, carries a stable block anchor, and is the
-receiver of the safe replace operations (`Span.replace`).
+editing surface: it maps a visible-text interval back to the concrete `w:t`
+text atoms that hold it, carries a stable block anchor, and is the receiver of
+the safe replace operations (`Span.replace`).
 
 Search space and block identity are shared with `docx.story` (one walker
 defines both), so a span's anchor always agrees with the outline.
@@ -64,6 +63,7 @@ _XML_SPACE = qn("xml:space")
 _FLD_SIMPLE = qn("w:fldSimple")
 _FLD_CHAR = qn("w:fldChar")
 _FLD_CHAR_TYPE = qn("w:fldCharType")
+_MATCH_POLICIES = ("exact", "normalized")
 
 
 @dataclass
@@ -346,6 +346,25 @@ def _normalized_with_map(value: str) -> Tuple[str, List[int]]:
     return "".join(compact), compact_map
 
 
+def _match_space(value: str, match: str) -> Tuple[str, List[int]]:
+    """Return policy-space text and a map from it to raw `value` offsets."""
+    if match == "exact":
+        return value, list(range(len(value)))
+    return _normalized_with_map(value)
+
+
+def _source_aligned(start: int, end: int, source_map: "Sequence[int]") -> bool:
+    """Whether a policy-space interval maps to whole raw characters."""
+    return (start == 0 or source_map[start - 1] != source_map[start]) and (
+        end == len(source_map) or source_map[end - 1] != source_map[end]
+    )
+
+
+def _validate_match_policy(match: str) -> None:
+    if match not in _MATCH_POLICIES:
+        raise ValueError(f"match must be one of {_MATCH_POLICIES}, got {match!r}")
+
+
 @dataclass(frozen=True)
 class ReplaceResult:
     """Outcome of a `Span.replace` call.
@@ -392,7 +411,9 @@ class Span:
 
     Spans hold live references into the document tree and go stale when the
     underlying text changes; every operation revalidates first and raises
-    |TargetNotFoundError| on staleness.
+    |TargetNotFoundError| on staleness. ``match_policy`` records the policy
+    that selected a search-produced span, or is ``None`` for a span constructed
+    from already-known live offsets.
     """
 
     text: str
@@ -408,7 +429,9 @@ class Span:
     _atoms: "List[_Atom]" = field(repr=False)
     _start_offset: int = field(repr=False)  # into first atom's text
     _end_offset: int = field(repr=False)  # exclusive, into last atom's text
-    _norm_start: int = field(repr=False)  # position in the story's normalized text
+    _raw_start: int = field(repr=False)  # position in the story's raw visible text
+    _match_start: int = field(repr=False)  # position in the selected policy space
+    match_policy: "Optional[str]" = field(default=None, init=False)
     _consumed: bool = field(default=False, repr=False)  # set by tracked replace
     _context_signatures: "Tuple[tuple, ...]" = field(init=False, repr=False)
     _atom_sequence: "Tuple[_Element, ...]" = field(init=False, repr=False)
@@ -669,7 +692,8 @@ class Span:
             _atoms=list(sub_atoms),
             _start_offset=start_off,
             _end_offset=end_off,
-            _norm_start=self._norm_start,
+            _raw_start=0,
+            _match_start=0,
         )
         sub_span._view = self._view
         sub_span._sequence_view = self._sequence_view
@@ -1708,26 +1732,35 @@ def _spans_for_story(
     document: "Document",
     story_name: str,
     atoms: "List[_Atom]",
-    needle_norm: str,
+    needle_match: str,
     *,
     all_atoms: "Sequence[_Atom]",
     view: str,
+    match: str,
 ) -> "List[Span]":
     raw_text, char_map = _assemble(atoms)
-    normalized, norm_map = _normalized_with_map(raw_text)
+    match_text, match_map = _match_space(raw_text, match)
     all_atom_positions = {
         id(atom.element): index for index, atom in enumerate(all_atoms)
     }
     spans: "List[Span]" = []
     search_from = 0
     while True:
-        found_at = normalized.find(needle_norm, search_from)
+        found_at = match_text.find(needle_match, search_from)
         if found_at < 0:
             break
-        search_from = found_at + len(needle_norm)
-        raw_start = norm_map[found_at]
-        raw_end = norm_map[found_at + len(needle_norm) - 1] + 1
+        match_end = found_at + len(needle_match)
+        if not _source_aligned(found_at, match_end, match_map):
+            search_from = found_at + 1
+            continue
+        search_from = match_end
+        raw_start = match_map[found_at]
+        raw_end = match_map[match_end - 1] + 1
         # trim paragraph-separator chars at the edges (they hold no atom text)
+        if match == "exact" and (
+            char_map[raw_start][1] == -1 or char_map[raw_end - 1][1] == -1
+        ):
+            continue
         while raw_start < raw_end and char_map[raw_start][1] == -1:
             raw_start += 1
         while raw_end > raw_start and char_map[raw_end - 1][1] == -1:
@@ -1761,8 +1794,10 @@ def _spans_for_story(
             _atoms=list(span_atoms),
             _start_offset=start_offset,
             _end_offset=end_offset + 1,
-            _norm_start=found_at,
+            _raw_start=raw_start,
+            _match_start=found_at,
         )
+        span.match_policy = match
         sequence_start = all_atom_positions[id(span_atoms[0].element)]
         sequence_end = all_atom_positions[id(span_atoms[-1].element)]
         span._atom_sequence = tuple(
@@ -1774,10 +1809,10 @@ def _spans_for_story(
     return spans
 
 
-def _near_distance(span_norm_start: int, near_positions: "List[int]") -> float:
+def _near_distance(span_match_start: int, near_positions: "List[int]") -> float:
     if not near_positions:
         return float("inf")
-    return min(abs(span_norm_start - position) for position in near_positions)
+    return min(abs(span_match_start - position) for position in near_positions)
 
 
 def find_text(
@@ -1788,21 +1823,24 @@ def find_text(
     near: Optional[str] = None,
     story: Optional[str] = None,
     view: str = "current",
+    match: str = "exact",
 ) -> "List[Span]":
-    """Every span of `needle` in `document`, normalized matching.
+    """Every span of `needle` in `document` under the selected match policy.
 
     `story` limits the search to one story part (e.g. "word/document.xml");
     `near` ranks matches by distance to the nearest occurrence of `near`'s
-    normalized text in the same story; `nth` (1-based) then selects a single
-    match. Matching assembles across fragmented runs and across paragraph
-    boundaries (a paragraph break matches a single space in the needle).
+    text under the same policy in the same story; `nth` (1-based) then selects
+    a single match. Exact matching is the default. Normalized matching folds
+    case, typography, and whitespace. Both assemble across fragmented runs;
+    exact matching represents each paragraph boundary as one literal ``\\n``.
     """
+    _validate_match_policy(match)
     if view not in VIEWS:
         raise ValueError(f"view must be one of {VIEWS}, got {view!r}")
-    needle_norm = normalize_text(needle)
-    if not needle_norm.strip():
+    needle_match, _ = _match_space(needle, match)
+    if not needle_match or (match == "normalized" and not needle_match.strip()):
         return []
-    near_norm = normalize_text(near) if near else None
+    near_match = _match_space(near, match)[0] if near else None
 
     all_spans: "List[Tuple[float, int, Span]]" = []
     order = 0
@@ -1817,23 +1855,26 @@ def find_text(
             document,
             story_name,
             atoms,
-            needle_norm,
+            needle_match,
             all_atoms=all_atoms,
             view=view,
+            match=match,
         )
         if not spans:
             continue
         near_positions: "List[int]" = []
-        if near_norm:
+        if near_match:
             raw_text, _ = _assemble(atoms)
-            normalized, _ = _normalized_with_map(raw_text)
-            start = normalized.find(near_norm)
+            match_text, match_map = _match_space(raw_text, match)
+            start = match_text.find(near_match)
             while start >= 0:
-                near_positions.append(start)
-                start = normalized.find(near_norm, start + 1)
+                end = start + len(near_match)
+                if _source_aligned(start, end, match_map):
+                    near_positions.append(start)
+                start = match_text.find(near_match, start + 1)
         for span in spans:
             distance = (
-                _near_distance(span._norm_start, near_positions) if near_norm else 0.0
+                _near_distance(span._match_start, near_positions) if near_match else 0.0
             )
             all_spans.append((distance, order, span))
             order += 1
@@ -1871,6 +1912,7 @@ def replace_all(
     *,
     story: Optional[str] = None,
     view: str = "current",
+    match: str = "exact",
     tracked: bool = False,
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
@@ -1879,15 +1921,19 @@ def replace_all(
 ) -> ReplaceAllResult:
     """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
 
-    One scan finds all matches, then replacements apply in reverse document order within each
-    story, so no pending match shifts. A refusal on one match is recorded in `refused` and the
-    rest proceed; a stale span aborts the batch instead, rolling back every replacement already
-    applied. Matches already equal to `new_text` are skipped. `preserve_structure` and
-    `preserve_revision` have the same contracts as |Span| ``.replace`` and are forwarded to
-    every match without adding a transaction per match.
+    ``match`` defaults to literal exact matching; ``"normalized"`` explicitly
+    enables folded matching. One scan finds all matches, then replacements
+    apply in reverse raw document order within each story, so no pending match
+    shifts. A refusal on one match is recorded in `refused` and the rest
+    proceed; a stale span aborts the batch instead, rolling back every
+    replacement already applied. Matches already equal to `new_text` are
+    skipped. `preserve_structure` and `preserve_revision` have the same
+    contracts as |Span| ``.replace`` and are forwarded to every match without
+    adding a transaction per match.
     """
     from docx.errors import PaperRefusal
 
+    _validate_match_policy(match)
     _validate_replacement_options(
         tracked=tracked,
         preserve_structure=preserve_structure,
@@ -1899,7 +1945,7 @@ def replace_all(
     _refuse_if_protected(document, "replace text")
     spans = [
         span
-        for span in find_text(document, needle, story=story, view=view)
+        for span in find_text(document, needle, story=story, view=view, match=match)
         if span.text != new_text
     ]
     by_story: "dict[str, List[Span]]" = {}
@@ -1929,7 +1975,7 @@ def replace_all(
         with rollback_on_error(document):
             for story_name in sorted(by_story):
                 ordered = sorted(
-                    by_story[story_name], key=lambda s: s._norm_start, reverse=True
+                    by_story[story_name], key=lambda s: s._raw_start, reverse=True
                 )
                 for span in ordered:
                     try:
@@ -1973,14 +2019,18 @@ def find_one(
     near: Optional[str] = None,
     story: Optional[str] = None,
     view: str = "current",
+    match: str = "exact",
 ) -> Span:
     """The single span matching `needle`, or a typed refusal.
 
-    Zero matches raise `TargetNotFoundError`. Two or more raise `AmbiguousTargetError`:
-    `nth` and `story` narrow the set, while `near` only ranks `find_text` results and never
-    reduces them.
+    Exact matching is the default; pass ``match="normalized"`` to opt into
+    folded targeting. Zero matches raise `TargetNotFoundError`. Two or more
+    raise `AmbiguousTargetError`: `nth` and `story` narrow the set, while
+    `near` only ranks `find_text` results and never reduces them.
     """
-    matches = find_text(document, needle, nth=nth, near=near, story=story, view=view)
+    matches = find_text(
+        document, needle, nth=nth, near=near, story=story, view=view, match=match
+    )
     if not matches:
         raise TargetNotFoundError(f"no match for {needle!r} in any story part")
     if len(matches) > 1:

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -197,6 +197,10 @@ def find_table(
     """
     _validate_match_policy(match)
     needle = near_text if match == "exact" else normalize_text(near_text)
+    if not needle or (match == "normalized" and not needle.strip()):
+        raise TargetNotFoundError(
+            "near_text must contain searchable text; an empty target cannot identify a table"
+        )
     matches: "list[Table]" = []
     for table in document.tables:
         seen_cells: "set[CT_Tc]" = set()

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -303,7 +303,8 @@ def update_cell(
         _atoms=atoms,
         _start_offset=0,
         _end_offset=len(atoms[-1].text),
-        _norm_start=0,
+        _raw_start=0,
+        _match_start=0,
     )
     return span.replace(new_text, tracked=tracked, author=author, date=date)
 

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -30,12 +30,14 @@ from docx.search import (
     Span,
     _collect_block_atoms,
     _next_revision_id,
+    _validate_match_policy,  # pyright: ignore[reportPrivateUsage]
     normalize_text,
 )
 from docx.story import Anchor, _iter_block_elements, _story_elements, content_hash
 
 if TYPE_CHECKING:
     from docx.document import Document
+    from docx.oxml.table import CT_Tc
     from docx.table import Table, _Cell
 
 check_install()
@@ -180,20 +182,38 @@ def _cell_text(cell: "_Cell") -> str:
     return "\n".join(p.text for p in cell.paragraphs)
 
 
-def find_table(document: "Document", *, near_text: str) -> "Table":
-    """The table whose cell text contains `near_text` (normalized matching).
+def find_table(
+    document: "Document", *, near_text: str, match: str = "exact"
+) -> "Table":
+    """The table with one physical cell containing `near_text`.
 
-    Zero matching tables raise |TargetNotFoundError|; more than one raise
-    |AmbiguousTargetError| — make `near_text` more specific.
+    Matching is literal and exact by default; ``match="normalized"`` folds case,
+    typography, and whitespace. Paragraph boundaries within one cell are represented
+    by literal newlines, but a match never crosses from one cell into another. Only
+    top-level tables in the main document body are searched.
+
+    Zero matching tables raise |TargetNotFoundError|; more than one matching table
+    raises |AmbiguousTargetError| — make `near_text` more specific.
     """
-    needle = normalize_text(near_text)
-    matches = []
+    _validate_match_policy(match)
+    needle = near_text if match == "exact" else normalize_text(near_text)
+    matches: "list[Table]" = []
     for table in document.tables:
-        text = normalize_text(
-            "\n".join(_cell_text(cell) for row in table.rows for cell in row.cells)
-        )
-        if needle in text:
-            matches.append(table)
+        seen_cells: "set[CT_Tc]" = set()
+        for row in table.rows:
+            for cell in row.cells:
+                physical_cell = cell._tc  # pyright: ignore[reportPrivateUsage]
+                if physical_cell in seen_cells:
+                    continue
+                seen_cells.add(physical_cell)
+                text = _cell_text(cell)
+                candidate = text if match == "exact" else normalize_text(text)
+                if needle in candidate:
+                    matches.append(table)
+                    break
+            else:
+                continue
+            break
     if not matches:
         raise TargetNotFoundError(f"no table contains {near_text!r}")
     if len(matches) > 1:

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -117,7 +117,11 @@ APPROVED_SIGNATURES = [
     ("docx.revision", "Revisions.accept_all", "(self, *, author=None)"),
     ("docx.revision", "Revisions.reject_all", "(self, *, author=None)"),
     # -- tables + numbering --------------------------------------------------
-    ("docx.tableops", "find_table", "(document, *, near_text)"),
+    (
+        "docx.tableops",
+        "find_table",
+        "(document, *, near_text, match='exact')",
+    ),
     (
         "docx.tableops",
         "update_cell",

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -79,12 +79,14 @@ APPROVED_SIGNATURES = [
     (
         "docx.search",
         "find_text",
-        "(document, needle, *, nth=None, near=None, story=None, view='current')",
+        "(document, needle, *, nth=None, near=None, story=None, view='current',"
+        " match='exact')",
     ),
     (
         "docx.search",
         "find_one",
-        "(document, needle, *, nth=None, near=None, story=None, view='current')",
+        "(document, needle, *, nth=None, near=None, story=None, view='current',"
+        " match='exact')",
     ),
     # -- replace -------------------------------------------------------------
     (
@@ -137,7 +139,7 @@ APPROVED_SIGNATURES = [
     (
         "docx.search",
         "replace_all",
-        "(document, needle, new_text, *, story=None, view='current',"
+        "(document, needle, new_text, *, story=None, view='current', match='exact',"
         " tracked=False, author=None, date=None, preserve_structure=False,"
         " preserve_revision=False)",
     ),

--- a/tests/paper/test_audit_secondary_safety.py
+++ b/tests/paper/test_audit_secondary_safety.py
@@ -57,6 +57,6 @@ def it_preserves_paragraph_boundaries_in_anchored_comment_text():
     document = docx.Document()
     document.add_paragraph("Alpha")
     document.add_paragraph("Beta")
-    comment = find_one(document, "Alpha Beta").comment("Review", author="Reviewer")
+    comment = find_one(document, "Alpha\nBeta").comment("Review", author="Reviewer")
 
     assert anchored_text(document, comment) == "Alpha\nBeta"

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -91,24 +91,26 @@ class DescribeBreakTolerantReplace:
 
     def it_edits_one_segment_of_a_tab_crossing_span(self):
         document, paragraph = self._tabbed_doc()
-        span = find_one(document, "Section 3. Termination")
+        span = find_one(document, "Section 3. Termination", match="normalized")
         span.replace("Section 4. Termination")
         assert paragraph.text == "Section 4.\tTermination"
 
     def it_edits_the_trailing_segment_too(self):
         document, paragraph = self._tabbed_doc()
-        find_one(document, "Section 3. Termination").replace("Section 3. Renewal")
+        find_one(
+            document, "Section 3. Termination", match="normalized"
+        ).replace("Section 3. Renewal")
         assert paragraph.text == "Section 3.\tRenewal"
 
     def it_narrows_tracked_replaces_the_same_way(self):
         document, paragraph = self._tabbed_doc()
-        find_one(document, "Section 3. Termination").replace(
+        find_one(document, "Section 3. Termination", match="normalized").replace(
             "Section 4. Termination", tracked=True, author="Carol QA", date=FROZEN
         )
         document.revisions.accept_all()
         assert paragraph.text == "Section 4.\tTermination"
         document2, paragraph2 = self._tabbed_doc()
-        find_one(document2, "Section 3. Termination").replace(
+        find_one(document2, "Section 3. Termination", match="normalized").replace(
             "Section 4. Termination", tracked=True, author="Carol QA", date=FROZEN
         )
         document2.revisions.reject_all()
@@ -118,14 +120,14 @@ class DescribeBreakTolerantReplace:
         """Whitespace in the replacement aligns with the existing tab: the
         document keeps its tab, both text segments change."""
         document, paragraph = self._tabbed_doc()
-        find_one(document, "Section 3. Termination").replace(
+        find_one(document, "Section 3. Termination", match="normalized").replace(
             "Chapter Three - Termination"
         )
         assert paragraph.text == "Chapter Three -\tTermination"
 
     def it_still_refuses_changes_that_would_swallow_the_break(self):
         document, _ = self._tabbed_doc()
-        span = find_one(document, "Section 3. Termination")
+        span = find_one(document, "Section 3. Termination", match="normalized")
         with pytest.raises(UnsupportedStructureError, match="tab or line break"):
             span.replace("Section3Termination")  # no whitespace for the tab
 
@@ -188,6 +190,37 @@ class DescribeReplaceAll:
         assert not result.refused
         texts = [b.text for b in iter_blocks(document)]
         assert "VALUE then VALUE then VALUE in one run." in texts
+
+    def it_defaults_to_exact_and_supports_explicit_normalized_matching(self):
+        exact_document = _doc()
+        exact_document.add_paragraph("Token token TOKEN")
+        exact = replace_all(exact_document, "token", "value")
+        assert exact.replaced_count == 1
+        assert "Token value TOKEN" in [b.text for b in iter_blocks(exact_document)]
+
+        normalized_document = _doc()
+        normalized_document.add_paragraph("Token token TOKEN")
+        normalized = replace_all(
+            normalized_document, "token", "value", match="normalized"
+        )
+        assert normalized.replaced_count == 3
+        assert "value value value" in [
+            b.text for b in iter_blocks(normalized_document)
+        ]
+
+    def it_replaces_normalized_matches_in_raw_reverse_order(self):
+        document = _doc()
+        document.add_paragraph("Straße Straße")
+        result = replace_all(document, "strasse", "road", match="normalized")
+        assert result.replaced_count == 2
+        assert "road road" in [b.text for b in iter_blocks(document)]
+
+    def it_rejects_an_invalid_policy_before_mutation(self):
+        document = _doc()
+        before = document.element.xml
+        with pytest.raises(ValueError, match="match must be one of"):
+            replace_all(document, "token", "value", match="fuzzy")
+        assert document.element.xml == before
 
     def it_reports_refused_matches_instead_of_skipping_silently(self):
         document = _doc(FIELDS)

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -73,7 +73,26 @@ class DescribeCasefoldExpansion:
         assert find_one(document, "Straße").text == "Straße"
         # matches AFTER the expansion point must stay aligned
         assert find_one(document, "Haus").text == "Haus"
-        assert find_one(document, "strasse").text == "Straße"  # casefold equal
+        assert find_one(document, "strasse", match="normalized").text == "Straße"
+
+    def it_does_not_select_part_of_an_expanding_casefold(self):
+        document = docx.Document()
+        document.add_paragraph("aßb")
+        assert find_text(document, "s", match="normalized") == []
+        assert find_text(document, "as", match="normalized") == []
+        assert find_text(document, "sb", match="normalized") == []
+
+        overlapping = docx.Document()
+        overlapping.add_paragraph("sß")
+        assert find_one(overlapping, "ss", match="normalized").text == "ß"
+
+    def it_does_not_use_part_of_an_expanding_casefold_as_near_context(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("target")
+        document.add_paragraph("ß")
+        matches = find_text(document, "target", near="s", match="normalized")
+        assert [span.anchor.index for span in matches] == [0, 1]
 
 
 class DescribeTabAndBreakMatching:
@@ -83,7 +102,7 @@ class DescribeTabAndBreakMatching:
         paragraph.add_run("alpha")
         paragraph.add_run().add_tab()
         paragraph.add_run("beta")
-        span = find_one(document, "alpha beta")  # tab normalizes to a space
+        span = find_one(document, "alpha beta", match="normalized")
         with pytest.raises(UnsupportedStructureError, match="tab or line break"):
             span.replace("gamma delta")
 

--- a/tests/paper/test_regressions_editing.py
+++ b/tests/paper/test_regressions_editing.py
@@ -274,7 +274,7 @@ class DescribeMiscEdgeCases:
         document = _doc()
         document.add_paragraph("Alpha beta.")
         document.add_paragraph("Gamma delta.")
-        span = find_one(document, "Alpha beta. Gamma delta.")
+        span = find_one(document, "Alpha beta.\nGamma delta.")
         span.replace("Alpha beta. Gamma omega.")
         texts = [b.text for b in iter_blocks(document)]
         assert "Gamma omega." in texts and "Alpha beta." in texts

--- a/tests/paper/test_revisions.py
+++ b/tests/paper/test_revisions.py
@@ -113,13 +113,13 @@ class DescribeTrackedEditAlgebra:
 
     def it_makes_accepted_span_replace_equal_plain_replace(self, tmp_path: Path):
         tracked_doc = _doc(FRAGMENTED)
-        find_one(tracked_doc, "$75-100/hr").replace(
+        find_one(tracked_doc, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         tracked_doc.revisions.accept_all()
 
         plain_doc = _doc(FRAGMENTED)
-        find_one(plain_doc, "$75-100/hr").replace("$85–110/hr")
+        find_one(plain_doc, "$75–100/hr").replace("$85–110/hr")
 
         tracked_out = save_and_reopen(tracked_doc, tmp_path / "tracked.docx")
         plain_out = save_and_reopen(plain_doc, tmp_path / "plain.docx")
@@ -128,7 +128,7 @@ class DescribeTrackedEditAlgebra:
     def it_makes_rejected_span_replace_equal_the_original(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
         pristine_texts = _texts(document)
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         document.revisions.reject_all()

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -71,18 +71,90 @@ class DescribeNormalizeText:
 
 class DescribeFindText:
     def it_matches_ascii_needles_against_smart_characters_across_runs(self):
-        span = find_one(_doc(FRAGMENTED), '$75-100/hr on a "full-service" basis')
+        span = find_one(
+            _doc(FRAGMENTED),
+            '$75-100/hr on a "full-service" basis',
+            match="normalized",
+        )
         assert span.text == RATE_TEXT  # raw text captured verbatim, 8 runs deep
+        assert span.match_policy == "normalized"
         assert not span.crosses_paragraphs
 
     def it_matches_through_no_break_spaces(self):
-        span = find_one(_doc(FRAGMENTED), "Net 30 payment terms")
+        span = find_one(
+            _doc(FRAGMENTED), "Net 30 payment terms", match="normalized"
+        )
         assert "Net 30" in span.text  # captured text preserves the raw NBSP
 
     def it_matches_across_a_paragraph_boundary(self):
-        spans = find_text(_doc(MINIMAL), "ordinary text. Second body paragraph")
+        spans = find_text(
+            _doc(MINIMAL), "ordinary text.\nSecond body paragraph"
+        )
         assert len(spans) == 1
+        assert spans[0].text == "ordinary text.\nSecond body paragraph"
         assert spans[0].crosses_paragraphs
+
+    @pytest.mark.parametrize(
+        ("document_text", "needle"),
+        [
+            ("Company", "company"),
+            ("“quoted”", '"quoted"'),
+            ("Net Income – Adjusted", "Net Income - Adjusted"),
+            ("Net 30", "Net 30"),
+            ("alpha   beta", "alpha beta"),
+            ("soft­hyphen", "softhyphen"),
+        ],
+    )
+    def it_keeps_literal_distinctions_by_default(
+        self, document_text: str, needle: str
+    ):
+        document = docx.Document()
+        document.add_paragraph(document_text)
+        assert find_text(document, needle) == []
+        assert find_one(document, needle, match="normalized").text == document_text
+
+    def it_matches_exact_text_through_run_fragmentation(self):
+        span = find_one(_doc(FRAGMENTED), RATE_TEXT)
+        assert span.text == RATE_TEXT
+        assert span.match_policy == "exact"
+
+    def it_treats_exact_whitespace_literally(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("alpha ")
+        paragraph.add_run(" beta")
+        assert find_one(document, "  ").text == "  "
+        assert find_text(document, " ")
+        assert find_text(document, "   ") == []
+        assert find_text(document, " ", match="normalized") == []
+
+    def it_uses_only_newline_as_the_exact_paragraph_separator(self):
+        document = _doc(MINIMAL)
+        assert find_text(document, "ordinary text.\nSecond body paragraph")
+        assert find_text(document, "ordinary text. Second body paragraph") == []
+        assert find_text(document, "ordinary text.\rSecond body paragraph") == []
+        assert find_text(document, "\n") == []
+        assert find_text(document, "\nSecond body paragraph") == []
+        assert find_text(document, "") == []
+        assert find_text(document, "\N{SOFT HYPHEN}", match="normalized") == []
+        assert find_text(
+            document,
+            "ordinary text. Second body paragraph",
+            match="normalized",
+        )
+
+        line_break_document = docx.Document()
+        paragraph = line_break_document.add_paragraph()
+        paragraph.add_run("alpha").add_break()
+        paragraph.add_run("beta")
+        line_break = find_one(line_break_document, "\n")
+        assert line_break.text == "\n"
+        assert not line_break.crosses_paragraphs
+
+    @pytest.mark.parametrize("api", [find_text, find_one])
+    def it_rejects_an_invalid_policy_before_scanning(self, api):
+        with pytest.raises(ValueError, match="match must be one of"):
+            api(object(), "target", match="fuzzy")
 
     def it_returns_matches_in_document_order_with_nth_selection(self):
         document = _doc(TRACKED)
@@ -108,6 +180,27 @@ class DescribeFindText:
         texts = [b.text for b in iter_blocks(document)]
         assert "Gauntlet numbered item one" in texts
         assert "Gauntlet renumbered item two" in texts
+
+    def it_applies_the_same_policy_to_target_and_near(self):
+        document = docx.Document()
+        document.add_paragraph("Near")
+        document.add_paragraph("target")
+        document.add_paragraph("near")
+        document.add_paragraph("target")
+        exact = find_text(document, "target", near="near", nth=1)[0]
+        normalized = find_text(
+            document, "TARGET", near="NEAR", nth=1, match="normalized"
+        )[0]
+        assert exact.anchor.index == 3
+        assert normalized.anchor.index == 1
+
+    def it_keeps_raw_order_separate_from_normalized_match_offsets(self):
+        document = docx.Document()
+        document.add_paragraph("Straße x Straße")
+        spans = find_text(document, "strasse", match="normalized")
+        assert [span.text for span in spans] == ["Straße", "Straße"]
+        assert [span._raw_start for span in spans] == [0, 9]
+        assert [span._match_start for span in spans] == [0, 10]
 
     def it_honors_the_view_parameter(self):
         document = _doc(TRACKED)
@@ -141,7 +234,7 @@ class DescribeFindOne:
 class DescribePlainReplace:
     def it_preserves_untouched_run_formatting(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
-        find_one(document, "$75-100/hr").replace("$85–110/hr")
+        find_one(document, "$75–100/hr").replace("$85–110/hr")
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         paragraph = reopened.paragraphs[0]
         assert paragraph.text == (
@@ -155,7 +248,7 @@ class DescribePlainReplace:
 
     def it_survives_a_bold_to_italic_formatting_transition(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
-        find_one(document, '100/hr on a "full-').replace("90/hr on any “full-")
+        find_one(document, "100/hr on a “full-").replace("90/hr on any “full-")
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert "90/hr on any “full-service”" in reopened.paragraphs[0].text
 
@@ -207,7 +300,7 @@ class DescribePlainReplace:
         working = tmp_path / "work.docx"
         shutil.copyfile(source, working)
         document = docx.Document(str(working))
-        find_one(document, "$75-100/hr").replace("$95–120/hr")
+        find_one(document, "$75–100/hr").replace("$95–120/hr")
         out = tmp_path / "out.docx"
         docx.package.patch_save(working, document, out)
         assert_changed_parts(working, out, {"word/document.xml"})
@@ -461,7 +554,7 @@ class DescribePreservationPolicies:
         working = tmp_path / "work.docx"
         shutil.copyfile(source, working)
         document = docx.Document(str(working))
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", preserve_structure=True
         )
         out = tmp_path / "out.docx"
@@ -495,7 +588,7 @@ class DescribeReplaceRefusals:
 
     def it_refuses_cross_paragraph_spans(self):
         document = _doc(MINIMAL)
-        span = find_one(document, "ordinary text. Second body paragraph")
+        span = find_one(document, "ordinary text.\nSecond body paragraph")
         with pytest.raises(BoundaryViolationError, match="paragraph boundary"):
             span.replace("anything")
 
@@ -528,7 +621,7 @@ class DescribeTrackedReplace:
     def it_marks_only_the_minimal_changed_span(self, tmp_path: Path):
         """The redline marks `75-10 -> 85-11`, not the sentence (pinned)."""
         document = _doc(FRAGMENTED)
-        result = find_one(document, "$75-100/hr").replace(
+        result = find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         assert result.deleted_text == "75–10"
@@ -541,7 +634,7 @@ class DescribeTrackedReplace:
 
     def it_keeps_deleted_text_in_delText_never_live_wt(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         reopened = save_and_reopen(document, tmp_path / "out.docx")
@@ -577,7 +670,7 @@ class DescribeTrackedReplace:
 
     def it_preserves_run_formatting_on_both_sides(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         reopened = save_and_reopen(document, tmp_path / "out.docx")
@@ -605,7 +698,7 @@ class DescribeTrackedReplace:
 
     def it_refuses_cross_paragraph_tracked_targets(self):
         document = _doc(MINIMAL)
-        span = find_one(document, "ordinary text. Second body paragraph")
+        span = find_one(document, "ordinary text.\nSecond body paragraph")
         with pytest.raises(BoundaryViolationError):
             span.replace("anything", tracked=True, author="Carol QA")
 
@@ -616,7 +709,7 @@ class DescribeTrackedReplace:
         working = tmp_path / "work.docx"
         shutil.copyfile(source, working)
         document = docx.Document(str(working))
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         out = tmp_path / "out.docx"
@@ -629,7 +722,7 @@ class DescribeTrackedReplace:
         from .harness.lo import assert_libreoffice_opens
 
         document = _doc(FRAGMENTED)
-        find_one(document, "$75-100/hr").replace(
+        find_one(document, "$75–100/hr").replace(
             "$85–110/hr", tracked=True, author="Carol QA", date=FROZEN
         )
         out = tmp_path / "out.docx"

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -42,6 +42,16 @@ def _doc_with_simple_table():
 
 
 class DescribeFindTable:
+    @pytest.mark.parametrize(
+        ("near_text", "match"),
+        [("", "exact"), ("   \t", "normalized")],
+    )
+    def it_refuses_targets_that_contain_no_searchable_text(self, near_text: str, match: str):
+        document, _ = _doc_with_simple_table()
+
+        with pytest.raises(TargetNotFoundError, match="searchable text"):
+            find_table(document, near_text=near_text, match=match)
+
     def it_finds_the_table_by_exact_cell_text_by_default(self):
         document, table = _doc_with_simple_table()
         found = find_table(document, near_text="cell 10")

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -42,22 +42,103 @@ def _doc_with_simple_table():
 
 
 class DescribeFindTable:
-    def it_finds_the_table_by_normalized_cell_text(self):
+    def it_finds_the_table_by_exact_cell_text_by_default(self):
         document, table = _doc_with_simple_table()
-        found = find_table(document, near_text="CELL 10")  # casefolded matching
-        assert found._tbl is table._tbl
+        found = find_table(document, near_text="cell 10")
+        assert found.cell(1, 0).text == table.cell(1, 0).text
+
+    def it_keeps_default_exact_matching_case_and_typography_sensitive(self):
+        document, table = _doc_with_simple_table()
+        table.cell(1, 0).text = "Résumé – Total"
+        for near_text in ("RÉSUMÉ – TOTAL", "Résumé - Total"):
+            with pytest.raises(TargetNotFoundError, match="no table"):
+                find_table(document, near_text=near_text)
+
+    def it_supports_explicit_normalized_matching(self):
+        document, table = _doc_with_simple_table()
+        table.cell(1, 0).text = "Résumé – Total"
+        found = find_table(
+            document,
+            near_text="RÉSUMÉ - TOTAL",
+            match="normalized",
+        )
+        assert found.cell(1, 0).text == table.cell(1, 0).text
+
+    def it_does_not_match_an_exact_query_across_adjacent_cells(self):
+        document, _ = _doc_with_simple_table()
+        with pytest.raises(TargetNotFoundError, match="no table"):
+            find_table(document, near_text="cell 00\ncell 01")
+
+    def it_does_not_match_a_normalized_query_across_adjacent_cells(self):
+        document = _doc(MINIMAL)
+        table = document.add_table(rows=1, cols=2)
+        table.cell(0, 0).text = "Account"
+        table.cell(0, 1).text = "Balance"
+        with pytest.raises(TargetNotFoundError, match="no table"):
+            find_table(
+                document,
+                near_text="Account Balance",
+                match="normalized",
+            )
+
+    def it_matches_paragraph_boundaries_within_one_cell(self):
+        document = _doc(MINIMAL)
+        table = document.add_table(rows=1, cols=1)
+        cell = table.cell(0, 0)
+        cell.text = "Account"
+        cell.add_paragraph("Balance")
+
+        exact = find_table(document, near_text="Account\nBalance")
+        normalized = find_table(
+            document,
+            near_text="ACCOUNT   BALANCE",
+            match="normalized",
+        )
+        assert exact.cell(0, 0).text == table.cell(0, 0).text
+        assert normalized.cell(0, 0).text == table.cell(0, 0).text
+
+    def it_counts_a_merged_physical_cell_only_once(self):
+        document = _doc(MINIMAL)
+        table = document.add_table(rows=1, cols=2)
+        cell = table.cell(0, 0).merge(table.cell(0, 1))
+        cell.text = "merged marker"
+
+        found = find_table(document, near_text="merged marker")
+        assert found.cell(0, 0).text == table.cell(0, 0).text
+
+    def it_counts_a_table_only_once_when_several_cells_match(self):
+        document = _doc(MINIMAL)
+        table = document.add_table(rows=1, cols=2)
+        table.cell(0, 0).text = "marker in first cell"
+        table.cell(0, 1).text = "marker in second cell"
+
+        found = find_table(document, near_text="marker", match="exact")
+        assert found.cell(0, 1).text == table.cell(0, 1).text
 
     def it_refuses_when_no_table_matches(self):
         document, _ = _doc_with_simple_table()
         with pytest.raises(TargetNotFoundError, match="no table"):
-            find_table(document, near_text="nothing like this")
+            find_table(
+                document,
+                near_text="NOTHING LIKE THIS",
+                match="normalized",
+            )
 
-    def it_refuses_ambiguity(self):
-        document, _ = _doc_with_simple_table()
+    def it_counts_ambiguity_between_tables(self):
+        document, first = _doc_with_simple_table()
+        first.cell(0, 0).text = "cell 10 in another cell"
         second = document.add_table(rows=1, cols=1)
         second.cell(0, 0).text = "cell 10 duplicate"
-        with pytest.raises(AmbiguousTargetError):
-            find_table(document, near_text="cell 10")
+        with pytest.raises(AmbiguousTargetError, match="2 tables"):
+            find_table(document, near_text="cell 10", match="exact")
+
+    def it_rejects_an_invalid_match_policy(self):
+        document, _ = _doc_with_simple_table()
+        with pytest.raises(
+            ValueError,
+            match=r"match must be one of .* got 'prefix'",
+        ):
+            find_table(document, near_text="cell 10", match="prefix")
 
 
 class DescribeUpdateCell:


### PR DESCRIPTION
## Why

Text mutation needs an explicit matching contract. Normalized matching can collapse case, typography, or whitespace distinctions that matter for targeting.

## Final behavior

- `find_text()`, `find_one()`, and `replace_all()` match exactly by default.
- `match="normalized"` remains an explicit inspection/matching opt-in.
- Table search compares within each physical cell and never synthesizes a match across cell boundaries.
- No hidden fuzzy targeting is introduced.

## Stack

Parent: #39. Child: #44. Published head: `df5409eb6176ed087f8464973a6a23775bda971d`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default matching behavior changes for all find/replace entry points, so existing callers may miss targets or hit different text unless they opt into `match="normalized"`; the change is intentional for safer mutations.
> 
> **Overview**
> **Text search and replace now use literal exact matching by default** instead of silently folding case, typography, and whitespace. Callers that relied on the old convenience behavior must pass `match="normalized"` on `find_text`, `find_one`, `replace_all`, and `find_table`.
> 
> Search spans record how they were found via **`Span.match_policy`** (`"exact"`, `"normalized"`, or `None` for non-search spans). Exact mode treats paragraph breaks as a single literal `\n` in needles; normalized mode keeps returning raw document characters in `Span.text` but adds **`_source_aligned`** checks so matches do not slice through expanding casefolds (e.g. `ß` / `ss`).
> 
> **`find_table`** gains the same `match` parameter and now matches **within one physical cell** only (deduping merged cells), rejecting empty needles and cross-cell concatenation. **`replace_all`** orders batch replacements by raw story offsets. Docs, API surface tests, and the broader test suite are updated for the new defaults and migration pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf7f8fd6b446c7bbe1d9e1ec406ce8a633f9132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->