### PR TITLE
refactor: keep near inspection-only

### DIFF
--- a/docs/api/paper-package.rst
+++ b/docs/api/paper-package.rst
@@ -14,6 +14,8 @@ copies before returning and refuses differences it cannot encode without loss.
 Word-level compare emits fine-grained edits only for one unambiguous old/new
 block pair of the same kind. A changed region containing multiple blocks uses
 coarse block deletions and insertions instead of similarity-based pairing.
+Within one changed table, cell-level edits likewise require exactly one old and
+one new row; larger changed row regions use coarse row deletions and insertions.
 Pure text insertions retain their exact zero-width boundary, so an ambiguous
 formatting or wrapper destination refuses rather than borrowing an anchor
 character.

--- a/docs/api/paper-package.rst
+++ b/docs/api/paper-package.rst
@@ -11,6 +11,12 @@ report what changed. ``diagnose`` triages an unopenable file into a typed
 verdict. ``compare`` generates a native tracked-change redline that transforms
 one document into another. It verifies acceptance and rejection on private
 copies before returning and refuses differences it cannot encode without loss.
+Word-level compare emits fine-grained edits only for one unambiguous old/new
+block pair of the same kind. A changed region containing multiple blocks uses
+coarse block deletions and insertions instead of similarity-based pairing.
+Pure text insertions retain their exact zero-width boundary, so an ambiguous
+formatting or wrapper destination refuses rather than borrowing an anchor
+character.
 These names are the pinned public path
 (``docx.package.*``); the implementation lives in private modules.
 

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -36,6 +36,39 @@ offsets have no search policy and report ``None``. Empty needles never match;
 exact whitespace is literal searchable content, while normalized input that
 folds to only whitespace does not match.
 
+Disambiguate without hiding uncertainty
+----------------------------------------
+
+``find_text(..., near=...)`` is an inspection operation. It returns every
+target candidate, ordered by the character distance from each target's start
+to its nearest eligible context occurrence. Target and context use the same
+story, view, and match policy. Multiple context occurrences are valid; each
+candidate uses the closest one. Equal distances retain stable document order,
+and missing context leaves the complete candidate set in ordinary document
+order. Neither case means that the first result has unique authority.
+
+``find_one(..., near=...)`` applies the authoritative form of that selector.
+It returns a span only when eligible context exists and exactly one target has
+the finite minimum distance. Missing context raises |TargetNotFoundError| and
+points the caller toward its context text, match policy, view, and story
+scope. A tied minimum raises |AmbiguousTargetError| with the tied locations
+and distance; use more distinctive context or a narrower story scope.
+Context in a different story or excluded by the selected view cannot rank a
+target.
+
+Use ``nth=`` only as an explicit 1-based positional selector when ``near`` is
+absent. ``near`` and ``nth`` are mutually exclusive and combining them raises
+:exc:`ValueError` before the document is searched. To inspect an inconclusive
+contextual selection before refining it:
+
+.. code-block:: python
+
+   candidates = find_text(doc, "Payment terms", near="Renewal")
+   # all candidates remain visible, even if context is absent or tied
+
+   target = find_one(doc, "Payment terms", near="Renewal")
+   # succeeds only for one unique nearest candidate
+
 Choose a replacement policy
 ---------------------------
 

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -47,27 +47,26 @@ candidate uses the closest one. Equal distances retain stable document order,
 and missing context leaves the complete candidate set in ordinary document
 order. Neither case means that the first result has unique authority.
 
-``find_one(..., near=...)`` applies the authoritative form of that selector.
-It returns a span only when eligible context exists and exactly one target has
-the finite minimum distance. Missing context raises |TargetNotFoundError| and
-points the caller toward its context text, match policy, view, and story
-scope. A tied minimum raises |AmbiguousTargetError| with the tied locations
-and distance; use more distinctive context or a narrower story scope.
-Context in a different story or excluded by the selected view cannot rank a
-target.
+The single-result ``find_one()`` resolver has no contextual-ranking keyword. It
+resolves ordinary zero/one/many matching: no candidate raises
+|TargetNotFoundError| and multiple candidates raise |AmbiguousTargetError|. Use
+a more specific exact target, narrow ``story``, or deliberately use ``nth=``
+when position is the intended identity.
 
-Use ``nth=`` only as an explicit 1-based positional selector when ``near`` is
-absent. ``near`` and ``nth`` are mutually exclusive and combining them raises
-:exc:`ValueError` before the document is searched. To inspect an inconclusive
-contextual selection before refining it:
+On ``find_text()``, ``nth=`` is an explicit 1-based positional selector and is
+mutually exclusive with ``near``. Combining them raises :exc:`ValueError`
+before the document is searched. To use contextual ranking for inspection:
 
 .. code-block:: python
 
    candidates = find_text(doc, "Payment terms", near="Renewal")
    # all candidates remain visible, even if context is absent or tied
 
-   target = find_one(doc, "Payment terms", near="Renewal")
-   # succeeds only for one unique nearest candidate
+   for candidate in candidates:
+       print(candidate.story, candidate.anchor, candidate.text)
+
+   # After inspecting the evidence, retain the deliberately chosen live span.
+   target = candidates[chosen_index]
 
 Choose a replacement policy
 ---------------------------

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -85,23 +85,23 @@ The normalized span is an intentional mutation target, not an inspection-only
 result. APIs outside ``docx.search`` do not repeat the ``match`` keyword; use
 this explicit preselection workflow when they need normalized targeting.
 
-When repeated text needs context, use ``near`` as a unique-nearest selector:
+When repeated text needs context, use ``near`` to rank the complete candidate
+set for inspection:
 
 ::
 
     candidates = find_text(doc, "Payment terms", near="Renewal")
     # inspection stays complete and proximity-ranked, including ties
 
-    span = find_one(doc, "Payment terms", near="Renewal")
-    # authoritative only when context exists and one candidate is nearest
+    for candidate in candidates:
+        print(candidate.story, candidate.anchor, candidate.text)
 
-``find_one`` raises |TargetNotFoundError| when the context is absent from the
-same story, view, or match policy, even if the target itself is unique. It
-raises |AmbiguousTargetError| when multiple candidates share the minimum
-distance. Refine ``near`` or narrow ``story`` in that case; document order is
-only presentation order, not identity. ``nth`` remains available as an
-explicit positional selector when no context is supplied, but cannot be
-combined with ``near``.
+Context in a different story or excluded by the selected view cannot rank a
+target. Missing or tied context leaves all candidates visible in stable order;
+the first result is not automatically authoritative. After inspecting the
+evidence, retain the deliberately chosen live span, or refine an ordinary
+``find_one`` call with a more specific exact target, ``story``, or explicit
+``nth``. On ``find_text``, ``nth`` cannot be combined with ``near``.
 
 Choose the option that matches the edit's preservation contract:
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -62,7 +62,7 @@ Edit one document
 
 ::
 
-    from docx.search import find_one
+    from docx.search import find_one, find_text
 
     span = find_one(doc, "rate: $75–100/hr")
     span.replace("rate: $85-110/hr")             # formatting intact
@@ -84,6 +84,24 @@ resulting live span to the mutation API:
 The normalized span is an intentional mutation target, not an inspection-only
 result. APIs outside ``docx.search`` do not repeat the ``match`` keyword; use
 this explicit preselection workflow when they need normalized targeting.
+
+When repeated text needs context, use ``near`` as a unique-nearest selector:
+
+::
+
+    candidates = find_text(doc, "Payment terms", near="Renewal")
+    # inspection stays complete and proximity-ranked, including ties
+
+    span = find_one(doc, "Payment terms", near="Renewal")
+    # authoritative only when context exists and one candidate is nearest
+
+``find_one`` raises |TargetNotFoundError| when the context is absent from the
+same story, view, or match policy, even if the target itself is unique. It
+raises |AmbiguousTargetError| when multiple candidates share the minimum
+distance. Refine ``near`` or narrow ``story`` in that case; document order is
+only presentation order, not identity. ``nth`` remains available as an
+explicit positional selector when no context is supplied, but cannot be
+combined with ``near``.
 
 Choose the option that matches the edit's preservation contract:
 
@@ -189,7 +207,7 @@ hierarchy, so a caller can tell a *safe refusal* apart from a bug:
     try:
         find_one(doc, "the")                     # matches everywhere
     except AmbiguousTargetError:
-        ...                                      # disambiguate: nth=, near=, story=
+        ...                                      # use context, story scope, or inspect candidates
     except PaperRefusal:
         ...                                      # any safe refusal, distinct from bugs
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -180,6 +180,9 @@ transforming one document into another. Accepting it yields the revised
 document; rejecting it yields the original. Before returning, ``compare``
 proves both outcomes on private copies. Style, relationship, or package-part
 changes it cannot express as tracked revisions produce a typed refusal.
+Fine-grained word or cell edits require one unambiguous old/new block pair;
+larger changed regions use coarse block revisions rather than similarity-based
+pairing.
 
 ::
 

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -14,8 +14,8 @@ insertions/deletions only — no move or rPrChange synthesis; no cross-story
 detection; paragraph add/remove outside the main body refuses; changed
 merged-cell tables refuse; images/objects, fields, content controls, package
 part changes, and formatting differences refuse; a block budget of
-`_MAX_BLOCKS` per story plus sequence-matching and changed-region pairing
-budgets refuse before quadratic work.
+`_MAX_BLOCKS` per story plus sequence-matching budgets refuse before
+quadratic work.
 
 Public path: `docx.package.compare` (kernel re-export).
 """
@@ -80,10 +80,6 @@ _PROOF_ERR = qn("w:proofErr")
 #: perf budget — documented typed refusal above this many blocks per story
 _MAX_BLOCKS = 10_000
 
-#: Pairing is quadratic in both memory and expensive SequenceMatcher calls.
-#: Refuse before allocating the matrix; block granularity never uses it.
-_MAX_PAIR_CELLS = 10_000
-
 #: SequenceMatcher has quadratic worst-case behavior on repeated sequences.
 #: Apply this budget before both story-block and table-row matching.
 _MAX_SEQUENCE_CELLS = 1_000_000
@@ -91,10 +87,6 @@ _MAX_SEQUENCE_CELLS = 1_000_000
 #: Bound character-similarity and token diff matchers independently from
 #: block/row sequence matching so each expensive layer has its own envelope.
 _MAX_TEXT_SEQUENCE_CELLS = 1_000_000
-
-#: similarity threshold below which paired blocks redline as del+ins rather
-#: than a word-level edit
-_PAIR_RATIO = 0.5
 
 
 @dataclass(frozen=True)
@@ -776,102 +768,25 @@ def _aligned_opcodes(
     return opcodes
 
 
-def _pair_region(old_run, new_run) -> "List[Tuple[str, Optional[int], Optional[int]]]":
-    """Order-preserving best-similarity block pairing within a changed region
-    (LCS-style DP maximizing summed pair ratios above `_PAIR_RATIO`)."""
-    m, n = len(old_run), len(new_run)
-    if m * n > _MAX_PAIR_CELLS:
-        raise UnsupportedStructureError(
-            "changed region exceeds the word-level compare pairing budget"
-            f" ({m} x {n} > {_MAX_PAIR_CELLS} cells); use"
-            " granularity='block' or split the documents"
-        )
-    text_cells = sum(
-        len(text_o) * len(text_r)
-        for kind_o, _element_o, text_o in old_run
-        for kind_r, _element_r, text_r in new_run
-        if kind_o == kind_r
-    )
-    if text_cells > _MAX_TEXT_SEQUENCE_CELLS:
-        raise UnsupportedStructureError(
-            "changed-region text exceeds the sequence-matching budget"
-            f" ({text_cells} > {_MAX_TEXT_SEQUENCE_CELLS} character cells);"
-            " use granularity='block' or split the documents"
-        )
-    ratios: dict = {}
-
-    def ratio(i: int, j: int) -> float:
-        if (i, j) not in ratios:
-            kind_o, _eo, text_o = old_run[i]
-            kind_r, _er, text_r = new_run[j]
-            if kind_o != kind_r:
-                ratios[(i, j)] = 0.0
-            else:
-                score = SequenceMatcher(None, text_o, text_r, autojunk=False).ratio()
-                ratios[(i, j)] = score if score >= _PAIR_RATIO else 0.0
-        return ratios[(i, j)]
-
-    score = [[0.0] * (n + 1) for _ in range(m + 1)]
-    for i in range(1, m + 1):
-        for j in range(1, n + 1):
-            best = max(score[i - 1][j], score[i][j - 1])
-            pair = ratio(i - 1, j - 1)
-            if pair > 0.0:
-                best = max(best, score[i - 1][j - 1] + pair)
-            score[i][j] = best
-    ops: "List[Tuple[str, Optional[int], Optional[int]]]" = []
-    i, j = m, n
-    while i > 0 or j > 0:
-        pair = ratio(i - 1, j - 1) if (i > 0 and j > 0) else 0.0
-        if pair > 0.0 and score[i][j] == score[i - 1][j - 1] + pair:
-            ops.append(("pair", i - 1, j - 1))
-            i -= 1
-            j -= 1
-        elif i > 0 and (j == 0 or score[i][j] == score[i - 1][j]):
-            ops.append(("delete", i - 1, None))
-            i -= 1
-        else:
-            ops.append(("insert", None, j - 1))
-            j -= 1
-    ops.reverse()
-    return ops
-
-
 def _compare_region(ctx: _Ctx, old_run, new_run) -> None:
-    """Emit tracked changes for one changed region; a cursor threads the
-    output position so unpaired insertions land in document order."""
-    if ctx.granularity == "block":
+    """Word-compare one unambiguous block pair; otherwise use coarse revisions."""
+    if (
+        ctx.granularity == "block"
+        or len(old_run) != 1
+        or len(new_run) != 1
+        or old_run[0][0] != new_run[0][0]
+    ):
         _insert_blocks(ctx, old_run, 0, new_run)
         for kind, element, text in old_run:
             _delete_block(ctx, kind, element, text)
         return
-    cursor: "Optional[_Element]" = None
-    for op, index_o, index_r in _pair_region(old_run, new_run):
-        if op == "pair":
-            kind_o, element_o, text_o = old_run[index_o]
-            _kind_r, element_r, text_r = new_run[index_r]
-            if kind_o == "table":
-                _compare_table(ctx, element_o, element_r)
-                cursor = element_o
-            elif ctx.granularity == "word":
-                _refuse_non_text_paragraph_change(ctx, element_o, element_r)
-                _replace_paragraph_text(ctx, element_o, text_o, text_r)
-                cursor = element_o
-        elif op == "delete":
-            kind_o, element_o, text_o = old_run[index_o]
-            _delete_block(ctx, kind_o, element_o, text_o)
-            cursor = element_o
-        else:  # insert
-            kind_r, element_r, _text_r = new_run[index_r]
-            clone = _cloned_as_insertion(ctx, kind_r, element_r)
-            if cursor is None:
-                reference = old_run[0][1]
-                _require_container_anchor(ctx, reference)
-                reference.addprevious(clone)
-            else:
-                _require_container_anchor(ctx, cursor)
-                cursor.addnext(clone)
-            cursor = clone
+    kind_o, element_o, text_o = old_run[0]
+    _kind_r, element_r, text_r = new_run[0]
+    if kind_o == "table":
+        _compare_table(ctx, element_o, element_r)
+        return
+    _refuse_non_text_paragraph_change(ctx, element_o, element_r)
+    _replace_paragraph_text(ctx, element_o, text_o, text_r)
 
 
 def _report_formatting_difference(ctx: _Ctx, block_o, block_r) -> None:
@@ -1362,8 +1277,7 @@ def _replace_paragraph_text(
 
 def _token_regions(old: str, new: str) -> "List[Tuple[int, int, str]]":
     """Changed character regions (old-start, old-end, replacement) from a
-    token-level diff; zero-width regions are widened by one anchor char so
-    every region maps to at least one atom."""
+    token-level diff. Pure insertions retain their zero-width boundary."""
     tokens_o = re.findall(r"\S+|\s+", old)
     tokens_r = re.findall(r"\S+|\s+", new)
     token_cells = len(tokens_o) * len(tokens_r)
@@ -1383,16 +1297,6 @@ def _token_regions(old: str, new: str) -> "List[Tuple[int, int, str]]":
             continue
         start, end = offsets[i1], offsets[i2]
         replacement = "".join(tokens_r[j1:j2])
-        if start == end:  # pure insertion: widen over one anchor char
-            if start > 0:
-                start -= 1
-                replacement = old[start] + replacement
-            elif end < len(old):
-                replacement = replacement + old[end]
-                end += 1
-            else:  # empty original paragraph text
-                regions.append((0, 0, replacement))
-                continue
         regions.append((start, end, replacement))
     return regions
 
@@ -1412,7 +1316,7 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
         for atom in _story_atoms(ctx.document, ctx.story, root)
         if atom.paragraph is paragraph and _include_atom(atom, "current")
     ]
-    if not atoms or start >= end:
+    if not atoms or start < 0 or end < start:
         return None
     positions = []  # (atom_index, offset) per visible character
     visible_pieces = []
@@ -1422,14 +1326,31 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
         visible_pieces.append(atom.text)
         for offset in range(len(atom.text)):
             positions.append((index, offset))
+    visible_text = "".join(visible_pieces)
     if end > len(positions):
         return None
-    start_atom, start_offset = positions[start]
-    end_atom, end_offset = positions[end - 1]
+    if start == end:
+        candidates = []
+        position = 0
+        for index, atom in enumerate(atoms):
+            if atom.barrier:
+                continue
+            piece_end = position + len(atom.text)
+            if position <= start <= piece_end and not atom.is_synthetic:
+                candidates.append((index, start - position))
+            position = piece_end
+        if not candidates:
+            return None
+        start_atom, start_offset = candidates[0]
+        end_atom, end_offset = candidates[-1]
+    else:
+        start_atom, start_offset = positions[start]
+        end_atom, last_offset = positions[end - 1]
+        end_offset = last_offset + 1
     span_atoms = atoms[start_atom : end_atom + 1]
     if any(atom.barrier for atom in span_atoms):
         return None
-    text = "".join(visible_pieces)[start:end]
+    text = visible_text[start:end]
     return Span(
         text=text,
         story=ctx.story,
@@ -1447,7 +1368,7 @@ def _paragraph_span(ctx: _Ctx, paragraph: "_Element", start: int, end: int):
         _document=ctx.document,
         _atoms=list(span_atoms),
         _start_offset=start_offset,
-        _end_offset=end_offset + 1,
+        _end_offset=end_offset,
         _raw_start=0,
         _match_start=0,
     )

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -1111,25 +1111,18 @@ def _compare_table(ctx: _Ctx, table_o: "_Element", table_r: "_Element") -> None:
             continue
         old_rows, new_rows = rows_o[i1:i2], rows_r[j1:j2]
         _refuse_merged_rows(ctx, list(old_rows) + list(new_rows))
-        paired = min(len(old_rows), len(new_rows))
-        cursor = None  # last row placed in OUTPUT order
-        for k in range(paired):
-            if _replace_row_cells(ctx, old_rows[k], new_rows[k]):
-                cursor = old_rows[k]
-            else:
-                _mark_row_deleted(ctx, old_rows[k])
-                inserted = _insert_rows(
-                    ctx, rows_o, i1 + k, [new_rows[k]], after=old_rows[k]
-                )
-                cursor = inserted[-1]
-        for row in old_rows[paired:]:
+        if len(old_rows) == 1 and len(new_rows) == 1:
+            if not _replace_row_cells(ctx, old_rows[0], new_rows[0]):
+                _mark_row_deleted(ctx, old_rows[0])
+                _insert_rows(ctx, rows_o, i2, new_rows, after=old_rows[0])
+            continue
+
+        # A larger replacement region does not prove which old row corresponds
+        # to which new row. Preserve the truthful coarse history instead of
+        # inventing positional row edits.
+        for row in old_rows:
             _mark_row_deleted(ctx, row)
-            cursor = row
-        if len(new_rows) > paired:
-            _insert_rows(
-                ctx, rows_o, i2, new_rows[paired:],
-                after=cursor if cursor is not None else old_rows[-1],
-            )
+        _insert_rows(ctx, rows_o, i2, new_rows, after=old_rows[-1])
 
 
 def _visible_paragraph_text(paragraph: "_Element") -> str:

--- a/src/docx/errors.py
+++ b/src/docx/errors.py
@@ -40,8 +40,8 @@ class AmbiguousTargetError(PaperRefusal):
     """The target specification matches more than one location.
 
     Supply a more specific exact target: for example a live span or block, a
-    narrower story, an explicit `nth` when supported, or a `near` context with
-    one unique nearest winner. `near` and `nth` are mutually exclusive.
+    narrower story, or an explicit `nth` when supported. To inspect contextual
+    ranking without hiding candidates, use `find_text(..., near=...)`.
     """
 
 

--- a/src/docx/errors.py
+++ b/src/docx/errors.py
@@ -39,8 +39,9 @@ class MalformedPackageError(PaperRefusal):
 class AmbiguousTargetError(PaperRefusal):
     """The target specification matches more than one location.
 
-    Disambiguate with `nth=`, `near=`, or `story=` rather than letting the
-    library guess.
+    Supply a more specific exact target: for example a live span or block, a
+    narrower story, an explicit `nth` when supported, or a `near` context with
+    one unique nearest winner. `near` and `nth` are mutually exclusive.
     """
 
 

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -2059,7 +2059,6 @@ def find_one(
     needle: str,
     *,
     nth: Optional[int] = None,
-    near: Optional[str] = None,
     story: Optional[str] = None,
     view: str = "current",
     match: str = "exact",
@@ -2068,38 +2067,13 @@ def find_one(
 
     Exact matching is the default; pass ``match="normalized"`` to opt into
     folded targeting. Zero matches raise `TargetNotFoundError`. Two or more
-    raise `AmbiguousTargetError`. `nth` and `story` narrow the set when no
-    context is supplied. `near` instead requires one finite nearest match;
-    missing context or a tied minimum refuses rather than choosing by order.
+    raise `AmbiguousTargetError`. `nth` and `story` explicitly narrow the set.
     """
-    ranked = _ranked_matches(
-        document, needle, nth=nth, near=near, story=story, view=view, match=match
+    matches = find_text(
+        document, needle, nth=nth, story=story, view=view, match=match
     )
-    if not ranked:
+    if not matches:
         raise TargetNotFoundError(f"no match for {needle!r} in any story part")
-    if near is not None:
-        eligible = [item for item in ranked if item.distance is not None]
-        if not eligible:
-            raise TargetNotFoundError(
-                f"no eligible context match for {near!r} while resolving"
-                f" {needle!r}; check the context text, match={match!r} policy,"
-                f" view={view!r}, or story scope"
-            )
-        minimum = eligible[0].distance
-        tied = [item for item in eligible if item.distance == minimum]
-        if len(tied) > 1:
-            locations = ", ".join(
-                f"{item.span.story}#{item.span.anchor.index}"
-                f" at character {item.span._raw_start}"
-                for item in tied
-            )
-            raise AmbiguousTargetError(
-                f"{len(tied)} matches for {needle!r} are equally near"
-                f" {near!r} at distance {minimum} (at {locations}); use more"
-                " distinctive near= context or a narrower story= scope"
-            )
-        return eligible[0].span
-    matches = [item.span for item in ranked]
     if len(matches) > 1:
         locations = ", ".join(
             f"{span.story}#{span.anchor.index}" for span in matches[:5]
@@ -2107,6 +2081,7 @@ def find_one(
         raise AmbiguousTargetError(
             f"{len(matches)} matches for {needle!r} (at {locations}"
             f"{', …' if len(matches) > 5 else ''}); disambiguate with nth=,"
-            " near=, or story="
+            " story=, a more specific exact target, or inspect"
+            " find_text(..., near=...)"
         )
     return matches[0]

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -1809,13 +1809,23 @@ def _spans_for_story(
     return spans
 
 
-def _near_distance(span_match_start: int, near_positions: "List[int]") -> float:
+def _near_distance(
+    span_match_start: int, near_positions: "Sequence[int]"
+) -> "Optional[int]":
     if not near_positions:
-        return float("inf")
+        return None
     return min(abs(span_match_start - position) for position in near_positions)
 
 
-def find_text(
+@dataclass(frozen=True)
+class _RankedMatch:
+    """One search candidate plus private contextual-ranking evidence."""
+
+    span: Span
+    distance: "Optional[int]"
+
+
+def _ranked_matches(
     document: "Document",
     needle: str,
     *,
@@ -1824,26 +1834,19 @@ def find_text(
     story: Optional[str] = None,
     view: str = "current",
     match: str = "exact",
-) -> "List[Span]":
-    """Every span of `needle` in `document` under the selected match policy.
-
-    `story` limits the search to one story part (e.g. "word/document.xml");
-    `near` ranks matches by distance to the nearest occurrence of `near`'s
-    text under the same policy in the same story; `nth` (1-based) then selects
-    a single match. Exact matching is the default. Normalized matching folds
-    case, typography, and whitespace. Both assemble across fragmented runs;
-    exact matching represents each paragraph boundary as one literal ``\\n``.
-    """
+) -> "List[_RankedMatch]":
+    """Search once, retaining private same-story proximity evidence."""
+    if near is not None and nth is not None:
+        raise ValueError("near and nth are mutually exclusive")
     _validate_match_policy(match)
     if view not in VIEWS:
         raise ValueError(f"view must be one of {VIEWS}, got {view!r}")
     needle_match, _ = _match_space(needle, match)
     if not needle_match or (match == "normalized" and not needle_match.strip()):
         return []
-    near_match = _match_space(near, match)[0] if near else None
+    near_match = _match_space(near, match)[0] if near is not None else None
 
-    all_spans: "List[Tuple[float, int, Span]]" = []
-    order = 0
+    ranked: "List[_RankedMatch]" = []
     for story_name, root in _story_elements(document):
         if story is not None and story_name != story:
             continue
@@ -1874,17 +1877,57 @@ def find_text(
                 start = match_text.find(near_match, start + 1)
         for span in spans:
             distance = (
-                _near_distance(span._match_start, near_positions) if near_match else 0.0
+                _near_distance(span._match_start, near_positions)
+                if near is not None
+                else None
             )
-            all_spans.append((distance, order, span))
-            order += 1
-    all_spans.sort(key=lambda item: (item[0], item[1]))
-    matches = [span for _, _, span in all_spans]
+            ranked.append(_RankedMatch(span=span, distance=distance))
+    ranked.sort(
+        key=lambda item: (
+            item.distance is None,
+            item.distance if item.distance is not None else 0,
+        )
+    )
     if nth is not None:
-        if nth < 1 or nth > len(matches):
+        if nth < 1 or nth > len(ranked):
             return []
-        return [matches[nth - 1]]
-    return matches
+        return [ranked[nth - 1]]
+    return ranked
+
+
+def find_text(
+    document: "Document",
+    needle: str,
+    *,
+    nth: Optional[int] = None,
+    near: Optional[str] = None,
+    story: Optional[str] = None,
+    view: str = "current",
+    match: str = "exact",
+) -> "List[Span]":
+    """Every span of `needle` in `document` under the selected match policy.
+
+    `story` limits the search to one story part (e.g. "word/document.xml");
+    `near` ranks every match by distance to the nearest occurrence of `near`'s
+    text under the same policy in the same story. Ranking remains complete
+    when context is missing or tied. `nth` (1-based) instead selects a match
+    by document position and cannot be combined with `near`. Exact matching is
+    the default. Normalized matching folds case, typography, and whitespace.
+    Both assemble across fragmented runs; exact matching represents each
+    paragraph boundary as one literal ``\\n``.
+    """
+    return [
+        item.span
+        for item in _ranked_matches(
+            document,
+            needle,
+            nth=nth,
+            near=near,
+            story=story,
+            view=view,
+            match=match,
+        )
+    ]
 
 
 @dataclass(frozen=True)
@@ -2025,14 +2068,38 @@ def find_one(
 
     Exact matching is the default; pass ``match="normalized"`` to opt into
     folded targeting. Zero matches raise `TargetNotFoundError`. Two or more
-    raise `AmbiguousTargetError`: `nth` and `story` narrow the set, while
-    `near` only ranks `find_text` results and never reduces them.
+    raise `AmbiguousTargetError`. `nth` and `story` narrow the set when no
+    context is supplied. `near` instead requires one finite nearest match;
+    missing context or a tied minimum refuses rather than choosing by order.
     """
-    matches = find_text(
+    ranked = _ranked_matches(
         document, needle, nth=nth, near=near, story=story, view=view, match=match
     )
-    if not matches:
+    if not ranked:
         raise TargetNotFoundError(f"no match for {needle!r} in any story part")
+    if near is not None:
+        eligible = [item for item in ranked if item.distance is not None]
+        if not eligible:
+            raise TargetNotFoundError(
+                f"no eligible context match for {near!r} while resolving"
+                f" {needle!r}; check the context text, match={match!r} policy,"
+                f" view={view!r}, or story scope"
+            )
+        minimum = eligible[0].distance
+        tied = [item for item in eligible if item.distance == minimum]
+        if len(tied) > 1:
+            locations = ", ".join(
+                f"{item.span.story}#{item.span.anchor.index}"
+                f" at character {item.span._raw_start}"
+                for item in tied
+            )
+            raise AmbiguousTargetError(
+                f"{len(tied)} matches for {needle!r} are equally near"
+                f" {near!r} at distance {minimum} (at {locations}); use more"
+                " distinctive near= context or a narrower story= scope"
+            )
+        return eligible[0].span
+    matches = [item.span for item in ranked]
     if len(matches) > 1:
         locations = ", ".join(
             f"{span.story}#{span.anchor.index}" for span in matches[:5]

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -85,8 +85,7 @@ APPROVED_SIGNATURES = [
     (
         "docx.search",
         "find_one",
-        "(document, needle, *, nth=None, near=None, story=None, view='current',"
-        " match='exact')",
+        "(document, needle, *, nth=None, story=None, view='current', match='exact')",
     ),
     # -- replace -------------------------------------------------------------
     (

--- a/tests/paper/test_audit_compare.py
+++ b/tests/paper/test_audit_compare.py
@@ -116,7 +116,7 @@ class DescribeStrictComparePreflight:
 
 
 class DescribeComparePairingBudget:
-    def it_refuses_an_oversized_word_pairing_before_allocating(self, tmp_path: Path):
+    def it_uses_coarse_revisions_instead_of_quadratic_word_pairing(self, tmp_path: Path):
         def build(prefix):
             def _build(document):
                 for index in range(101):
@@ -125,8 +125,12 @@ class DescribeComparePairingBudget:
             return _build
 
         a, b = _save_pair(tmp_path, build("Old"), build("New"))
-        with pytest.raises(UnsupportedStructureError, match="pairing budget"):
-            compare(a, b, author="Reviewer", date=FROZEN)
+        result = compare(a, b, author="Reviewer", date=FROZEN)
+
+        revision_types = {
+            revision.revision_type for revision in result.document.revisions
+        }
+        assert {"deletion", "insertion"} <= revision_types
 
     def it_uses_linear_whole_block_edits_in_block_mode(self, tmp_path: Path):
         def build(prefix):

--- a/tests/paper/test_audit_compare_raw_packages.py
+++ b/tests/paper/test_audit_compare_raw_packages.py
@@ -210,7 +210,7 @@ class DescribeSequenceMatcherBudget:
         ):
             compare(original, revised, author="Reviewer", date=FROZEN)
 
-    def it_refuses_changed_text_before_quadratic_similarity_work(
+    def it_avoids_character_similarity_work_for_one_changed_block(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         def build(text):
@@ -232,10 +232,9 @@ class DescribeSequenceMatcherBudget:
         monkeypatch.setattr(compare_impl, "SequenceMatcher", guarded_matcher)
         monkeypatch.setattr(compare_impl, "_MAX_TEXT_SEQUENCE_CELLS", 4)
 
-        with pytest.raises(
-            UnsupportedStructureError, match="changed-region text.*budget"
-        ):
-            compare(original, revised, author="Reviewer", date=FROZEN)
+        result = compare(original, revised, author="Reviewer", date=FROZEN)
+
+        assert result.document.revisions
 
     def it_refuses_token_matching_before_quadratic_work(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -305,6 +305,43 @@ class DescribeCompareBehavior:
         assert not any(r.revision_type.startswith("row_") for r in revisions)
         assert not any("Advisory" in r.text for r in revisions)
 
+    def it_uses_coarse_revisions_for_ambiguous_multi_row_changes(
+        self, tmp_path: Path
+    ):
+        original_path = tmp_path / "table-original.docx"
+        revised_path = tmp_path / "table-revised.docx"
+
+        original = docx.Document()
+        table = original.add_table(rows=2, cols=1)
+        table.cell(0, 0).text = "Repeated Alpha"
+        table.cell(1, 0).text = "Repeated Alpha"
+        original.save(original_path)
+
+        revised = docx.Document()
+        revised.add_table(rows=1, cols=1).cell(0, 0).text = "Repeated Beta"
+        revised.save(revised_path)
+
+        result = compare(
+            original_path,
+            revised_path,
+            author="Compare Engine",
+            date=FROZEN,
+        )
+        revisions = result.document.revisions
+
+        assert sum(r.revision_type == "row_deletion" for r in revisions) == 2
+        assert sum(r.revision_type == "row_insertion" for r in revisions) == 1
+        assert not any(r.revision_type == "deletion" and r.text == "Alph" for r in revisions)
+
+        redline_path = tmp_path / "table-redline.docx"
+        result.document.save(redline_path)
+        accepted = docx.Document(redline_path)
+        accepted.revisions.accept_all()
+        assert _visible(accepted) == _visible(docx.Document(revised_path))
+        rejected = docx.Document(redline_path)
+        rejected.revisions.reject_all()
+        assert _visible(rejected) == _visible(docx.Document(original_path))
+
     def it_uses_coarse_revisions_for_a_multi_block_changed_region(self, tmp_path: Path):
         original_path = tmp_path / "multi-original.docx"
         revised_path = tmp_path / "multi-revised.docx"

--- a/tests/paper/test_compare.py
+++ b/tests/paper/test_compare.py
@@ -213,8 +213,25 @@ class DescribeCompareBehavior:
         assert result.document.paragraphs[0].text == "Logo  new language"
         assert len(result.document.inline_shapes) == 1
 
-    def it_redlines_a_word_level_edit_minimally(self):
-        result = _compare_fixture_pair()
+    def it_redlines_one_unambiguous_paragraph_pair_minimally(self, tmp_path: Path):
+        original_path = tmp_path / "word-original.docx"
+        revised_path = tmp_path / "word-revised.docx"
+        for path, middle in (
+            (original_path, "Either party may terminate with thirty days notice."),
+            (revised_path, "Either party may terminate with sixty days notice."),
+        ):
+            document = docx.Document()
+            document.add_paragraph("unchanged before")
+            document.add_paragraph(middle)
+            document.add_paragraph("unchanged after")
+            document.save(path)
+
+        result = compare(
+            original_path,
+            revised_path,
+            author="Compare Engine",
+            date=FROZEN,
+        )
         revisions = result.document.revisions
         deleted = [r.text for r in revisions if r.revision_type == "deletion"]
         inserted = [r.text for r in revisions if r.revision_type == "insertion"]
@@ -225,19 +242,107 @@ class DescribeCompareBehavior:
         full = "Either party may terminate with thirty days notice."
         assert full not in deleted  # never a whole-paragraph rewrite
 
-    def it_redlines_the_table_cell_change_cell_wise(self):
-        result = _compare_fixture_pair()
+    def it_emits_a_pure_insertion_without_deleting_an_anchor_character(self, tmp_path: Path):
+        original_path = tmp_path / "insert-original.docx"
+        revised_path = tmp_path / "insert-revised.docx"
+        for path, middle in (
+            (original_path, "consulting services"),
+            (revised_path, "consulting and advisory services"),
+        ):
+            document = docx.Document()
+            document.add_paragraph("unchanged before")
+            document.add_paragraph(middle)
+            document.add_paragraph("unchanged after")
+            document.save(path)
+
+        result = compare(
+            original_path,
+            revised_path,
+            author="Compare Engine",
+            date=FROZEN,
+        )
+
+        assert [
+            revision.text
+            for revision in result.document.revisions
+            if revision.revision_type == "insertion"
+        ] == ["and advisory "]
+        assert not any(
+            revision.revision_type == "deletion" for revision in result.document.revisions
+        )
+        redline_path = tmp_path / "insert-redline.docx"
+        result.document.save(redline_path)
+        accepted = docx.Document(redline_path)
+        accepted.revisions.accept_all()
+        assert _visible(accepted) == _visible(docx.Document(revised_path))
+        rejected = docx.Document(redline_path)
+        rejected.revisions.reject_all()
+        assert _visible(rejected) == _visible(docx.Document(original_path))
+
+    def it_redlines_one_unambiguous_table_pair_cell_wise(self, tmp_path: Path):
+        original_path = tmp_path / "table-original.docx"
+        revised_path = tmp_path / "table-revised.docx"
+        for path, amount in ((original_path, "$200"), (revised_path, "$250")):
+            document = docx.Document()
+            document.add_paragraph("unchanged before")
+            table = document.add_table(rows=1, cols=2)
+            table.cell(0, 0).text = "Advisory"
+            table.cell(0, 1).text = amount
+            document.add_paragraph("unchanged after")
+            document.save(path)
+
+        result = compare(
+            original_path,
+            revised_path,
+            author="Compare Engine",
+            date=FROZEN,
+        )
         revisions = result.document.revisions
         # $200 -> $250 narrows to the single changed character in the cell;
         # crucially the ROW was edited cell-wise, not deleted + reinserted
-        assert any(
-            r.revision_type == "deletion" and r.text == "0" for r in revisions
-        )
-        assert any(
-            r.revision_type == "insertion" and r.text == "5" for r in revisions
-        )
+        assert any(r.revision_type == "deletion" and r.text == "0" for r in revisions)
+        assert any(r.revision_type == "insertion" and r.text == "5" for r in revisions)
         assert not any(r.revision_type.startswith("row_") for r in revisions)
         assert not any("Advisory" in r.text for r in revisions)
+
+    def it_uses_coarse_revisions_for_a_multi_block_changed_region(self, tmp_path: Path):
+        original_path = tmp_path / "multi-original.docx"
+        revised_path = tmp_path / "multi-revised.docx"
+        for path, changed in (
+            (original_path, ("Repeated Alpha", "Repeated Alpha")),
+            (revised_path, ("Repeated Beta",)),
+        ):
+            document = docx.Document()
+            document.add_paragraph("unchanged before")
+            for text in changed:
+                document.add_paragraph(text)
+            document.add_paragraph("unchanged after")
+            document.save(path)
+
+        result = compare(
+            original_path,
+            revised_path,
+            author="Compare Engine",
+            date=FROZEN,
+        )
+        revisions = result.document.revisions
+
+        assert any(
+            revision.revision_type == "deletion" and "Repeated Alpha" in revision.text
+            for revision in revisions
+        )
+        assert any(
+            revision.revision_type == "insertion" and "Repeated Beta" in revision.text
+            for revision in revisions
+        )
+        redline_path = tmp_path / "multi-redline.docx"
+        result.document.save(redline_path)
+        accepted = docx.Document(redline_path)
+        accepted.revisions.accept_all()
+        assert _visible(accepted) == _visible(docx.Document(revised_path))
+        rejected = docx.Document(redline_path)
+        rejected.revisions.reject_all()
+        assert _visible(rejected) == _visible(docx.Document(original_path))
 
     def it_stamps_every_revision_with_the_caller_identity(self):
         result = _compare_fixture_pair()

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -172,7 +172,11 @@ class DescribeFindText:
 
     def it_ranks_by_proximity_to_the_near_text(self):
         document = _doc(GAUNTLET)
-        span = find_text(document, "Gauntlet numbered item", near="item two", nth=1)[0]
+        matches = find_text(
+            document, "Gauntlet numbered item", near="item two"
+        )
+        assert len(matches) == 2
+        span = matches[0]
         follow_on = span.text  # nearest match to "item two"
         assert follow_on == "Gauntlet numbered item"
         # prove it selected the second occurrence: replace it and look
@@ -187,12 +191,36 @@ class DescribeFindText:
         document.add_paragraph("target")
         document.add_paragraph("near")
         document.add_paragraph("target")
-        exact = find_text(document, "target", near="near", nth=1)[0]
+        exact = find_text(document, "target", near="near")[0]
         normalized = find_text(
-            document, "TARGET", near="NEAR", nth=1, match="normalized"
+            document, "TARGET", near="NEAR", match="normalized"
         )[0]
         assert exact.anchor.index == 3
         assert normalized.anchor.index == 1
+
+    def it_keeps_tied_near_candidates_in_stable_document_order(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("nearby")
+        document.add_paragraph("target")
+        document.add_paragraph("padding that makes the next candidate farther")
+        document.add_paragraph("target")
+
+        matches = find_text(document, "target", near="nearby")
+
+        assert [span.anchor.index for span in matches] == [0, 2, 4]
+
+    def it_keeps_the_complete_candidate_set_when_context_is_missing(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("target")
+
+        ordinary = find_text(document, "target")
+        ranked = find_text(document, "target", near="absent context")
+
+        assert [span.anchor.index for span in ranked] == [
+            span.anchor.index for span in ordinary
+        ]
 
     def it_keeps_raw_order_separate_from_normalized_match_offsets(self):
         document = docx.Document()
@@ -229,6 +257,162 @@ class DescribeFindOne:
     def it_resolves_ambiguity_with_nth(self):
         span = find_one(_doc(TRACKED), "Paragraph", nth=1)
         assert span.text == "Paragraph"
+
+    def it_resolves_only_the_unique_nearest_candidate(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("padding between candidates")
+        document.add_paragraph("target")
+        document.add_paragraph("nearby")
+
+        span = find_one(document, "target", near="nearby")
+
+        assert span.anchor.index == 2
+
+    def it_uses_the_nearest_of_multiple_context_occurrences(self):
+        document = docx.Document()
+        document.add_paragraph("nearby")
+        document.add_paragraph("target")
+        document.add_paragraph("filler filler")
+        document.add_paragraph("target")
+        document.add_paragraph("padding")
+        document.add_paragraph("nearby")
+
+        span = find_one(document, "target", near="nearby")
+
+        assert span.anchor.index == 1
+
+    def it_refuses_missing_context_even_for_one_target(self):
+        document = docx.Document()
+        document.add_paragraph("only target")
+
+        with pytest.raises(TargetNotFoundError) as caught:
+            find_one(document, "target", near="missing context")
+
+        message = str(caught.value)
+        assert "no eligible context match" in message
+        assert "missing context" in message
+        assert "match='exact'" in message
+        assert "view='current'" in message
+        assert "story scope" in message
+
+    def it_refuses_a_tied_minimum_and_reports_only_the_tied_locations(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("nearby")
+        document.add_paragraph("target")
+        document.add_paragraph("padding that makes the next candidate farther")
+        document.add_paragraph("target")
+
+        with pytest.raises(AmbiguousTargetError) as caught:
+            find_one(document, "target", near="nearby")
+
+        message = str(caught.value)
+        assert "distance 7" in message
+        assert "word/document.xml#0" in message
+        assert "word/document.xml#2" in message
+        assert "word/document.xml#4" not in message
+        assert "nth" not in message
+
+    def it_distinguishes_tied_locations_within_one_paragraph(self):
+        document = docx.Document()
+        document.add_paragraph("target nearby target")
+
+        with pytest.raises(AmbiguousTargetError) as caught:
+            find_one(document, "target", near="nearby")
+
+        message = str(caught.value)
+        assert "word/document.xml#0 at character 0" in message
+        assert "word/document.xml#0 at character 14" in message
+
+    def it_uses_one_policy_for_both_target_and_context_authority(self):
+        document = docx.Document()
+        document.add_paragraph("Near")
+        document.add_paragraph("target")
+        document.add_paragraph("near")
+        document.add_paragraph("target")
+
+        exact = find_one(document, "target", near="near")
+        assert exact.anchor.index == 3
+        with pytest.raises(AmbiguousTargetError, match="equally near"):
+            find_one(
+                document,
+                "TARGET",
+                near="NEAR",
+                match="normalized",
+            )
+
+    def it_does_not_use_context_from_another_story(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.sections[0].header.paragraphs[0].text = "nearby"
+
+        for story in (None, "word/document.xml"):
+            with pytest.raises(TargetNotFoundError, match="eligible context"):
+                find_one(document, "target", near="nearby", story=story)
+
+    def it_ranks_eligible_stories_before_ineligible_ones_without_hiding_targets(
+        self,
+    ):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.sections[0].header.paragraphs[0].text = "nearby target"
+
+        matches = find_text(document, "target", near="nearby")
+
+        assert [span.story for span in matches] == [
+            "word/header1.xml",
+            "word/document.xml",
+        ]
+        assert find_one(document, "target", near="nearby").story == "word/header1.xml"
+
+    @pytest.mark.parametrize(
+        ("wrapper", "excluded_view", "eligible_views"),
+        [
+            (
+                f'<w:ins {W} w:id="4" w:author="Editor">'
+                "<w:r><w:t>nearby</w:t></w:r></w:ins>",
+                "original",
+                ("current", "all"),
+            ),
+            (
+                f'<w:del {W} w:id="5" w:author="Editor">'
+                "<w:r><w:delText>nearby</w:delText></w:r></w:del>",
+                "current",
+                ("original", "all"),
+            ),
+        ],
+    )
+    def it_applies_view_scope_to_context(
+        self, wrapper: str, excluded_view: str, eligible_views: tuple[str, str]
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph("target ")
+        paragraph._p.append(parse_xml(wrapper))
+
+        with pytest.raises(TargetNotFoundError, match="eligible context"):
+            find_one(document, "target", near="nearby", view=excluded_view)
+        for view in eligible_views:
+            assert find_one(
+                document, "target", near="nearby", view=view
+            ).text == "target"
+
+    @pytest.mark.parametrize("api", [find_text, find_one])
+    @pytest.mark.parametrize("match", ["exact", "normalized"])
+    def it_rejects_near_with_nth_before_result_state(self, api, match: str):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.add_paragraph("target")
+
+        for needle in ("target", "missing target"):
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                api(
+                    document,
+                    needle,
+                    near="missing context",
+                    nth=99,
+                    match=match,
+                )
 
 
 class DescribePlainReplace:

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -175,15 +175,7 @@ class DescribeFindText:
         matches = find_text(
             document, "Gauntlet numbered item", near="item two"
         )
-        assert len(matches) == 2
-        span = matches[0]
-        follow_on = span.text  # nearest match to "item two"
-        assert follow_on == "Gauntlet numbered item"
-        # prove it selected the second occurrence: replace it and look
-        span.replace("Gauntlet renumbered item")
-        texts = [b.text for b in iter_blocks(document)]
-        assert "Gauntlet numbered item one" in texts
-        assert "Gauntlet renumbered item two" in texts
+        assert [span.anchor.index for span in matches] == [27, 26]
 
     def it_applies_the_same_policy_to_target_and_near(self):
         document = docx.Document()
@@ -244,31 +236,6 @@ class DescribeFindText:
         controlled = find_one(document, "controlled text")
         assert controlled.in_content_control
 
-
-class DescribeFindOne:
-    def it_refuses_zero_matches(self):
-        with pytest.raises(TargetNotFoundError, match="no match"):
-            find_one(_doc(MINIMAL), "text that does not exist anywhere")
-
-    def it_refuses_ambiguity_without_disambiguators(self):
-        with pytest.raises(AmbiguousTargetError, match="disambiguate"):
-            find_one(_doc(TRACKED), "Paragraph")
-
-    def it_resolves_ambiguity_with_nth(self):
-        span = find_one(_doc(TRACKED), "Paragraph", nth=1)
-        assert span.text == "Paragraph"
-
-    def it_resolves_only_the_unique_nearest_candidate(self):
-        document = docx.Document()
-        document.add_paragraph("target")
-        document.add_paragraph("padding between candidates")
-        document.add_paragraph("target")
-        document.add_paragraph("nearby")
-
-        span = find_one(document, "target", near="nearby")
-
-        assert span.anchor.index == 2
-
     def it_uses_the_nearest_of_multiple_context_occurrences(self):
         document = docx.Document()
         document.add_paragraph("nearby")
@@ -278,78 +245,9 @@ class DescribeFindOne:
         document.add_paragraph("padding")
         document.add_paragraph("nearby")
 
-        span = find_one(document, "target", near="nearby")
+        matches = find_text(document, "target", near="nearby")
 
-        assert span.anchor.index == 1
-
-    def it_refuses_missing_context_even_for_one_target(self):
-        document = docx.Document()
-        document.add_paragraph("only target")
-
-        with pytest.raises(TargetNotFoundError) as caught:
-            find_one(document, "target", near="missing context")
-
-        message = str(caught.value)
-        assert "no eligible context match" in message
-        assert "missing context" in message
-        assert "match='exact'" in message
-        assert "view='current'" in message
-        assert "story scope" in message
-
-    def it_refuses_a_tied_minimum_and_reports_only_the_tied_locations(self):
-        document = docx.Document()
-        document.add_paragraph("target")
-        document.add_paragraph("nearby")
-        document.add_paragraph("target")
-        document.add_paragraph("padding that makes the next candidate farther")
-        document.add_paragraph("target")
-
-        with pytest.raises(AmbiguousTargetError) as caught:
-            find_one(document, "target", near="nearby")
-
-        message = str(caught.value)
-        assert "distance 7" in message
-        assert "word/document.xml#0" in message
-        assert "word/document.xml#2" in message
-        assert "word/document.xml#4" not in message
-        assert "nth" not in message
-
-    def it_distinguishes_tied_locations_within_one_paragraph(self):
-        document = docx.Document()
-        document.add_paragraph("target nearby target")
-
-        with pytest.raises(AmbiguousTargetError) as caught:
-            find_one(document, "target", near="nearby")
-
-        message = str(caught.value)
-        assert "word/document.xml#0 at character 0" in message
-        assert "word/document.xml#0 at character 14" in message
-
-    def it_uses_one_policy_for_both_target_and_context_authority(self):
-        document = docx.Document()
-        document.add_paragraph("Near")
-        document.add_paragraph("target")
-        document.add_paragraph("near")
-        document.add_paragraph("target")
-
-        exact = find_one(document, "target", near="near")
-        assert exact.anchor.index == 3
-        with pytest.raises(AmbiguousTargetError, match="equally near"):
-            find_one(
-                document,
-                "TARGET",
-                near="NEAR",
-                match="normalized",
-            )
-
-    def it_does_not_use_context_from_another_story(self):
-        document = docx.Document()
-        document.add_paragraph("target")
-        document.sections[0].header.paragraphs[0].text = "nearby"
-
-        for story in (None, "word/document.xml"):
-            with pytest.raises(TargetNotFoundError, match="eligible context"):
-                find_one(document, "target", near="nearby", story=story)
+        assert [span.anchor.index for span in matches] == [1, 3]
 
     def it_ranks_eligible_stories_before_ineligible_ones_without_hiding_targets(
         self,
@@ -364,7 +262,6 @@ class DescribeFindOne:
             "word/header1.xml",
             "word/document.xml",
         ]
-        assert find_one(document, "target", near="nearby").story == "word/header1.xml"
 
     @pytest.mark.parametrize(
         ("wrapper", "excluded_view", "eligible_views"),
@@ -387,32 +284,66 @@ class DescribeFindOne:
         self, wrapper: str, excluded_view: str, eligible_views: tuple[str, str]
     ):
         document = docx.Document()
+        document.add_paragraph("target")
         paragraph = document.add_paragraph("target ")
         paragraph._p.append(parse_xml(wrapper))
 
-        with pytest.raises(TargetNotFoundError, match="eligible context"):
-            find_one(document, "target", near="nearby", view=excluded_view)
+        excluded = find_text(document, "target", near="nearby", view=excluded_view)
+        assert [span.anchor.index for span in excluded] == [0, 1]
         for view in eligible_views:
-            assert find_one(
-                document, "target", near="nearby", view=view
-            ).text == "target"
+            ranked = find_text(document, "target", near="nearby", view=view)
+            assert [span.anchor.index for span in ranked] == [1, 0]
 
-    @pytest.mark.parametrize("api", [find_text, find_one])
     @pytest.mark.parametrize("match", ["exact", "normalized"])
-    def it_rejects_near_with_nth_before_result_state(self, api, match: str):
+    def it_rejects_near_with_nth_before_result_state(self, match: str):
         document = docx.Document()
         document.add_paragraph("target")
         document.add_paragraph("target")
 
         for needle in ("target", "missing target"):
             with pytest.raises(ValueError, match="mutually exclusive"):
-                api(
+                find_text(
                     document,
                     needle,
                     near="missing context",
                     nth=99,
                     match=match,
                 )
+
+
+class DescribeFindOne:
+    def it_refuses_zero_matches(self):
+        with pytest.raises(TargetNotFoundError, match="no match"):
+            find_one(_doc(MINIMAL), "text that does not exist anywhere")
+
+    def it_returns_one_match(self):
+        span = find_one(_doc(MINIMAL), "Second body paragraph")
+        assert span.text == "Second body paragraph"
+
+    def it_refuses_ambiguity_without_disambiguators(self):
+        with pytest.raises(AmbiguousTargetError, match="disambiguate"):
+            find_one(_doc(TRACKED), "Paragraph")
+
+    def it_resolves_ambiguity_with_nth(self):
+        span = find_one(_doc(TRACKED), "Paragraph", nth=1)
+        assert span.text == "Paragraph"
+
+    def it_resolves_ambiguity_with_story(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        document.sections[0].header.paragraphs[0].text = "target"
+
+        span = find_one(document, "target", story="word/header1.xml")
+
+        assert span.story == "word/header1.xml"
+
+    def it_rejects_the_removed_near_keyword(self):
+        with pytest.raises(TypeError, match="unexpected keyword argument 'near'"):
+            find_one(
+                _doc(MINIMAL),
+                "target",
+                near="context",  # type: ignore[call-arg]
+            )
 
 
 class DescribePlainReplace:


### PR DESCRIPTION
## Why

`near` is useful for ranking inspection results, but character distance is not identity and must not authorize mutation.

## Final behavior

- `near` remains inspection-only on `find_text()`.
- `find_one()` retains zero/one/many refusal behavior and has no `near` keyword.
- Missing context and tied distances keep candidates visible rather than selecting one.

No new behavior commit was added during the final follow-up; this branch was replayed only, per product direction.

## Stack

Parent: #43. Child: #45. Published head: `749278ac1ad169128e8356df72239c8a5482ad6b`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change (`find_one` no longer accepts `near`) and materially different compare/search behavior where proximity or heuristic pairing previously picked a single target.
> 
> **Overview**
> **Search:** `find_text(..., near=...)` now only **ranks** the full match list by distance to the nearest same-story context hit (ties and missing context keep every candidate in stable order). **`find_one` drops the `near` argument**—disambiguation is `nth`, `story`, or a more specific target; contextual ranking is documented via `find_text` + manual pick. **`near` and `nth` on `find_text` are mutually exclusive** (`ValueError`). `AmbiguousTargetError` text points callers at this split.
> 
> **Compare:** Removes similarity-based block/row pairing inside changed regions. **Word- or cell-level redlines apply only when there is exactly one old and one new block (or table row) of the same kind**; otherwise compare emits **coarse** block or row deletions/insertions. **Pure insertions** no longer widen spans by borrowing an anchor character; `_paragraph_span` supports zero-width insertion boundaries.
> 
> Docs and tests are updated for the new search contract and compare semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25c802609d587b22069f7d8868670d34a3c4be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->