### PR TITLE
refactor: retain live blocks without portable locators

### DIFF
--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -10,6 +10,19 @@ that stamps paragraph marks so Word accepts or rejects them exactly.
 ``insert_blocks_after`` takes typed |RichParagraph|/|ListBlock|/|TableBlock|
 blocks.
 
+Targets may be an exact string, a live |Span|, a live |Block|, or a current
+portable :class:`docx.story.BlockLocator`. Live blocks validate document ownership and exact
+element attachment. Locators require one complete exact content/topology and
+adjacent-context match; missing evidence raises |TargetNotFoundError| and
+multiple matches raise |AmbiguousTargetError|. Tables remain blocks but are
+not paragraph anchors, so table blocks and table locators raise
+|UnsupportedStructureError|.
+
+Legacy |Anchor| values are inert location evidence and are refused with
+migration guidance. Reacquire a live block with ``iter_blocks()``/``outline()``,
+pass an exact string or live span, or deserialize a current ``BlockLocator``.
+Do not use an old index/hash payload as a mutation target.
+
 .. currentmodule:: docx.blocks
 
 

--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -15,6 +15,12 @@ validate document ownership and exact element attachment. Tables remain
 blocks but are not paragraph anchors, so live table blocks raise
 |UnsupportedStructureError|.
 
+Live block and span mutation targets must be captured from ``view="current"``.
+Objects captured from ``"original"`` or ``"all"`` remain live and useful for
+inspection, but they do not authorize a current-document mutation. Reacquire
+the intended target from the current view before editing. Exact strings use
+exact lookup in the current view.
+
 Legacy |Anchor| values are inert location evidence and are refused with
 migration guidance. Reacquire a live block with ``iter_blocks()``/``outline()``,
 or pass an exact string or live span. Do not use an old index/hash payload as a

--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -10,18 +10,15 @@ that stamps paragraph marks so Word accepts or rejects them exactly.
 ``insert_blocks_after`` takes typed |RichParagraph|/|ListBlock|/|TableBlock|
 blocks.
 
-Targets may be an exact string, a live |Span|, a live |Block|, or a current
-portable :class:`docx.story.BlockLocator`. Live blocks validate document ownership and exact
-element attachment. Locators require one complete exact content/topology and
-adjacent-context match; missing evidence raises |TargetNotFoundError| and
-multiple matches raise |AmbiguousTargetError|. Tables remain blocks but are
-not paragraph anchors, so table blocks and table locators raise
+Targets may be an exact string, a live |Span|, or a live |Block|. Live blocks
+validate document ownership and exact element attachment. Tables remain
+blocks but are not paragraph anchors, so live table blocks raise
 |UnsupportedStructureError|.
 
 Legacy |Anchor| values are inert location evidence and are refused with
 migration guidance. Reacquire a live block with ``iter_blocks()``/``outline()``,
-pass an exact string or live span, or deserialize a current ``BlockLocator``.
-Do not use an old index/hash payload as a mutation target.
+or pass an exact string or live span. Do not use an old index/hash payload as a
+mutation target.
 
 .. currentmodule:: docx.blocks
 

--- a/docs/api/paper-fields.rst
+++ b/docs/api/paper-fields.rst
@@ -10,6 +10,11 @@ carries placeholder result text and sets the update-fields-on-open flag. This
 package authors the field formulas. Word computes their displayed values when
 it opens and paginates the document.
 
+``insert_toc_after()`` accepts exact strings and live paragraph targets. A
+live |Block| or |Span| destination must be captured from ``view="current"``;
+historical projections remain inspection-only and must be reacquired before
+TOC insertion.
+
 .. currentmodule:: docx.fields
 
 

--- a/docs/api/paper-revisions.rst
+++ b/docs/api/paper-revisions.rst
@@ -10,6 +10,16 @@ format changes, table-row revisions, and moves as paired units. Exotic markup
 is enumerated and refused *by name*. ``accept_all``/``reject_all`` validate the
 whole selected set before applying any changes.
 
+Each block-contained |Revision| exposes two deliberately different values:
+``revision.anchor`` is inert compatibility/location evidence, while
+``revision.block_locator`` is the containing block's portable exact locator.
+Revision schema version 4 makes that status machine-readable with
+``anchor_role="legacy_inert_location_evidence"``.
+Body-level section-property changes belong to no traversed block and therefore
+serialize ``block_locator`` as ``None``; their synthetic story-level Anchor
+cannot serve as a paragraph mutation target. Revision accept/reject freshness
+continues to use the live revision element, not either serialized value.
+
 .. currentmodule:: docx.revision
 
 

--- a/docs/api/paper-revisions.rst
+++ b/docs/api/paper-revisions.rst
@@ -10,15 +10,13 @@ format changes, table-row revisions, and moves as paired units. Exotic markup
 is enumerated and refused *by name*. ``accept_all``/``reject_all`` validate the
 whole selected set before applying any changes.
 
-Each block-contained |Revision| exposes two deliberately different values:
-``revision.anchor`` is inert compatibility/location evidence, while
-``revision.block_locator`` is the containing block's portable exact locator.
-Revision schema version 4 makes that status machine-readable with
+Each |Revision| exposes ``revision.anchor`` as inert compatibility/location
+evidence. Revision schema version 4 makes that status machine-readable with
 ``anchor_role="legacy_inert_location_evidence"``.
-Body-level section-property changes belong to no traversed block and therefore
-serialize ``block_locator`` as ``None``; their synthetic story-level Anchor
-cannot serve as a paragraph mutation target. Revision accept/reject freshness
-continues to use the live revision element, not either serialized value.
+Body-level section-property changes belong to no traversed block; their
+synthetic story-level Anchor cannot serve as a paragraph mutation target.
+Revision accept/reject freshness continues to use the live revision element,
+not the serialized value.
 
 .. currentmodule:: docx.revision
 

--- a/docs/api/paper-story.rst
+++ b/docs/api/paper-story.rst
@@ -9,8 +9,10 @@ Story traversal
 content controls, text boxes, and notes, these functions walk every story part
 (body, headers, footers, footnotes, endnotes, comments) and every region that
 standard traversal misses. A chosen *view* selects ``"current"``,
-``"original"``, or ``"all"``. Blocks carry stable |Anchor| identities usable
-as edit targets, and |Outline| reports regions it could not read.
+``"original"``, or ``"all"``. Blocks are live, owner-bound targets; separate
+:class:`docx.story.BlockLocator` values carry portable exact evidence. Generic |Anchor| values
+are inert historical location evidence, and |Outline| reports regions it
+could not read.
 
 .. currentmodule:: docx.story
 
@@ -39,6 +41,38 @@ as edit targets, and |Outline| reports regions it could not read.
    :undoc-members:
    :member-order: bysource
 
+Story traversal returns live blocks tied to the exact OOXML element and
+document that produced them. A live block follows that element when preceding
+blocks change its index, but becomes stale when the element is detached or
+replaced. ``Block.to_dict()`` is only an inspection snapshot and never
+serializes live identity. Outline schema version 3 keeps the historical
+``anchor`` value but labels it with
+``anchor_role="legacy_inert_location_evidence"``; the separate ``locator``
+payload is the portable form.
+
+
+``BlockLocator`` objects
+------------------------
+
+.. autoclass:: BlockLocator()
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+``block.locator`` is the portable form. Its strict ``paper_block_locator``
+version-1 payload records story, capture view, kind, exact case/whitespace/
+Unicode-sensitive content, table cell topology, structural facts, immediate
+previous/next evidence (including start/end boundaries), an index hint, and an
+optional pre-existing Word paragraph ID. ``BlockLocator.from_dict()`` accepts
+only that complete current schema; it never upgrades a three-field |Anchor|,
+normalizes text, resolves a document, or creates Word IDs.
+
+Resolution scans every block in the recorded story and view. Zero complete
+matches are stale, one succeeds, and multiple complete matches are ambiguous.
+The index and Word ID are supporting evidence only. Adjacent edits,
+third-party rewrites, or copied repeated regions can therefore make a locator
+stale or ambiguous; reacquire a live block or a new locator in that case.
+
 
 |TableShape| objects
 --------------------
@@ -56,3 +90,6 @@ as edit targets, and |Outline| reports regions it could not read.
    :members:
    :undoc-members:
    :member-order: bysource
+
+``Anchor`` remains readable and serializable for search/revision location
+evidence, but it cannot authorize a block mutation.

--- a/docs/api/paper-story.rst
+++ b/docs/api/paper-story.rst
@@ -50,6 +50,11 @@ serializes live identity. Outline schema version 3 keeps the historical
 nor an |Anchor| can be used to reconstruct mutation authority. Reacquire a
 fresh live block in a later session.
 
+Captured view and live identity are separate. Blocks from ``"original"`` and
+``"all"`` remain valid inspection values, but block mutation APIs require a
+target reacquired from ``view="current"``. A historical projection is not
+stale merely because it cannot authorize a mutation.
+
 
 |TableShape| objects
 --------------------

--- a/docs/api/paper-story.rst
+++ b/docs/api/paper-story.rst
@@ -10,9 +10,8 @@ content controls, text boxes, and notes, these functions walk every story part
 (body, headers, footers, footnotes, endnotes, comments) and every region that
 standard traversal misses. A chosen *view* selects ``"current"``,
 ``"original"``, or ``"all"``. Blocks are live, owner-bound targets; separate
-:class:`docx.story.BlockLocator` values carry portable exact evidence. Generic |Anchor| values
-are inert historical location evidence, and |Outline| reports regions it
-could not read.
+|Anchor| values are inert historical location evidence, and |Outline| reports
+regions it could not read.
 
 .. currentmodule:: docx.story
 
@@ -47,31 +46,9 @@ blocks change its index, but becomes stale when the element is detached or
 replaced. ``Block.to_dict()`` is only an inspection snapshot and never
 serializes live identity. Outline schema version 3 keeps the historical
 ``anchor`` value but labels it with
-``anchor_role="legacy_inert_location_evidence"``; the separate ``locator``
-payload is the portable form.
-
-
-``BlockLocator`` objects
-------------------------
-
-.. autoclass:: BlockLocator()
-   :members:
-   :undoc-members:
-   :member-order: bysource
-
-``block.locator`` is the portable form. Its strict ``paper_block_locator``
-version-1 payload records story, capture view, kind, exact case/whitespace/
-Unicode-sensitive content, table cell topology, structural facts, immediate
-previous/next evidence (including start/end boundaries), an index hint, and an
-optional pre-existing Word paragraph ID. ``BlockLocator.from_dict()`` accepts
-only that complete current schema; it never upgrades a three-field |Anchor|,
-normalizes text, resolves a document, or creates Word IDs.
-
-Resolution scans every block in the recorded story and view. Zero complete
-matches are stale, one succeeds, and multiple complete matches are ambiguous.
-The index and Word ID are supporting evidence only. Adjacent edits,
-third-party rewrites, or copied repeated regions can therefore make a locator
-stale or ambiguous; reacquire a live block or a new locator in that case.
+``anchor_role="legacy_inert_location_evidence"``. Neither ``Block.to_dict()``
+nor an |Anchor| can be used to reconstruct mutation authority. Reacquire a
+fresh live block in a later session.
 
 
 |TableShape| objects

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -58,6 +58,13 @@ A live block follows its exact element across harmless index shifts and becomes
 stale if that element is detached, replaced, or structurally moved. Reacquire a
 fresh block from the document in a later session.
 
+The view that produced a live block or span is also part of its editing
+authority. ``"original"`` and ``"all"`` projections remain available for
+inspection, but paragraph and TOC mutations require a target captured from
+``view="current"``. When a historical target is refused, inspect it as needed,
+then deliberately reacquire the intended current target; the package does not
+silently remap it by text or position.
+
 The older ``block.anchor`` and ``revision.anchor`` values remain inert result
 locations for compatibility. They cannot authorize paragraph mutation. Use a
 live block/span or an exact string instead.

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -44,6 +44,33 @@ at once (``"all"``). |Outline| reports what it could not read.
     o.blind_region_counts                    # {"tracked_insertions": 2, "text_boxes": 1, ...}
     [b.text for b in o.blocks if b.in_text_box]
 
+Blocks in an outline are live targets bound to the exact document element.
+Use them directly during the current in-memory editing session. Persist the
+separate versioned locator when a later process must attempt fail-closed
+reacquisition:
+
+::
+
+    from docx.story import BlockLocator, iter_blocks
+
+    block = next(b for b in iter_blocks(doc) if b.text == "Termination")
+    locator_payload = block.locator.to_dict()       # JSON-safe exact evidence
+    locator = BlockLocator.from_dict(locator_payload)
+    insert_section_after(doc, locator, heading="Notice", paragraphs=[])
+
+A live block follows its exact element across harmless index shifts. A locator
+is portable but not guaranteed durable: its recorded view, exact content and
+table topology, structural facts, and immediate neighbors must identify one
+candidate. Zero candidates are stale and repeated complete evidence is
+ambiguous; reacquire after adjacent edits or third-party rewrites. Its index is
+only a hint, and an existing Word paragraph ID is only supporting evidence.
+
+The older ``block.anchor`` and ``revision.anchor`` values remain inert result
+locations for compatibility. They cannot authorize paragraph mutation. Use a
+live block/span, an exact string, ``block.locator``, or a block-contained
+``revision.block_locator`` instead. Section-level revisions have no block
+locator.
+
 :ref:`docx.search <paper_search_api>` matches literal visible text by default,
 across the multiple runs Word fragments text into. Callers can explicitly opt
 into normalization of smart quotes, dashes, exotic spaces, whitespace and

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -45,31 +45,22 @@ at once (``"all"``). |Outline| reports what it could not read.
     [b.text for b in o.blocks if b.in_text_box]
 
 Blocks in an outline are live targets bound to the exact document element.
-Use them directly during the current in-memory editing session. Persist the
-separate versioned locator when a later process must attempt fail-closed
-reacquisition:
+Use them directly during the current in-memory editing session:
 
 ::
 
-    from docx.story import BlockLocator, iter_blocks
+    from docx.story import iter_blocks
 
     block = next(b for b in iter_blocks(doc) if b.text == "Termination")
-    locator_payload = block.locator.to_dict()       # JSON-safe exact evidence
-    locator = BlockLocator.from_dict(locator_payload)
-    insert_section_after(doc, locator, heading="Notice", paragraphs=[])
+    insert_section_after(doc, block, heading="Notice", paragraphs=[])
 
-A live block follows its exact element across harmless index shifts. A locator
-is portable but not guaranteed durable: its recorded view, exact content and
-table topology, structural facts, and immediate neighbors must identify one
-candidate. Zero candidates are stale and repeated complete evidence is
-ambiguous; reacquire after adjacent edits or third-party rewrites. Its index is
-only a hint, and an existing Word paragraph ID is only supporting evidence.
+A live block follows its exact element across harmless index shifts and becomes
+stale if that element is detached, replaced, or structurally moved. Reacquire a
+fresh block from the document in a later session.
 
 The older ``block.anchor`` and ``revision.anchor`` values remain inert result
 locations for compatibility. They cannot authorize paragraph mutation. Use a
-live block/span, an exact string, ``block.locator``, or a block-contained
-``revision.block_locator`` instead. Section-level revisions have no block
-locator.
+live block/span or an exact string instead.
 
 :ref:`docx.search <paper_search_api>` matches literal visible text by default,
 across the multiple runs Word fragments text into. Callers can explicitly opt

--- a/src/docx/_compare.py
+++ b/src/docx/_compare.py
@@ -34,10 +34,10 @@ from docx.errors import PaperRefusal, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.story import (
     Anchor,
-    _build_block,
     _iter_block_elements,
     _story_elements,
     _subtree_text,
+    _table_text,
     content_hash,
 )
 
@@ -672,11 +672,19 @@ def _numbering_ids(document: "Document") -> frozenset:
 
 def _story_blocks(story: str, root: "_Element") -> "List[Tuple[str, _Element, str]]":
     blocks = []
-    for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-        block = _build_block(
-            story, kind, index, element, "current", in_sdt=in_sdt, in_txbx=in_txbx
+    for kind, _index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
+        text = (
+            _table_text(element, "current")
+            if kind == "table"
+            else _subtree_text(
+                element,
+                "current",
+                skip_text_boxes=True,
+                in_sdt=in_sdt,
+                in_txbx=in_txbx,
+            ).text
         )
-        blocks.append((kind, element, block.text))
+        blocks.append((kind, element, text))
     return blocks
 
 

--- a/src/docx/_ownership.py
+++ b/src/docx/_ownership.py
@@ -8,7 +8,7 @@ document can mutate that other package.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from docx.errors import (
     BoundaryViolationError,
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from docx.comments import Comment
     from docx.document import Document
     from docx.search import Span
+    from docx.story import Block
 
 
 def require_span_owner(
@@ -39,8 +40,30 @@ def require_anchor_owner(
     document: "Document", anchor: object, *, argument: str = "anchor"
 ) -> None:
     """Check ownership for live anchor forms; value/string anchors are inert."""
-    if getattr(anchor, "_document", None) is not None:
-        require_span_owner(document, cast("Span", anchor), argument=argument)
+    from docx.search import Span
+    from docx.story import Block
+
+    if isinstance(anchor, Span):
+        require_span_owner(document, anchor, argument=argument)
+    elif isinstance(anchor, Block):
+        require_block_owner(document, anchor, argument=argument)
+
+
+def require_block_owner(
+    document: "Document", block: "Block", *, argument: str = "block"
+) -> None:
+    """Refuse unattached snapshots and live blocks from another package."""
+    owner = getattr(block, "_document", None)
+    if owner is None:
+        raise TargetNotFoundError(
+            f"{argument} is not a live block; reacquire it with iter_blocks()"
+            " or outline(), or use its current BlockLocator"
+        )
+    if getattr(owner, "part", None) is not document.part:
+        raise BoundaryViolationError(
+            f"{argument} belongs to a different document; reacquire the block"
+            " from the document passed to this operation"
+        )
 
 
 def require_comment_owner(

--- a/src/docx/_ownership.py
+++ b/src/docx/_ownership.py
@@ -57,7 +57,7 @@ def require_block_owner(
     if owner is None:
         raise TargetNotFoundError(
             f"{argument} is not a live block; reacquire it with iter_blocks()"
-            " or outline(), or use its current BlockLocator"
+            " or outline()"
         )
     if getattr(owner, "part", None) is not document.part:
         raise BoundaryViolationError(

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -120,20 +120,30 @@ class BlockEditResult:
 # ---------------------------------------------------------------------------
 
 
+def _refuse_paragraph_mutation(document: "Document") -> None:
+    """The one paragraph-mutation protection gate call in this module.
+
+    Single-target and range block operations both reach the gate through
+    here, so the refusal wording and the operation class stay identical
+    however the caller located its anchors.
+    """
+    _refuse_if_protected(document, "insert or remove paragraphs")
+
+
 def _resolve_anchor_paragraph(
     document: "Document", anchor: object
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
-    Every block operation resolves its MUTATION anchor here, so this is
-    also the protection choke point; read-only anchor
-    resolution (e.g. a composition SOURCE range) uses
-    `_locate_anchor_paragraph` directly.
+    Single-target block operations resolve their MUTATION anchor here.
+    Range operations locate every endpoint first, then call the same
+    protection gate. Read-only anchor resolution (e.g. a composition
+    SOURCE range) uses `_locate_anchor_paragraph` directly.
     """
     require_anchor_owner(document, anchor)
     located = _locate_anchor_paragraph(document, anchor)
     _require_current_mutation_view(anchor)
-    _refuse_if_protected(document, "insert or remove paragraphs")
+    _refuse_paragraph_mutation(document)
     return located
 
 
@@ -469,7 +479,7 @@ def _select_paragraph_range(
     if end_anchor is not None:
         end_location = _locate_anchor_paragraph(document, end_anchor)
         _require_current_mutation_view(end_anchor)
-    _refuse_if_protected(document, "insert or remove paragraphs")
+    _refuse_paragraph_mutation(document)
     root = dict(_story_elements(document))[story]
     _refuse_paragraph_in_open_field(story, root, start_p, for_insertion=False)
     # ranges are counted among the start paragraph's SIBLINGS: nested

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -131,8 +131,27 @@ def _resolve_anchor_paragraph(
     `_locate_anchor_paragraph` directly.
     """
     require_anchor_owner(document, anchor)
+    located = _locate_anchor_paragraph(document, anchor)
+    _require_current_mutation_view(anchor)
     _refuse_if_protected(document, "insert or remove paragraphs")
-    return _locate_anchor_paragraph(document, anchor)
+    return located
+
+
+def _require_current_mutation_view(anchor: object) -> None:
+    """Require live mutation targets to come from the current projection."""
+    if not isinstance(anchor, (Block, Span)):
+        return
+    view = anchor._view  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    if view not in VIEWS:
+        raise TargetNotFoundError(
+            f"live {type(anchor).__name__} is stale: its captured view is invalid"
+        )
+    if view != "current":
+        raise UnsupportedStructureError(
+            f"live {type(anchor).__name__} was captured from view={view!r};"
+            " historical projections are inspection-only as mutation anchors."
+            " Reacquire the intended target with view=\"current\" and retry"
+        )
 
 
 def _locate_anchor_paragraph(
@@ -444,7 +463,13 @@ def _select_paragraph_range(
     require_anchor_owner(document, start_anchor, argument="start_anchor")
     if end_anchor is not None:
         require_anchor_owner(document, end_anchor, argument="end_anchor")
-    story, start_p = _resolve_anchor_paragraph(document, start_anchor)
+    story, start_p = _locate_anchor_paragraph(document, start_anchor)
+    _require_current_mutation_view(start_anchor)
+    end_location = None
+    if end_anchor is not None:
+        end_location = _locate_anchor_paragraph(document, end_anchor)
+        _require_current_mutation_view(end_anchor)
+    _refuse_if_protected(document, "insert or remove paragraphs")
     root = dict(_story_elements(document))[story]
     _refuse_paragraph_in_open_field(story, root, start_p, for_insertion=False)
     # ranges are counted among the start paragraph's SIBLINGS: nested
@@ -454,7 +479,8 @@ def _select_paragraph_range(
     siblings = [child for child in parent if child.tag == _P]
     start_index = next(i for i, p in enumerate(siblings) if p is start_p)
     if end_anchor is not None:
-        end_story, end_p = _resolve_anchor_paragraph(document, end_anchor)
+        assert end_location is not None
+        end_story, end_p = end_location
         if end_story != story:
             raise BoundaryViolationError(
                 "start and end anchors live in different story parts"

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -29,7 +29,6 @@ from docx._guard import check_install
 from docx._ownership import require_anchor_owner
 from docx._transaction import rollback_on_error
 from docx.errors import (
-    AmbiguousTargetError,
     BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
@@ -48,8 +47,6 @@ from docx.story import (
     VIEWS,
     Anchor,
     Block,
-    BlockLocator,
-    _build_story_blocks,  # pyright: ignore[reportPrivateUsage]
     _container_elements,  # pyright: ignore[reportPrivateUsage]
     _iter_block_elements,
     _story_elements,
@@ -62,7 +59,7 @@ if TYPE_CHECKING:
 
 check_install()
 
-BlockTarget = Union[str, Block, Span, BlockLocator]
+BlockTarget = Union[str, Block, Span]
 
 _P = qn("w:p")
 _PPR = qn("w:pPr")
@@ -124,7 +121,7 @@ class BlockEditResult:
 
 
 def _resolve_anchor_paragraph(
-    document: "Document", anchor: BlockTarget
+    document: "Document", anchor: object
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
@@ -139,13 +136,12 @@ def _resolve_anchor_paragraph(
 
 
 def _locate_anchor_paragraph(
-    document: "Document", anchor: BlockTarget
+    document: "Document", anchor: object
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
-    Strings are found exactly via `find_one` (ambiguity refuses), live blocks
-    resolve by owner and OOXML element identity, and portable locators resolve
-    only when their complete exact evidence has one candidate.
+    Strings are found exactly via `find_one` (ambiguity refuses), while live
+    spans and blocks resolve by owner and exact OOXML element identity.
     """
     require_anchor_owner(document, anchor)
     if isinstance(anchor, str):
@@ -164,11 +160,11 @@ def _locate_anchor_paragraph(
         raise UnsupportedStructureError(
             "legacy Anchor values are inert location evidence and cannot"
             " authorize a block mutation; reacquire a live Block or exact"
-            " Span, use an exact string, or deserialize a current BlockLocator"
+            " Span, or use an exact string"
         )
     if isinstance(anchor, Block):
         return _locate_live_block(document, anchor)
-    return _locate_block_locator(document, anchor)
+    raise TypeError(f"unsupported block target {type(anchor).__name__!r}")
 
 
 def _paragraph_block(story: str, kind: str, element: "_Element") -> "Tuple[str, _Element]":
@@ -221,55 +217,6 @@ def _locate_live_block(
             "live block is stale: its kind or containing story structure changed"
         )
     return _paragraph_block(block.story, candidates[0], element)
-
-
-def _locator_matches(expected: BlockLocator, candidate: BlockLocator) -> bool:
-    return (
-        candidate.story == expected.story
-        and candidate.view == expected.view
-        and candidate.kind == expected.kind
-        and candidate.evidence == expected.evidence
-        and candidate.previous == expected.previous
-        and candidate.next == expected.next
-    )
-
-
-def _locate_block_locator(
-    document: "Document", locator: BlockLocator
-) -> "Tuple[str, _Element]":
-    root = dict(_story_elements(document)).get(locator.story)
-    if root is None:
-        raise TargetNotFoundError(f"locator story part {locator.story!r} not found")
-    matches: "List[Block]" = []
-    for block in _build_story_blocks(document, locator.story, root, locator.view):
-        if block.locator is not None and _locator_matches(locator, block.locator):
-            matches.append(block)
-    if not matches:
-        raise TargetNotFoundError(
-            "block locator is stale: no block matches its exact content,"
-            " topology, structural, and adjacent-context evidence"
-        )
-    if len(matches) > 1:
-        locations = ", ".join(
-            f"{block.story}#{block.index}" for block in matches[:5]
-        )
-        raise AmbiguousTargetError(
-            f"block locator matches {len(matches)} blocks ({locations}"
-            f"{', …' if len(matches) > 5 else ''}); reacquire a live Block"
-            " or a locator with distinctive adjacent context"
-        )
-    block = matches[0]
-    if (
-        locator.paragraph_id is not None
-        and block.locator is not None
-        and block.locator.paragraph_id != locator.paragraph_id
-    ):
-        raise TargetNotFoundError(
-            "block locator is stale: its sole exact candidate carries a"
-            " contradictory Word paragraph ID"
-        )
-    assert block._element is not None  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-    return _paragraph_block(block.story, block.kind, block._element)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 
 
 def _validated_style_id(

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -29,6 +29,7 @@ from docx._guard import check_install
 from docx._ownership import require_anchor_owner
 from docx._transaction import rollback_on_error
 from docx.errors import (
+    AmbiguousTargetError,
     BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
@@ -43,7 +44,16 @@ from docx.search import (
     _validate_xml_characters,
     find_one,
 )
-from docx.story import Anchor, Block, _iter_block_elements, _story_elements
+from docx.story import (
+    VIEWS,
+    Anchor,
+    Block,
+    BlockLocator,
+    _build_story_blocks,  # pyright: ignore[reportPrivateUsage]
+    _container_elements,  # pyright: ignore[reportPrivateUsage]
+    _iter_block_elements,
+    _story_elements,
+)
 
 if TYPE_CHECKING:
     from lxml.etree import _Element
@@ -52,7 +62,7 @@ if TYPE_CHECKING:
 
 check_install()
 
-AnchorLike = Union[str, Block, Span, Anchor]
+BlockTarget = Union[str, Block, Span, BlockLocator]
 
 _P = qn("w:p")
 _PPR = qn("w:pPr")
@@ -114,7 +124,7 @@ class BlockEditResult:
 
 
 def _resolve_anchor_paragraph(
-    document: "Document", anchor: AnchorLike
+    document: "Document", anchor: BlockTarget
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
@@ -129,13 +139,13 @@ def _resolve_anchor_paragraph(
 
 
 def _locate_anchor_paragraph(
-    document: "Document", anchor: AnchorLike
+    document: "Document", anchor: BlockTarget
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
-    Strings are found via `find_one` (ambiguity refuses); Block/Anchor values
-    are re-verified by content hash against the current-view text of the
-    block at their recorded position.
+    Strings are found exactly via `find_one` (ambiguity refuses), live blocks
+    resolve by owner and OOXML element identity, and portable locators resolve
+    only when their complete exact evidence has one candidate.
     """
     require_anchor_owner(document, anchor)
     if isinstance(anchor, str):
@@ -150,33 +160,116 @@ def _locate_anchor_paragraph(
         if paragraph is None:
             raise TargetNotFoundError("span anchor is not inside a paragraph")
         return anchor.story, paragraph
-    block_anchor = anchor.anchor if isinstance(anchor, Block) else anchor
-    for story, root in _story_elements(document):
-        if story != block_anchor.story:
-            continue
-        for kind, index, element, _sdt, _txbx in _iter_block_elements(story, root):
-            if index != block_anchor.index:
-                continue
-            if kind != "paragraph":
-                raise UnsupportedStructureError(
-                    "anchor addresses a table block; block operations anchor"
-                    " on paragraphs"
-                )
-            from docx.story import _build_block
-
-            block = _build_block(
-                story, kind, index, element, "current", in_sdt=_sdt, in_txbx=_txbx
-            )
-            if block.anchor.content_hash != block_anchor.content_hash:
-                raise TargetNotFoundError(
-                    f"anchor is stale: block {block_anchor.index} in"
-                    f" {block_anchor.story} no longer carries the anchored content"
-                )
-            return story, element
-        raise TargetNotFoundError(
-            f"anchor index {block_anchor.index} does not exist in {block_anchor.story}"
+    if isinstance(anchor, Anchor):
+        raise UnsupportedStructureError(
+            "legacy Anchor values are inert location evidence and cannot"
+            " authorize a block mutation; reacquire a live Block or exact"
+            " Span, use an exact string, or deserialize a current BlockLocator"
         )
-    raise TargetNotFoundError(f"story part {block_anchor.story!r} not found")
+    if isinstance(anchor, Block):
+        return _locate_live_block(document, anchor)
+    return _locate_block_locator(document, anchor)
+
+
+def _paragraph_block(story: str, kind: str, element: "_Element") -> "Tuple[str, _Element]":
+    if kind != "paragraph":
+        raise UnsupportedStructureError(
+            "target addresses a table block; block operations anchor on paragraphs"
+        )
+    return story, element
+
+
+def _locate_live_block(
+    document: "Document", block: Block
+) -> "Tuple[str, _Element]":
+    roots = dict(_story_elements(document))
+    root = roots.get(block.story)
+    if root is None or root is not block._story_root:  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        raise TargetNotFoundError(
+            f"live block is stale: story part {block.story!r} was removed or replaced"
+        )
+    element = block._element  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    if element is None or element.getparent() is not block._parent:  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        raise TargetNotFoundError(
+            "live block is stale: its exact document element was detached or reparented"
+        )
+    if block._view not in VIEWS:  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        raise TargetNotFoundError("live block is stale: its captured view is invalid")
+    candidates = [
+        kind
+        for kind, _index, candidate, _in_sdt, _in_txbx in _iter_block_elements(
+            block.story, root
+        )
+        if candidate is element
+    ]
+    if len(candidates) != 1:
+        raise TargetNotFoundError(
+            "live block is stale: its exact element is no longer reachable once"
+            " through supported story traversal"
+        )
+    captured_containers = block._container_elements  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    current_containers = _container_elements(element, root)
+    if (
+        candidates[0] != block.kind
+        or len(current_containers) != len(captured_containers)
+        or any(
+            current is not captured
+            for current, captured in zip(current_containers, captured_containers)
+        )
+    ):
+        raise TargetNotFoundError(
+            "live block is stale: its kind or containing story structure changed"
+        )
+    return _paragraph_block(block.story, candidates[0], element)
+
+
+def _locator_matches(expected: BlockLocator, candidate: BlockLocator) -> bool:
+    return (
+        candidate.story == expected.story
+        and candidate.view == expected.view
+        and candidate.kind == expected.kind
+        and candidate.evidence == expected.evidence
+        and candidate.previous == expected.previous
+        and candidate.next == expected.next
+    )
+
+
+def _locate_block_locator(
+    document: "Document", locator: BlockLocator
+) -> "Tuple[str, _Element]":
+    root = dict(_story_elements(document)).get(locator.story)
+    if root is None:
+        raise TargetNotFoundError(f"locator story part {locator.story!r} not found")
+    matches: "List[Block]" = []
+    for block in _build_story_blocks(document, locator.story, root, locator.view):
+        if block.locator is not None and _locator_matches(locator, block.locator):
+            matches.append(block)
+    if not matches:
+        raise TargetNotFoundError(
+            "block locator is stale: no block matches its exact content,"
+            " topology, structural, and adjacent-context evidence"
+        )
+    if len(matches) > 1:
+        locations = ", ".join(
+            f"{block.story}#{block.index}" for block in matches[:5]
+        )
+        raise AmbiguousTargetError(
+            f"block locator matches {len(matches)} blocks ({locations}"
+            f"{', …' if len(matches) > 5 else ''}); reacquire a live Block"
+            " or a locator with distinctive adjacent context"
+        )
+    block = matches[0]
+    if (
+        locator.paragraph_id is not None
+        and block.locator is not None
+        and block.locator.paragraph_id != locator.paragraph_id
+    ):
+        raise TargetNotFoundError(
+            "block locator is stale: its sole exact candidate carries a"
+            " contradictory Word paragraph ID"
+        )
+    assert block._element is not None  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    return _paragraph_block(block.story, block.kind, block._element)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 
 
 def _validated_style_id(
@@ -393,8 +486,8 @@ def _mark_paragraph_deleted(
 
 def _select_paragraph_range(
     document: "Document",
-    start_anchor: AnchorLike,
-    end_anchor: Optional[AnchorLike],
+    start_anchor: BlockTarget,
+    end_anchor: Optional[BlockTarget],
     count: int,
 ) -> "Tuple[str, List[_Element]]":
     if count < 1:
@@ -465,7 +558,7 @@ def _validate_tracked_identity(author: "Optional[str]", date: object) -> None:
 
 def insert_section_after(
     document: "Document",
-    anchor: AnchorLike,
+    anchor: BlockTarget,
     *,
     heading: str,
     paragraphs: Sequence[str],
@@ -519,9 +612,9 @@ def insert_section_after(
 
 def tracked_delete_paragraphs(
     document: "Document",
-    start_anchor: AnchorLike,
+    start_anchor: BlockTarget,
     *,
-    end_anchor: Optional[AnchorLike] = None,
+    end_anchor: Optional[BlockTarget] = None,
     count: int = 1,
     author: str,
     date: Optional[dt.datetime] = None,
@@ -560,10 +653,10 @@ def tracked_delete_paragraphs(
 
 def tracked_replace_paragraphs(
     document: "Document",
-    start_anchor: AnchorLike,
+    start_anchor: BlockTarget,
     replacement_paragraphs: Sequence[str],
     *,
-    end_anchor: Optional[AnchorLike] = None,
+    end_anchor: Optional[BlockTarget] = None,
     count: int = 1,
     body_style: Optional[str] = None,
     author: str,
@@ -756,7 +849,7 @@ def _new_table(document: "Document", block: TableBlock) -> "_Element":
 
 def insert_blocks_after(
     document: "Document",
-    anchor: AnchorLike,
+    anchor: BlockTarget,
     *,
     blocks: "Sequence[object]",
     tracked: bool = False,

--- a/src/docx/numbering.py
+++ b/src/docx/numbering.py
@@ -20,10 +20,10 @@ from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
 from docx.story import (
-    _build_block,
     _first_choice_children,
     _iter_block_elements,
     _story_elements,
+    _subtree_text,
 )
 
 if TYPE_CHECKING:
@@ -256,22 +256,20 @@ def list_numbering(document: "Document") -> NumberingReport:
                         f"paragraph resolves to undefined numbering level {level}"
                         f" for numId={num_id}; nothing was changed"
                     )
-                block = _build_block(
-                    story,
-                    "paragraph",
-                    index,
+                text = _subtree_text(
                     paragraph,
                     "current",
+                    skip_text_boxes=True,
                     in_sdt=in_sdt,
                     in_txbx=in_txbx,
-                )
+                ).text
                 numbered.append(
                     NumberedParagraph(
                         story=story,
                         index=index,
                         num_id=num_id,
                         level=level,
-                        text=block.text,
+                        text=text,
                         table_cell=_table_cell_address(paragraph),
                     )
                 )

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -28,7 +28,6 @@ from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
 from docx.story import (
     Anchor,
-    BlockLocator,
     _build_story_blocks,
     _first_choice_children,
     _story_elements,
@@ -192,7 +191,6 @@ class Revision:
     anchor: Anchor
     is_paragraph_mark: bool
     _element: "_Element"
-    block_locator: Optional[BlockLocator] = None
     _document: "Optional[Document]" = None
     _snapshot_signature: "Tuple[_Element, ...]" = field(
         default=(), repr=False, compare=False
@@ -286,9 +284,6 @@ class Revision:
             "story": self.story,
             "anchor": self.anchor.to_dict(),
             "anchor_role": "legacy_inert_location_evidence",
-            "block_locator": (
-                self.block_locator.to_dict() if self.block_locator else None
-            ),
             "is_paragraph_mark": self.is_paragraph_mark,
         }
 
@@ -414,7 +409,7 @@ class Revisions(Sequence[Revision]):
             # v2: move/format_change types + census
             # v3: row_insertion/row_deletion + named exotic types; format
             #     changes and row revisions resolvable
-            # v4: inert location evidence is distinct from optional block locators
+            # v4: Anchor is explicitly inert location evidence
             "version": 4,
             "revisions": [revision.to_dict() for revision in self._items],
             "remaining_unsupported": self.remaining_unsupported(),
@@ -867,7 +862,6 @@ def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
                     text=text,
                     story=story,
                     anchor=block.anchor,
-                    block_locator=block.locator,
                     is_paragraph_mark=_is_paragraph_mark_revision(node),
                     _element=node,
                     _document=document,
@@ -889,7 +883,6 @@ def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
                     text="",
                     story=story,
                     anchor=Anchor(story=story, index=-1, content_hash=content_hash("")),
-                    block_locator=None,
                     is_paragraph_mark=False,
                     _element=node,
                     _document=document,

--- a/src/docx/revision.py
+++ b/src/docx/revision.py
@@ -28,8 +28,9 @@ from docx.oxml.ns import qn
 from docx.protection import _refuse_if_protected
 from docx.story import (
     Anchor,
+    BlockLocator,
+    _build_story_blocks,
     _first_choice_children,
-    _iter_block_elements,
     _story_elements,
     content_hash,
 )
@@ -191,6 +192,7 @@ class Revision:
     anchor: Anchor
     is_paragraph_mark: bool
     _element: "_Element"
+    block_locator: Optional[BlockLocator] = None
     _document: "Optional[Document]" = None
     _snapshot_signature: "Tuple[_Element, ...]" = field(
         default=(), repr=False, compare=False
@@ -283,6 +285,10 @@ class Revision:
             "text": self.text,
             "story": self.story,
             "anchor": self.anchor.to_dict(),
+            "anchor_role": "legacy_inert_location_evidence",
+            "block_locator": (
+                self.block_locator.to_dict() if self.block_locator else None
+            ),
             "is_paragraph_mark": self.is_paragraph_mark,
         }
 
@@ -408,7 +414,8 @@ class Revisions(Sequence[Revision]):
             # v2: move/format_change types + census
             # v3: row_insertion/row_deletion + named exotic types; format
             #     changes and row revisions resolvable
-            "version": 3,
+            # v4: inert location evidence is distinct from optional block locators
+            "version": 4,
             "revisions": [revision.to_dict() for revision in self._items],
             "remaining_unsupported": self.remaining_unsupported(),
         }
@@ -843,20 +850,12 @@ def _iter_revision_nodes(
 
 
 def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
-    from docx.story import _build_block
-
     for story, root in _story_elements(document):
-        for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-            skip_boxes = kind == "paragraph"
-            block_anchor = None
+        for block in _build_story_blocks(document, story, root, "current"):
+            element = block._element  # noqa: SLF001 - canonical story block attachment
+            assert element is not None
+            skip_boxes = block.kind == "paragraph"
             for node in _iter_revision_nodes(element, skip_text_boxes=skip_boxes):
-                if block_anchor is None:
-                    # the anchor is the containing BLOCK's (so it verifies
-                    # against outline blocks and is usable as an AnchorLike)
-                    block_anchor = _build_block(
-                        story, kind, index, element, "current",
-                        in_sdt=in_sdt, in_txbx=in_txbx,
-                    ).anchor
                 revision_type = _revision_type_of(node)
                 text = _node_text(node)
                 if not text and node.tag in (_RPR_CHANGE, _PPR_CHANGE):
@@ -867,7 +866,8 @@ def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
                     date=_parse_date(node.get(_DATE)),
                     text=text,
                     story=story,
-                    anchor=block_anchor,
+                    anchor=block.anchor,
+                    block_locator=block.locator,
                     is_paragraph_mark=_is_paragraph_mark_revision(node),
                     _element=node,
                     _document=document,
@@ -889,6 +889,7 @@ def _enumerate_revisions(document: "Document") -> Iterator[Revision]:
                     text="",
                     story=story,
                     anchor=Anchor(story=story, index=-1, content_hash=content_hash("")),
+                    block_locator=None,
                     is_paragraph_mark=False,
                     _element=node,
                     _document=document,

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -4,11 +4,12 @@
 text when requested. Both policies assemble across Word's fragmented runs and
 across paragraph boundaries. The returned |Span| is the pivotal object of the
 editing surface: it maps a visible-text interval back to the concrete `w:t`
-text atoms that hold it, carries a stable block anchor, and is the receiver of
-the safe replace operations (`Span.replace`).
+text atoms that hold it, retains their exact live identity, and is the receiver
+of the safe replace operations (`Span.replace`). Its `Anchor` is inert location
+evidence, not mutation authority.
 
 Search space and block identity are shared with `docx.story` (one walker
-defines both), so a span's anchor always agrees with the outline.
+defines both), so a span's location evidence agrees with the outline.
 """
 
 from __future__ import annotations

--- a/src/docx/story.py
+++ b/src/docx/story.py
@@ -25,8 +25,18 @@ Traversal rules:
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    cast,
+)
 
 from docx import _textatoms
 from docx._guard import check_install
@@ -118,18 +128,18 @@ def _story_sort_key(name: str) -> Tuple[int, str]:
 
 @dataclass(frozen=True)
 class Anchor:
-    """Stable block address: story part + index + content hash.
+    """Legacy, inert location evidence: story part + index + content hash.
 
-    The hash (first 8 hex chars of SHA-256 over the block's normalized text)
-    is what detects staleness — a raw index alone is forbidden as a public
-    anchor because it goes stale across edits.
+    ``Anchor`` remains serializable for historical search and revision result
+    data. It is not a mutation-capable block target; reacquire a live |Block|
+    or |Span|, or persist a ``BlockLocator`` instead.
     """
 
     story: str
     index: int
     content_hash: str
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> "Dict[str, object]":
         return {"story": self.story, "index": self.index, "content_hash": self.content_hash}
 
 
@@ -140,7 +150,7 @@ class TableShape:
     has_merges: bool
     has_nested_table: bool
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> "Dict[str, object]":
         return {
             "rows": self.rows,
             "columns": self.columns,
@@ -149,9 +159,370 @@ class TableShape:
         }
 
 
+def _strict_keys(
+    value: object, expected: "AbstractSet[str]", *, label: str
+) -> "Dict[str, object]":
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must contain exactly {sorted(expected)!r}")
+    data = cast("Dict[object, object]", value)
+    if not all(isinstance(key, str) for key in data) or set(data) != expected:
+        raise ValueError(f"{label} must contain exactly {sorted(expected)!r}")
+    return cast("Dict[str, object]", data)
+
+
+def _strict_str(value: object, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    return value
+
+
+def _strict_optional_str(value: object, *, label: str) -> Optional[str]:
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"{label} must be a string or null")
+    return value
+
+
+def _strict_bool(value: object, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean")
+    return value
+
+
+def _strict_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    return value
+
+
+@dataclass(frozen=True)
+class _TableCellEvidence:
+    text: str
+    grid_span: int
+    vertical_merge: Optional[str]
+    nested_tables: "Tuple[_TableEvidence, ...]"
+
+    def to_dict(self) -> "Dict[str, object]":
+        return {
+            "text": self.text,
+            "grid_span": self.grid_span,
+            "vertical_merge": self.vertical_merge,
+            "nested_tables": [table.to_dict() for table in self.nested_tables],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "_TableCellEvidence":
+        data = _strict_keys(
+            value,
+            {"text", "grid_span", "vertical_merge", "nested_tables"},
+            label="table cell evidence",
+        )
+        nested = data["nested_tables"]
+        if not isinstance(nested, list):
+            raise ValueError("table cell nested_tables must be a list")
+        nested_items = cast("List[object]", nested)
+        grid_span = _strict_int(data["grid_span"], label="table cell grid_span")
+        if grid_span < 1:
+            raise ValueError("table cell grid_span must be >= 1")
+        return cls(
+            text=_strict_str(data["text"], label="table cell text"),
+            grid_span=grid_span,
+            vertical_merge=_strict_optional_str(
+                data["vertical_merge"], label="table cell vertical_merge"
+            ),
+            nested_tables=tuple(
+                _TableEvidence.from_dict(item) for item in nested_items
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class _TableEvidence:
+    shape: TableShape
+    rows: "Tuple[Tuple[_TableCellEvidence, ...], ...]"
+
+    def to_dict(self) -> "Dict[str, object]":
+        return {
+            "shape": self.shape.to_dict(),
+            "rows": [[cell.to_dict() for cell in row] for row in self.rows],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "_TableEvidence":
+        data = _strict_keys(value, {"shape", "rows"}, label="table evidence")
+        shape_data = _strict_keys(
+            data["shape"],
+            {"rows", "columns", "has_merges", "has_nested_table"},
+            label="table shape",
+        )
+        shape = TableShape(
+            rows=_strict_int(shape_data["rows"], label="table shape rows"),
+            columns=_strict_int(shape_data["columns"], label="table shape columns"),
+            has_merges=_strict_bool(
+                shape_data["has_merges"], label="table shape has_merges"
+            ),
+            has_nested_table=_strict_bool(
+                shape_data["has_nested_table"],
+                label="table shape has_nested_table",
+            ),
+        )
+        rows = data["rows"]
+        if not isinstance(rows, list):
+            raise ValueError("table evidence rows must be a list of lists")
+        row_items = cast("List[object]", rows)
+        if not all(isinstance(row, list) for row in row_items):
+            raise ValueError("table evidence rows must be a list of lists")
+        parsed_rows = tuple(
+            tuple(
+                _TableCellEvidence.from_dict(cell)
+                for cell in cast("List[object]", row)
+            )
+            for row in row_items
+        )
+        if shape.rows != len(parsed_rows) or shape.columns != max(
+            (len(row) for row in parsed_rows), default=0
+        ):
+            raise ValueError("table evidence rows do not match its declared shape")
+        return cls(shape=shape, rows=parsed_rows)
+
+
+@dataclass(frozen=True)
+class _BlockEvidence:
+    kind: str
+    text: str
+    style_id: Optional[str]
+    in_content_control: bool
+    in_text_box: bool
+    container_path: "Tuple[Tuple[str, Optional[str]], ...]"
+    table: Optional[_TableEvidence]
+
+    def to_dict(self) -> "Dict[str, object]":
+        return {
+            "kind": self.kind,
+            "text": self.text,
+            "style_id": self.style_id,
+            "in_content_control": self.in_content_control,
+            "in_text_box": self.in_text_box,
+            "container_path": [
+                {"tag": tag, "id": identifier}
+                for tag, identifier in self.container_path
+            ],
+            "table": self.table.to_dict() if self.table else None,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "_BlockEvidence":
+        data = _strict_keys(
+            value,
+            {
+                "kind",
+                "text",
+                "style_id",
+                "in_content_control",
+                "in_text_box",
+                "container_path",
+                "table",
+            },
+            label="block evidence",
+        )
+        kind = _strict_str(data["kind"], label="block evidence kind")
+        if kind not in ("paragraph", "table"):
+            raise ValueError("block evidence kind must be 'paragraph' or 'table'")
+        path_data = data["container_path"]
+        if not isinstance(path_data, list) or not path_data:
+            raise ValueError("block evidence container_path must be a non-empty list")
+        path: "List[Tuple[str, Optional[str]]]" = []
+        for item in cast("List[object]", path_data):
+            entry = _strict_keys(item, {"tag", "id"}, label="container path item")
+            path.append(
+                (
+                    _strict_str(entry["tag"], label="container path tag"),
+                    _strict_optional_str(entry["id"], label="container path id"),
+                )
+            )
+        table_data = data["table"]
+        table = None if table_data is None else _TableEvidence.from_dict(table_data)
+        if (kind == "table") != (table is not None):
+            raise ValueError("block evidence table details must match its kind")
+        style_id = _strict_optional_str(data["style_id"], label="block style_id")
+        if kind == "table" and style_id is not None:
+            raise ValueError("table block evidence cannot carry a paragraph style_id")
+        return cls(
+            kind=kind,
+            text=_strict_str(data["text"], label="block evidence text"),
+            style_id=style_id,
+            in_content_control=_strict_bool(
+                data["in_content_control"], label="block in_content_control"
+            ),
+            in_text_box=_strict_bool(data["in_text_box"], label="block in_text_box"),
+            container_path=tuple(path),
+            table=table,
+        )
+
+
+@dataclass(frozen=True)
+class _NeighborEvidence:
+    boundary: Optional[str] = None
+    block: Optional[_BlockEvidence] = None
+
+    def to_dict(self) -> "Dict[str, object]":
+        if self.boundary is not None:
+            return {"boundary": self.boundary}
+        assert self.block is not None
+        return {"block": self.block.to_dict()}
+
+    @classmethod
+    def from_dict(cls, value: object, *, side: str) -> "_NeighborEvidence":
+        if not isinstance(value, dict):
+            raise ValueError(f"{side} context must be an object")
+        data = cast("Dict[object, object]", value)
+        if set(data) == {"boundary"}:
+            boundary = _strict_str(data["boundary"], label=f"{side} boundary")
+            expected = "start" if side == "previous" else "end"
+            if boundary != expected:
+                raise ValueError(f"{side} boundary must be {expected!r}")
+            return cls(boundary=boundary)
+        if set(data) == {"block"}:
+            return cls(block=_BlockEvidence.from_dict(data["block"]))
+        raise ValueError(
+            f"{side} context must contain exactly 'boundary' or exactly 'block'"
+        )
+
+
+@dataclass(frozen=True)
+class BlockLocator:
+    """Versioned, portable block evidence resolved fail-closed.
+
+    A locator is inert data until an operation evaluates all of its exact
+    story/view/kind/content/topology and adjacent-block evidence against a
+    document. Its positional hint and optional Word paragraph ID never select
+    a candidate on their own.
+    """
+
+    SCHEMA: ClassVar[str] = "paper_block_locator"
+    VERSION: ClassVar[int] = 1
+
+    story: str
+    view: str
+    kind: str
+    evidence: _BlockEvidence
+    previous: _NeighborEvidence
+    next: _NeighborEvidence
+    position_hint: int
+    paragraph_id: Optional[str]
+
+    def __post_init__(self) -> None:
+        _strict_str(self.story, label="block locator story")
+        view = _strict_str(self.view, label="block locator view")
+        if view not in VIEWS:
+            raise ValueError(f"block locator view must be one of {VIEWS!r}")
+        kind = _strict_str(self.kind, label="block locator kind")
+        if kind not in ("paragraph", "table"):
+            raise ValueError("block locator kind must be 'paragraph' or 'table'")
+        evidence_value = cast("object", self.evidence)
+        previous_value = cast("object", self.previous)
+        next_value = cast("object", self.next)
+        if not isinstance(evidence_value, _BlockEvidence):
+            raise ValueError("block locator evidence must contain block evidence")
+        if evidence_value.kind != kind:
+            raise ValueError("block locator kind contradicts its evidence")
+        if not isinstance(previous_value, _NeighborEvidence):
+            raise ValueError("block locator previous context is invalid")
+        if not isinstance(next_value, _NeighborEvidence):
+            raise ValueError("block locator next context is invalid")
+        try:
+            evidence = _BlockEvidence.from_dict(evidence_value.to_dict())
+            previous = _NeighborEvidence.from_dict(
+                previous_value.to_dict(), side="previous"
+            )
+            next_evidence = _NeighborEvidence.from_dict(
+                next_value.to_dict(), side="next"
+            )
+        except (AttributeError, AssertionError, TypeError) as exc:
+            raise ValueError("block locator contains malformed evidence") from exc
+        if (
+            evidence != evidence_value
+            or previous != previous_value
+            or next_evidence != next_value
+        ):
+            raise ValueError("block locator evidence must use canonical field types")
+        position_hint = _strict_int(
+            self.position_hint, label="block locator position_hint"
+        )
+        if position_hint < 0:
+            raise ValueError("block locator position_hint must be >= 0")
+        paragraph_id = _strict_optional_str(
+            self.paragraph_id, label="block locator paragraph_id"
+        )
+        if kind == "table" and paragraph_id is not None:
+            raise ValueError("table block locators cannot carry a paragraph_id")
+
+    def to_dict(self) -> "Dict[str, object]":
+        return {
+            "schema": self.SCHEMA,
+            "version": self.VERSION,
+            "story": self.story,
+            "view": self.view,
+            "kind": self.kind,
+            "evidence": self.evidence.to_dict(),
+            "context": {
+                "previous": self.previous.to_dict(),
+                "next": self.next.to_dict(),
+            },
+            "position_hint": self.position_hint,
+            "paragraph_id": self.paragraph_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "BlockLocator":
+        data = _strict_keys(
+            value,
+            {
+                "schema",
+                "version",
+                "story",
+                "view",
+                "kind",
+                "evidence",
+                "context",
+                "position_hint",
+                "paragraph_id",
+            },
+            label="block locator",
+        )
+        if data["schema"] != cls.SCHEMA:
+            raise ValueError(f"block locator schema must be {cls.SCHEMA!r}")
+        if _strict_int(data["version"], label="block locator version") != cls.VERSION:
+            raise ValueError(f"unsupported block locator version {data['version']!r}")
+        story = _strict_str(data["story"], label="block locator story")
+        view = _strict_str(data["view"], label="block locator view")
+        kind = _strict_str(data["kind"], label="block locator kind")
+        evidence = _BlockEvidence.from_dict(data["evidence"])
+        context = _strict_keys(
+            data["context"], {"previous", "next"}, label="block locator context"
+        )
+        position_hint = _strict_int(
+            data["position_hint"], label="block locator position_hint"
+        )
+        paragraph_id = _strict_optional_str(
+            data["paragraph_id"], label="block locator paragraph_id"
+        )
+        return cls(
+            story=story,
+            view=view,
+            kind=kind,
+            evidence=evidence,
+            previous=_NeighborEvidence.from_dict(
+                context["previous"], side="previous"
+            ),
+            next=_NeighborEvidence.from_dict(context["next"], side="next"),
+            position_hint=position_hint,
+            paragraph_id=paragraph_id,
+        )
+
+
 @dataclass(frozen=True)
 class Block:
-    """One block-level item (paragraph or table) somewhere in the document."""
+    """One live, owner-bound paragraph or table observed during traversal."""
 
     story: str
     kind: str  # "paragraph" | "table"
@@ -165,13 +536,23 @@ class Block:
     in_text_box: bool
     has_field: bool
     table: Optional[TableShape]
+    locator: Optional[BlockLocator] = None
+    _document: "Optional[Document]" = field(default=None, repr=False, compare=False)
+    _element: "Optional[_Element]" = field(default=None, repr=False, compare=False)
+    _story_root: "Optional[_Element]" = field(default=None, repr=False, compare=False)
+    _parent: "Optional[_Element]" = field(default=None, repr=False, compare=False)
+    _container_elements: "Tuple[_Element, ...]" = field(
+        default=(), repr=False, compare=False
+    )
+    _view: str = field(default="current", repr=False, compare=False)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> "Dict[str, object]":
         return {
             "story": self.story,
             "kind": self.kind,
             "index": self.index,
             "anchor": self.anchor.to_dict(),
+            "anchor_role": "legacy_inert_location_evidence",
             "text": self.text,
             "style_id": self.style_id,
             "in_insert": self.in_insert,
@@ -180,6 +561,7 @@ class Block:
             "in_text_box": self.in_text_box,
             "has_field": self.has_field,
             "table": self.table.to_dict() if self.table else None,
+            "locator": self.locator.to_dict() if self.locator else None,
         }
 
 
@@ -191,11 +573,10 @@ class Outline:
     blocks: Tuple[Block, ...]
     blind_region_counts: Dict[str, int]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> "Dict[str, object]":
         return {
             "schema": "paper_outline",
-            "version": 2,  # v2: moves/format_changes/fields + confession keys,
-            #     per-block has_field
+            "version": 3,  # v3: inert Anchor evidence + exact BlockLocator data
             "story_parts": list(self.story_parts),
             "blind_region_counts": dict(sorted(self.blind_region_counts.items())),
             "blocks": [block.to_dict() for block in self.blocks],
@@ -472,23 +853,91 @@ def _count_fldchar_delta(element: "_Element") -> int:
     return delta
 
 
-def _build_block(
-    story: str,
+def _container_elements(element: "_Element", root: "_Element") -> "Tuple[_Element, ...]":
+    elements: "List[_Element]" = []
+    current = element.getparent()
+    while current is not None:
+        elements.append(current)
+        if current is root:
+            return tuple(elements)
+        current = current.getparent()
+    return tuple(elements)
+
+
+def _container_path(
+    element: "_Element", root: "_Element"
+) -> "Tuple[Tuple[str, Optional[str]], ...]":
+    identifying_tags = {
+        qn("w:footnote"),
+        qn("w:endnote"),
+        qn("w:comment"),
+        qn("w:sdt"),
+    }
+    return tuple(
+        (
+            str(container.tag),
+            container.get(qn("w:id")) if container.tag in identifying_tags else None,
+        )
+        for container in _container_elements(element, root)
+    )
+
+
+def _nested_tables(cell: "_Element") -> "Tuple[_Element, ...]":
+    return tuple(
+        element
+        for kind, _index, element, _in_sdt, _in_txbx in _walk_container(
+            cell, [0], in_sdt=False, in_txbx=False
+        )
+        if kind == "table"
+    )
+
+
+def _table_evidence(table: "_Element", view: str) -> _TableEvidence:
+    rows: "List[Tuple[_TableCellEvidence, ...]]" = []
+    for row in table.findall(qn("w:tr")):
+        cells: "List[_TableCellEvidence]" = []
+        for cell in row.findall(qn("w:tc")):
+            tc_pr = cell.find(qn("w:tcPr"))
+            grid_span = tc_pr.find(qn("w:gridSpan")) if tc_pr is not None else None
+            vertical_merge = tc_pr.find(qn("w:vMerge")) if tc_pr is not None else None
+            cells.append(
+                _TableCellEvidence(
+                    text=_subtree_text(cell, view, skip_text_boxes=False).text,
+                    grid_span=(
+                        int(grid_span.get(qn("w:val")) or 1)
+                        if grid_span is not None
+                        else 1
+                    ),
+                    vertical_merge=(
+                        vertical_merge.get(qn("w:val")) or "continue"
+                        if vertical_merge is not None
+                        else None
+                    ),
+                    nested_tables=tuple(
+                        _table_evidence(nested, view) for nested in _nested_tables(cell)
+                    ),
+                )
+            )
+        rows.append(tuple(cells))
+    return _TableEvidence(shape=_table_shape(table), rows=tuple(rows))
+
+
+def _block_snapshot(
     kind: str,
-    index: int,
     element: "_Element",
     view: str,
+    root: "_Element",
     *,
     in_sdt: bool,
     in_txbx: bool,
-    in_open_field: bool = False,
-) -> Block:
+) -> "Tuple[str, Optional[str], Optional[TableShape], _TextVisitor, _BlockEvidence]":
     if kind == "table":
         visitor = _subtree_text(element, view, skip_text_boxes=False,
                                 in_sdt=in_sdt, in_txbx=in_txbx)
         text = _table_text(element, view)
         style_id = None
         table = _table_shape(element)
+        table_evidence = _table_evidence(element, view)
     else:
         visitor = _subtree_text(element, view, skip_text_boxes=True,
                                 in_sdt=in_sdt, in_txbx=in_txbx)
@@ -496,22 +945,115 @@ def _build_block(
         style_values = element.xpath(_P_STYLE_XPATH)
         style_id = str(style_values[0]) if style_values else None
         table = None
-    return Block(
-        story=story,
+        table_evidence = None
+    evidence = _BlockEvidence(
         kind=kind,
-        index=index,
-        anchor=Anchor(story=story, index=index, content_hash=content_hash(text)),
         text=text,
         style_id=style_id,
-        in_insert=visitor.in_insert,
-        in_delete=visitor.in_delete,
         in_content_control=in_sdt or visitor.in_content_control,
         in_text_box=in_txbx or visitor.in_text_box,
-        # a block BETWEEN a field's begin and end (TOC entry paragraphs) is
-        # field content even though neither marker lives in it
-        has_field=visitor.has_field or in_open_field,
-        table=table,
+        container_path=_container_path(element, root),
+        table=table_evidence,
     )
+    return text, style_id, table, visitor, evidence
+
+
+@dataclass(frozen=True)
+class _BlockRecord:
+    kind: str
+    index: int
+    element: "_Element"
+    text: str
+    style_id: Optional[str]
+    table: Optional[TableShape]
+    visitor: _TextVisitor
+    evidence: _BlockEvidence
+    in_open_field: bool
+
+
+def _build_story_blocks(
+    document: "Document", story: str, root: "_Element", view: str
+) -> "Tuple[Block, ...]":
+    """Canonical live-block and locator-evidence builder for one story."""
+    records: "List[_BlockRecord]" = []
+    open_field_depth = 0
+    for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
+        text, style_id, table, visitor, evidence = _block_snapshot(
+            kind, element, view, root, in_sdt=in_sdt, in_txbx=in_txbx
+        )
+        records.append(
+            _BlockRecord(
+                kind=kind,
+                index=index,
+                element=element,
+                text=text,
+                style_id=style_id,
+                table=table,
+                visitor=visitor,
+                evidence=evidence,
+                in_open_field=open_field_depth > 0,
+            )
+        )
+        open_field_depth = max(0, open_field_depth + _count_fldchar_delta(element))
+
+    blocks: "List[Block]" = []
+    for position, record in enumerate(records):
+        previous = (
+            _NeighborEvidence(boundary="start")
+            if position == 0
+            else _NeighborEvidence(block=records[position - 1].evidence)
+        )
+        next_evidence = (
+            _NeighborEvidence(boundary="end")
+            if position == len(records) - 1
+            else _NeighborEvidence(block=records[position + 1].evidence)
+        )
+        paragraph_id = (
+            record.element.get(qn("w14:paraId"))
+            if record.kind == "paragraph"
+            else None
+        )
+        locator = BlockLocator(
+            story=story,
+            view=view,
+            kind=record.kind,
+            evidence=record.evidence,
+            previous=previous,
+            next=next_evidence,
+            position_hint=record.index,
+            paragraph_id=paragraph_id,
+        )
+        containers = _container_elements(record.element, root)
+        blocks.append(
+            Block(
+                story=story,
+                kind=record.kind,
+                index=record.index,
+                anchor=Anchor(
+                    story=story,
+                    index=record.index,
+                    content_hash=content_hash(record.text),
+                ),
+                text=record.text,
+                style_id=record.style_id,
+                in_insert=record.visitor.in_insert,
+                in_delete=record.visitor.in_delete,
+                in_content_control=record.evidence.in_content_control,
+                in_text_box=record.evidence.in_text_box,
+                # a block BETWEEN a field's begin and end (TOC entry paragraphs) is
+                # field content even though neither marker lives in it
+                has_field=record.visitor.has_field or record.in_open_field,
+                table=record.table,
+                locator=locator,
+                _document=document,
+                _element=record.element,
+                _story_root=root,
+                _parent=record.element.getparent(),
+                _container_elements=containers,
+                _view=view,
+            )
+        )
+    return tuple(blocks)
 
 
 def _table_text(table: "_Element", view: str) -> str:
@@ -604,14 +1146,7 @@ def iter_blocks(document: "Document", *, view: str = "current") -> Iterator[Bloc
     if view not in VIEWS:
         raise ValueError(f"view must be one of {VIEWS}, got {view!r}")
     for story, root in _story_elements(document):
-        open_field_depth = 0
-        for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-            yield _build_block(
-                story, kind, index, element, view,
-                in_sdt=in_sdt, in_txbx=in_txbx,
-                in_open_field=open_field_depth > 0,
-            )
-            open_field_depth = max(0, open_field_depth + _count_fldchar_delta(element))
+        yield from _build_story_blocks(document, story, root, view)
 
 
 def outline(document: "Document", *, view: str = "current") -> Outline:

--- a/src/docx/story.py
+++ b/src/docx/story.py
@@ -28,14 +28,11 @@ import hashlib
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
-    ClassVar,
     Dict,
     Iterator,
     List,
     Optional,
     Tuple,
-    cast,
 )
 
 from docx import _textatoms
@@ -132,7 +129,7 @@ class Anchor:
 
     ``Anchor`` remains serializable for historical search and revision result
     data. It is not a mutation-capable block target; reacquire a live |Block|
-    or |Span|, or persist a ``BlockLocator`` instead.
+    or |Span| instead.
     """
 
     story: str
@@ -159,367 +156,6 @@ class TableShape:
         }
 
 
-def _strict_keys(
-    value: object, expected: "AbstractSet[str]", *, label: str
-) -> "Dict[str, object]":
-    if not isinstance(value, dict):
-        raise ValueError(f"{label} must contain exactly {sorted(expected)!r}")
-    data = cast("Dict[object, object]", value)
-    if not all(isinstance(key, str) for key in data) or set(data) != expected:
-        raise ValueError(f"{label} must contain exactly {sorted(expected)!r}")
-    return cast("Dict[str, object]", data)
-
-
-def _strict_str(value: object, *, label: str) -> str:
-    if not isinstance(value, str):
-        raise ValueError(f"{label} must be a string")
-    return value
-
-
-def _strict_optional_str(value: object, *, label: str) -> Optional[str]:
-    if value is not None and not isinstance(value, str):
-        raise ValueError(f"{label} must be a string or null")
-    return value
-
-
-def _strict_bool(value: object, *, label: str) -> bool:
-    if not isinstance(value, bool):
-        raise ValueError(f"{label} must be a boolean")
-    return value
-
-
-def _strict_int(value: object, *, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(f"{label} must be an integer")
-    return value
-
-
-@dataclass(frozen=True)
-class _TableCellEvidence:
-    text: str
-    grid_span: int
-    vertical_merge: Optional[str]
-    nested_tables: "Tuple[_TableEvidence, ...]"
-
-    def to_dict(self) -> "Dict[str, object]":
-        return {
-            "text": self.text,
-            "grid_span": self.grid_span,
-            "vertical_merge": self.vertical_merge,
-            "nested_tables": [table.to_dict() for table in self.nested_tables],
-        }
-
-    @classmethod
-    def from_dict(cls, value: object) -> "_TableCellEvidence":
-        data = _strict_keys(
-            value,
-            {"text", "grid_span", "vertical_merge", "nested_tables"},
-            label="table cell evidence",
-        )
-        nested = data["nested_tables"]
-        if not isinstance(nested, list):
-            raise ValueError("table cell nested_tables must be a list")
-        nested_items = cast("List[object]", nested)
-        grid_span = _strict_int(data["grid_span"], label="table cell grid_span")
-        if grid_span < 1:
-            raise ValueError("table cell grid_span must be >= 1")
-        return cls(
-            text=_strict_str(data["text"], label="table cell text"),
-            grid_span=grid_span,
-            vertical_merge=_strict_optional_str(
-                data["vertical_merge"], label="table cell vertical_merge"
-            ),
-            nested_tables=tuple(
-                _TableEvidence.from_dict(item) for item in nested_items
-            ),
-        )
-
-
-@dataclass(frozen=True)
-class _TableEvidence:
-    shape: TableShape
-    rows: "Tuple[Tuple[_TableCellEvidence, ...], ...]"
-
-    def to_dict(self) -> "Dict[str, object]":
-        return {
-            "shape": self.shape.to_dict(),
-            "rows": [[cell.to_dict() for cell in row] for row in self.rows],
-        }
-
-    @classmethod
-    def from_dict(cls, value: object) -> "_TableEvidence":
-        data = _strict_keys(value, {"shape", "rows"}, label="table evidence")
-        shape_data = _strict_keys(
-            data["shape"],
-            {"rows", "columns", "has_merges", "has_nested_table"},
-            label="table shape",
-        )
-        shape = TableShape(
-            rows=_strict_int(shape_data["rows"], label="table shape rows"),
-            columns=_strict_int(shape_data["columns"], label="table shape columns"),
-            has_merges=_strict_bool(
-                shape_data["has_merges"], label="table shape has_merges"
-            ),
-            has_nested_table=_strict_bool(
-                shape_data["has_nested_table"],
-                label="table shape has_nested_table",
-            ),
-        )
-        rows = data["rows"]
-        if not isinstance(rows, list):
-            raise ValueError("table evidence rows must be a list of lists")
-        row_items = cast("List[object]", rows)
-        if not all(isinstance(row, list) for row in row_items):
-            raise ValueError("table evidence rows must be a list of lists")
-        parsed_rows = tuple(
-            tuple(
-                _TableCellEvidence.from_dict(cell)
-                for cell in cast("List[object]", row)
-            )
-            for row in row_items
-        )
-        if shape.rows != len(parsed_rows) or shape.columns != max(
-            (len(row) for row in parsed_rows), default=0
-        ):
-            raise ValueError("table evidence rows do not match its declared shape")
-        return cls(shape=shape, rows=parsed_rows)
-
-
-@dataclass(frozen=True)
-class _BlockEvidence:
-    kind: str
-    text: str
-    style_id: Optional[str]
-    in_content_control: bool
-    in_text_box: bool
-    container_path: "Tuple[Tuple[str, Optional[str]], ...]"
-    table: Optional[_TableEvidence]
-
-    def to_dict(self) -> "Dict[str, object]":
-        return {
-            "kind": self.kind,
-            "text": self.text,
-            "style_id": self.style_id,
-            "in_content_control": self.in_content_control,
-            "in_text_box": self.in_text_box,
-            "container_path": [
-                {"tag": tag, "id": identifier}
-                for tag, identifier in self.container_path
-            ],
-            "table": self.table.to_dict() if self.table else None,
-        }
-
-    @classmethod
-    def from_dict(cls, value: object) -> "_BlockEvidence":
-        data = _strict_keys(
-            value,
-            {
-                "kind",
-                "text",
-                "style_id",
-                "in_content_control",
-                "in_text_box",
-                "container_path",
-                "table",
-            },
-            label="block evidence",
-        )
-        kind = _strict_str(data["kind"], label="block evidence kind")
-        if kind not in ("paragraph", "table"):
-            raise ValueError("block evidence kind must be 'paragraph' or 'table'")
-        path_data = data["container_path"]
-        if not isinstance(path_data, list) or not path_data:
-            raise ValueError("block evidence container_path must be a non-empty list")
-        path: "List[Tuple[str, Optional[str]]]" = []
-        for item in cast("List[object]", path_data):
-            entry = _strict_keys(item, {"tag", "id"}, label="container path item")
-            path.append(
-                (
-                    _strict_str(entry["tag"], label="container path tag"),
-                    _strict_optional_str(entry["id"], label="container path id"),
-                )
-            )
-        table_data = data["table"]
-        table = None if table_data is None else _TableEvidence.from_dict(table_data)
-        if (kind == "table") != (table is not None):
-            raise ValueError("block evidence table details must match its kind")
-        style_id = _strict_optional_str(data["style_id"], label="block style_id")
-        if kind == "table" and style_id is not None:
-            raise ValueError("table block evidence cannot carry a paragraph style_id")
-        return cls(
-            kind=kind,
-            text=_strict_str(data["text"], label="block evidence text"),
-            style_id=style_id,
-            in_content_control=_strict_bool(
-                data["in_content_control"], label="block in_content_control"
-            ),
-            in_text_box=_strict_bool(data["in_text_box"], label="block in_text_box"),
-            container_path=tuple(path),
-            table=table,
-        )
-
-
-@dataclass(frozen=True)
-class _NeighborEvidence:
-    boundary: Optional[str] = None
-    block: Optional[_BlockEvidence] = None
-
-    def to_dict(self) -> "Dict[str, object]":
-        if self.boundary is not None:
-            return {"boundary": self.boundary}
-        assert self.block is not None
-        return {"block": self.block.to_dict()}
-
-    @classmethod
-    def from_dict(cls, value: object, *, side: str) -> "_NeighborEvidence":
-        if not isinstance(value, dict):
-            raise ValueError(f"{side} context must be an object")
-        data = cast("Dict[object, object]", value)
-        if set(data) == {"boundary"}:
-            boundary = _strict_str(data["boundary"], label=f"{side} boundary")
-            expected = "start" if side == "previous" else "end"
-            if boundary != expected:
-                raise ValueError(f"{side} boundary must be {expected!r}")
-            return cls(boundary=boundary)
-        if set(data) == {"block"}:
-            return cls(block=_BlockEvidence.from_dict(data["block"]))
-        raise ValueError(
-            f"{side} context must contain exactly 'boundary' or exactly 'block'"
-        )
-
-
-@dataclass(frozen=True)
-class BlockLocator:
-    """Versioned, portable block evidence resolved fail-closed.
-
-    A locator is inert data until an operation evaluates all of its exact
-    story/view/kind/content/topology and adjacent-block evidence against a
-    document. Its positional hint and optional Word paragraph ID never select
-    a candidate on their own.
-    """
-
-    SCHEMA: ClassVar[str] = "paper_block_locator"
-    VERSION: ClassVar[int] = 1
-
-    story: str
-    view: str
-    kind: str
-    evidence: _BlockEvidence
-    previous: _NeighborEvidence
-    next: _NeighborEvidence
-    position_hint: int
-    paragraph_id: Optional[str]
-
-    def __post_init__(self) -> None:
-        _strict_str(self.story, label="block locator story")
-        view = _strict_str(self.view, label="block locator view")
-        if view not in VIEWS:
-            raise ValueError(f"block locator view must be one of {VIEWS!r}")
-        kind = _strict_str(self.kind, label="block locator kind")
-        if kind not in ("paragraph", "table"):
-            raise ValueError("block locator kind must be 'paragraph' or 'table'")
-        evidence_value = cast("object", self.evidence)
-        previous_value = cast("object", self.previous)
-        next_value = cast("object", self.next)
-        if not isinstance(evidence_value, _BlockEvidence):
-            raise ValueError("block locator evidence must contain block evidence")
-        if evidence_value.kind != kind:
-            raise ValueError("block locator kind contradicts its evidence")
-        if not isinstance(previous_value, _NeighborEvidence):
-            raise ValueError("block locator previous context is invalid")
-        if not isinstance(next_value, _NeighborEvidence):
-            raise ValueError("block locator next context is invalid")
-        try:
-            evidence = _BlockEvidence.from_dict(evidence_value.to_dict())
-            previous = _NeighborEvidence.from_dict(
-                previous_value.to_dict(), side="previous"
-            )
-            next_evidence = _NeighborEvidence.from_dict(
-                next_value.to_dict(), side="next"
-            )
-        except (AttributeError, AssertionError, TypeError) as exc:
-            raise ValueError("block locator contains malformed evidence") from exc
-        if (
-            evidence != evidence_value
-            or previous != previous_value
-            or next_evidence != next_value
-        ):
-            raise ValueError("block locator evidence must use canonical field types")
-        position_hint = _strict_int(
-            self.position_hint, label="block locator position_hint"
-        )
-        if position_hint < 0:
-            raise ValueError("block locator position_hint must be >= 0")
-        paragraph_id = _strict_optional_str(
-            self.paragraph_id, label="block locator paragraph_id"
-        )
-        if kind == "table" and paragraph_id is not None:
-            raise ValueError("table block locators cannot carry a paragraph_id")
-
-    def to_dict(self) -> "Dict[str, object]":
-        return {
-            "schema": self.SCHEMA,
-            "version": self.VERSION,
-            "story": self.story,
-            "view": self.view,
-            "kind": self.kind,
-            "evidence": self.evidence.to_dict(),
-            "context": {
-                "previous": self.previous.to_dict(),
-                "next": self.next.to_dict(),
-            },
-            "position_hint": self.position_hint,
-            "paragraph_id": self.paragraph_id,
-        }
-
-    @classmethod
-    def from_dict(cls, value: object) -> "BlockLocator":
-        data = _strict_keys(
-            value,
-            {
-                "schema",
-                "version",
-                "story",
-                "view",
-                "kind",
-                "evidence",
-                "context",
-                "position_hint",
-                "paragraph_id",
-            },
-            label="block locator",
-        )
-        if data["schema"] != cls.SCHEMA:
-            raise ValueError(f"block locator schema must be {cls.SCHEMA!r}")
-        if _strict_int(data["version"], label="block locator version") != cls.VERSION:
-            raise ValueError(f"unsupported block locator version {data['version']!r}")
-        story = _strict_str(data["story"], label="block locator story")
-        view = _strict_str(data["view"], label="block locator view")
-        kind = _strict_str(data["kind"], label="block locator kind")
-        evidence = _BlockEvidence.from_dict(data["evidence"])
-        context = _strict_keys(
-            data["context"], {"previous", "next"}, label="block locator context"
-        )
-        position_hint = _strict_int(
-            data["position_hint"], label="block locator position_hint"
-        )
-        paragraph_id = _strict_optional_str(
-            data["paragraph_id"], label="block locator paragraph_id"
-        )
-        return cls(
-            story=story,
-            view=view,
-            kind=kind,
-            evidence=evidence,
-            previous=_NeighborEvidence.from_dict(
-                context["previous"], side="previous"
-            ),
-            next=_NeighborEvidence.from_dict(context["next"], side="next"),
-            position_hint=position_hint,
-            paragraph_id=paragraph_id,
-        )
-
-
 @dataclass(frozen=True)
 class Block:
     """One live, owner-bound paragraph or table observed during traversal."""
@@ -536,7 +172,6 @@ class Block:
     in_text_box: bool
     has_field: bool
     table: Optional[TableShape]
-    locator: Optional[BlockLocator] = None
     _document: "Optional[Document]" = field(default=None, repr=False, compare=False)
     _element: "Optional[_Element]" = field(default=None, repr=False, compare=False)
     _story_root: "Optional[_Element]" = field(default=None, repr=False, compare=False)
@@ -561,7 +196,6 @@ class Block:
             "in_text_box": self.in_text_box,
             "has_field": self.has_field,
             "table": self.table.to_dict() if self.table else None,
-            "locator": self.locator.to_dict() if self.locator else None,
         }
 
 
@@ -576,7 +210,7 @@ class Outline:
     def to_dict(self) -> "Dict[str, object]":
         return {
             "schema": "paper_outline",
-            "version": 3,  # v3: inert Anchor evidence + exact BlockLocator data
+            "version": 3,  # v3: Anchor is explicitly inert location evidence
             "story_parts": list(self.story_parts),
             "blind_region_counts": dict(sorted(self.blind_region_counts.items())),
             "blocks": [block.to_dict() for block in self.blocks],
@@ -864,80 +498,20 @@ def _container_elements(element: "_Element", root: "_Element") -> "Tuple[_Elemen
     return tuple(elements)
 
 
-def _container_path(
-    element: "_Element", root: "_Element"
-) -> "Tuple[Tuple[str, Optional[str]], ...]":
-    identifying_tags = {
-        qn("w:footnote"),
-        qn("w:endnote"),
-        qn("w:comment"),
-        qn("w:sdt"),
-    }
-    return tuple(
-        (
-            str(container.tag),
-            container.get(qn("w:id")) if container.tag in identifying_tags else None,
-        )
-        for container in _container_elements(element, root)
-    )
-
-
-def _nested_tables(cell: "_Element") -> "Tuple[_Element, ...]":
-    return tuple(
-        element
-        for kind, _index, element, _in_sdt, _in_txbx in _walk_container(
-            cell, [0], in_sdt=False, in_txbx=False
-        )
-        if kind == "table"
-    )
-
-
-def _table_evidence(table: "_Element", view: str) -> _TableEvidence:
-    rows: "List[Tuple[_TableCellEvidence, ...]]" = []
-    for row in table.findall(qn("w:tr")):
-        cells: "List[_TableCellEvidence]" = []
-        for cell in row.findall(qn("w:tc")):
-            tc_pr = cell.find(qn("w:tcPr"))
-            grid_span = tc_pr.find(qn("w:gridSpan")) if tc_pr is not None else None
-            vertical_merge = tc_pr.find(qn("w:vMerge")) if tc_pr is not None else None
-            cells.append(
-                _TableCellEvidence(
-                    text=_subtree_text(cell, view, skip_text_boxes=False).text,
-                    grid_span=(
-                        int(grid_span.get(qn("w:val")) or 1)
-                        if grid_span is not None
-                        else 1
-                    ),
-                    vertical_merge=(
-                        vertical_merge.get(qn("w:val")) or "continue"
-                        if vertical_merge is not None
-                        else None
-                    ),
-                    nested_tables=tuple(
-                        _table_evidence(nested, view) for nested in _nested_tables(cell)
-                    ),
-                )
-            )
-        rows.append(tuple(cells))
-    return _TableEvidence(shape=_table_shape(table), rows=tuple(rows))
-
-
 def _block_snapshot(
     kind: str,
     element: "_Element",
     view: str,
-    root: "_Element",
     *,
     in_sdt: bool,
     in_txbx: bool,
-) -> "Tuple[str, Optional[str], Optional[TableShape], _TextVisitor, _BlockEvidence]":
+) -> "Tuple[str, Optional[str], Optional[TableShape], _TextVisitor, bool, bool]":
     if kind == "table":
         visitor = _subtree_text(element, view, skip_text_boxes=False,
                                 in_sdt=in_sdt, in_txbx=in_txbx)
         text = _table_text(element, view)
         style_id = None
         table = _table_shape(element)
-        table_evidence = _table_evidence(element, view)
     else:
         visitor = _subtree_text(element, view, skip_text_boxes=True,
                                 in_sdt=in_sdt, in_txbx=in_txbx)
@@ -945,17 +519,14 @@ def _block_snapshot(
         style_values = element.xpath(_P_STYLE_XPATH)
         style_id = str(style_values[0]) if style_values else None
         table = None
-        table_evidence = None
-    evidence = _BlockEvidence(
-        kind=kind,
-        text=text,
-        style_id=style_id,
-        in_content_control=in_sdt or visitor.in_content_control,
-        in_text_box=in_txbx or visitor.in_text_box,
-        container_path=_container_path(element, root),
-        table=table_evidence,
+    return (
+        text,
+        style_id,
+        table,
+        visitor,
+        in_sdt or visitor.in_content_control,
+        in_txbx or visitor.in_text_box,
     )
-    return text, style_id, table, visitor, evidence
 
 
 @dataclass(frozen=True)
@@ -967,19 +538,22 @@ class _BlockRecord:
     style_id: Optional[str]
     table: Optional[TableShape]
     visitor: _TextVisitor
-    evidence: _BlockEvidence
+    in_content_control: bool
+    in_text_box: bool
     in_open_field: bool
 
 
 def _build_story_blocks(
     document: "Document", story: str, root: "_Element", view: str
 ) -> "Tuple[Block, ...]":
-    """Canonical live-block and locator-evidence builder for one story."""
+    """Canonical live-block builder for one story."""
     records: "List[_BlockRecord]" = []
     open_field_depth = 0
     for kind, index, element, in_sdt, in_txbx in _iter_block_elements(story, root):
-        text, style_id, table, visitor, evidence = _block_snapshot(
-            kind, element, view, root, in_sdt=in_sdt, in_txbx=in_txbx
+        text, style_id, table, visitor, in_content_control, in_text_box = (
+            _block_snapshot(
+                kind, element, view, in_sdt=in_sdt, in_txbx=in_txbx
+            )
         )
         records.append(
             _BlockRecord(
@@ -990,39 +564,15 @@ def _build_story_blocks(
                 style_id=style_id,
                 table=table,
                 visitor=visitor,
-                evidence=evidence,
+                in_content_control=in_content_control,
+                in_text_box=in_text_box,
                 in_open_field=open_field_depth > 0,
             )
         )
         open_field_depth = max(0, open_field_depth + _count_fldchar_delta(element))
 
     blocks: "List[Block]" = []
-    for position, record in enumerate(records):
-        previous = (
-            _NeighborEvidence(boundary="start")
-            if position == 0
-            else _NeighborEvidence(block=records[position - 1].evidence)
-        )
-        next_evidence = (
-            _NeighborEvidence(boundary="end")
-            if position == len(records) - 1
-            else _NeighborEvidence(block=records[position + 1].evidence)
-        )
-        paragraph_id = (
-            record.element.get(qn("w14:paraId"))
-            if record.kind == "paragraph"
-            else None
-        )
-        locator = BlockLocator(
-            story=story,
-            view=view,
-            kind=record.kind,
-            evidence=record.evidence,
-            previous=previous,
-            next=next_evidence,
-            position_hint=record.index,
-            paragraph_id=paragraph_id,
-        )
+    for record in records:
         containers = _container_elements(record.element, root)
         blocks.append(
             Block(
@@ -1038,13 +588,12 @@ def _build_story_blocks(
                 style_id=record.style_id,
                 in_insert=record.visitor.in_insert,
                 in_delete=record.visitor.in_delete,
-                in_content_control=record.evidence.in_content_control,
-                in_text_box=record.evidence.in_text_box,
+                in_content_control=record.in_content_control,
+                in_text_box=record.in_text_box,
                 # a block BETWEEN a field's begin and end (TOC entry paragraphs) is
                 # field content even though neither marker lives in it
                 has_field=record.visitor.has_field or record.in_open_field,
                 table=record.table,
-                locator=locator,
                 _document=document,
                 _element=record.element,
                 _story_root=root,

--- a/tests/paper/golden/outline-minimal.json
+++ b/tests/paper/golden/outline-minimal.json
@@ -35,59 +35,7 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null,
-      "locator": {
-        "schema": "paper_block_locator",
-        "version": 1,
-        "story": "word/document.xml",
-        "view": "current",
-        "kind": "paragraph",
-        "evidence": {
-          "kind": "paragraph",
-          "text": "Minimal Clean Document",
-          "style_id": "Heading1",
-          "in_content_control": false,
-          "in_text_box": false,
-          "container_path": [
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-              "id": null
-            },
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-              "id": null
-            }
-          ],
-          "table": null
-        },
-        "context": {
-          "previous": {
-            "boundary": "start"
-          },
-          "next": {
-            "block": {
-              "kind": "paragraph",
-              "text": "First body paragraph with perfectly ordinary text.",
-              "style_id": null,
-              "in_content_control": false,
-              "in_text_box": false,
-              "container_path": [
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-                  "id": null
-                },
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-                  "id": null
-                }
-              ],
-              "table": null
-            }
-          }
-        },
-        "position_hint": 0,
-        "paragraph_id": null
-      }
+      "table": null
     },
     {
       "story": "word/document.xml",
@@ -106,76 +54,7 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null,
-      "locator": {
-        "schema": "paper_block_locator",
-        "version": 1,
-        "story": "word/document.xml",
-        "view": "current",
-        "kind": "paragraph",
-        "evidence": {
-          "kind": "paragraph",
-          "text": "First body paragraph with perfectly ordinary text.",
-          "style_id": null,
-          "in_content_control": false,
-          "in_text_box": false,
-          "container_path": [
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-              "id": null
-            },
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-              "id": null
-            }
-          ],
-          "table": null
-        },
-        "context": {
-          "previous": {
-            "block": {
-              "kind": "paragraph",
-              "text": "Minimal Clean Document",
-              "style_id": "Heading1",
-              "in_content_control": false,
-              "in_text_box": false,
-              "container_path": [
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-                  "id": null
-                },
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-                  "id": null
-                }
-              ],
-              "table": null
-            }
-          },
-          "next": {
-            "block": {
-              "kind": "paragraph",
-              "text": "Second body paragraph, equally unremarkable.",
-              "style_id": null,
-              "in_content_control": false,
-              "in_text_box": false,
-              "container_path": [
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-                  "id": null
-                },
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-                  "id": null
-                }
-              ],
-              "table": null
-            }
-          }
-        },
-        "position_hint": 1,
-        "paragraph_id": null
-      }
+      "table": null
     },
     {
       "story": "word/document.xml",
@@ -194,59 +73,7 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null,
-      "locator": {
-        "schema": "paper_block_locator",
-        "version": 1,
-        "story": "word/document.xml",
-        "view": "current",
-        "kind": "paragraph",
-        "evidence": {
-          "kind": "paragraph",
-          "text": "Second body paragraph, equally unremarkable.",
-          "style_id": null,
-          "in_content_control": false,
-          "in_text_box": false,
-          "container_path": [
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-              "id": null
-            },
-            {
-              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-              "id": null
-            }
-          ],
-          "table": null
-        },
-        "context": {
-          "previous": {
-            "block": {
-              "kind": "paragraph",
-              "text": "First body paragraph with perfectly ordinary text.",
-              "style_id": null,
-              "in_content_control": false,
-              "in_text_box": false,
-              "container_path": [
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
-                  "id": null
-                },
-                {
-                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
-                  "id": null
-                }
-              ],
-              "table": null
-            }
-          },
-          "next": {
-            "boundary": "end"
-          }
-        },
-        "position_hint": 2,
-        "paragraph_id": null
-      }
+      "table": null
     }
   ]
 }

--- a/tests/paper/golden/outline-minimal.json
+++ b/tests/paper/golden/outline-minimal.json
@@ -1,6 +1,6 @@
 {
   "schema": "paper_outline",
-  "version": 2,
+  "version": 3,
   "story_parts": [
     "word/document.xml"
   ],
@@ -27,6 +27,7 @@
         "index": 0,
         "content_hash": "bd6f203d"
       },
+      "anchor_role": "legacy_inert_location_evidence",
       "text": "Minimal Clean Document",
       "style_id": "Heading1",
       "in_insert": false,
@@ -34,7 +35,59 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null
+      "table": null,
+      "locator": {
+        "schema": "paper_block_locator",
+        "version": 1,
+        "story": "word/document.xml",
+        "view": "current",
+        "kind": "paragraph",
+        "evidence": {
+          "kind": "paragraph",
+          "text": "Minimal Clean Document",
+          "style_id": "Heading1",
+          "in_content_control": false,
+          "in_text_box": false,
+          "container_path": [
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+              "id": null
+            },
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+              "id": null
+            }
+          ],
+          "table": null
+        },
+        "context": {
+          "previous": {
+            "boundary": "start"
+          },
+          "next": {
+            "block": {
+              "kind": "paragraph",
+              "text": "First body paragraph with perfectly ordinary text.",
+              "style_id": null,
+              "in_content_control": false,
+              "in_text_box": false,
+              "container_path": [
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+                  "id": null
+                },
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+                  "id": null
+                }
+              ],
+              "table": null
+            }
+          }
+        },
+        "position_hint": 0,
+        "paragraph_id": null
+      }
     },
     {
       "story": "word/document.xml",
@@ -45,6 +98,7 @@
         "index": 1,
         "content_hash": "06f4270a"
       },
+      "anchor_role": "legacy_inert_location_evidence",
       "text": "First body paragraph with perfectly ordinary text.",
       "style_id": null,
       "in_insert": false,
@@ -52,7 +106,76 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null
+      "table": null,
+      "locator": {
+        "schema": "paper_block_locator",
+        "version": 1,
+        "story": "word/document.xml",
+        "view": "current",
+        "kind": "paragraph",
+        "evidence": {
+          "kind": "paragraph",
+          "text": "First body paragraph with perfectly ordinary text.",
+          "style_id": null,
+          "in_content_control": false,
+          "in_text_box": false,
+          "container_path": [
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+              "id": null
+            },
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+              "id": null
+            }
+          ],
+          "table": null
+        },
+        "context": {
+          "previous": {
+            "block": {
+              "kind": "paragraph",
+              "text": "Minimal Clean Document",
+              "style_id": "Heading1",
+              "in_content_control": false,
+              "in_text_box": false,
+              "container_path": [
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+                  "id": null
+                },
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+                  "id": null
+                }
+              ],
+              "table": null
+            }
+          },
+          "next": {
+            "block": {
+              "kind": "paragraph",
+              "text": "Second body paragraph, equally unremarkable.",
+              "style_id": null,
+              "in_content_control": false,
+              "in_text_box": false,
+              "container_path": [
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+                  "id": null
+                },
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+                  "id": null
+                }
+              ],
+              "table": null
+            }
+          }
+        },
+        "position_hint": 1,
+        "paragraph_id": null
+      }
     },
     {
       "story": "word/document.xml",
@@ -63,6 +186,7 @@
         "index": 2,
         "content_hash": "c187c6cc"
       },
+      "anchor_role": "legacy_inert_location_evidence",
       "text": "Second body paragraph, equally unremarkable.",
       "style_id": null,
       "in_insert": false,
@@ -70,7 +194,59 @@
       "in_content_control": false,
       "in_text_box": false,
       "has_field": false,
-      "table": null
+      "table": null,
+      "locator": {
+        "schema": "paper_block_locator",
+        "version": 1,
+        "story": "word/document.xml",
+        "view": "current",
+        "kind": "paragraph",
+        "evidence": {
+          "kind": "paragraph",
+          "text": "Second body paragraph, equally unremarkable.",
+          "style_id": null,
+          "in_content_control": false,
+          "in_text_box": false,
+          "container_path": [
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+              "id": null
+            },
+            {
+              "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+              "id": null
+            }
+          ],
+          "table": null
+        },
+        "context": {
+          "previous": {
+            "block": {
+              "kind": "paragraph",
+              "text": "First body paragraph with perfectly ordinary text.",
+              "style_id": null,
+              "in_content_control": false,
+              "in_text_box": false,
+              "container_path": [
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body",
+                  "id": null
+                },
+                {
+                  "tag": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+                  "id": null
+                }
+              ],
+              "table": null
+            }
+          },
+          "next": {
+            "boundary": "end"
+          }
+        },
+        "position_hint": 2,
+        "paragraph_id": null
+      }
     }
   ]
 }

--- a/tests/paper/test_audit_compare.py
+++ b/tests/paper/test_audit_compare.py
@@ -14,6 +14,7 @@ from docx.errors import UnsupportedStructureError
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.package import compare
+from docx.story import iter_blocks
 
 FROZEN = dt.datetime(2026, 7, 10, 12, 0, tzinfo=dt.timezone.utc)
 
@@ -168,6 +169,18 @@ def it_saves_compare_output_with_deterministic_zip_metadata(tmp_path: Path):
         assert {info.date_time for info in package.infolist()} == {
             (1980, 1, 1, 0, 0, 0)
         }
+
+
+def it_keeps_compare_result_blocks_owned_by_the_result_document(tmp_path: Path):
+    a, b = _save_pair(
+        tmp_path,
+        lambda document: document.add_paragraph("Original text"),
+        lambda document: document.add_paragraph("Revised text"),
+    )
+    result = compare(a, b, author="Reviewer", date=FROZEN)
+    blocks = tuple(iter_blocks(result.document))
+    assert blocks
+    assert all(block._document is result.document for block in blocks)  # noqa: SLF001
 
 
 class DescribeCompareAlignmentTrim:

--- a/tests/paper/test_audit_composition.py
+++ b/tests/paper/test_audit_composition.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 import docx
@@ -20,6 +22,9 @@ from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.search import find_one
+from docx.story import iter_blocks
+
+from .harness.contract import save_and_reopen
 
 _SECT_PR = qn("w:sectPr")
 _SDT = qn("w:sdt")
@@ -209,6 +214,45 @@ def it_composes_top_level_content_controls_as_whole_blocks(mode: str) -> None:
     assert "".join(node.text or "" for node in copied[0].iter(qn("w:t"))) == (
         "Controlled source block"
     )
+
+
+@pytest.mark.parametrize("view", ["original", "all"])
+@pytest.mark.parametrize("target_kind", ["block", "span"])
+def it_keeps_historical_live_composition_sources_view_neutral(
+    view: str, target_kind: str, tmp_path: Path
+) -> None:
+    source = docx.Document()
+    _clear_body(source)
+    source.add_paragraph("First source block")
+    source.add_paragraph("Second source block")
+    if target_kind == "block":
+        blocks = {
+            block.text: block
+            for block in iter_blocks(source, view=view)
+            if block.kind == "paragraph"
+        }
+        start, end = blocks["First source block"], blocks["Second source block"]
+    else:
+        start = find_one(source, "First source block", view=view)
+        end = find_one(source, "Second source block", view=view)
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    source_before = _package_state(source)  # pyright: ignore[reportUnknownVariableType]
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        start,
+        end_anchor=end,
+        anchor="Destination anchor",
+    )
+
+    assert _package_state(source) == source_before
+    assert report.inserted_blocks == 2
+    reopened = save_and_reopen(destination, tmp_path / f"{view}-{target_kind}.docx")
+    texts = [paragraph.text for paragraph in reopened.paragraphs]
+    assert "First source block" in texts
+    assert "Second source block" in texts
 
 
 def it_refuses_a_data_bound_control_before_composition_mutates() -> None:

--- a/tests/paper/test_blocks.py
+++ b/tests/paper/test_blocks.py
@@ -20,7 +20,6 @@ from docx.blocks import (
     tracked_replace_paragraphs,
 )
 from docx.errors import (
-    AmbiguousTargetError,
     BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
@@ -126,6 +125,8 @@ class DescribeLiveBlockTargets:
             {"_view": "bogus"},
             {"kind": "table"},
             {"story": "word/missing.xml"},
+            {"_story_root": OxmlElement("w:document")},
+            {"_container_elements": ()},
         ],
     )
     def it_refuses_live_blocks_with_contradictory_attachment_state(self, changes):
@@ -134,98 +135,12 @@ class DescribeLiveBlockTargets:
         with pytest.raises(TargetNotFoundError, match="stale"):
             insert_section_after(document, target, heading="wrong", paragraphs=[])
 
-
-class DescribePortableBlockLocators:
-    def it_resolves_after_a_pure_index_shift_with_context_intact(self):
-        document = _memory_doc("A", "target", "C")
-        locator = tuple(iter_blocks(document))[1].locator
-        assert locator is not None
-        document.paragraphs[0].insert_paragraph_before("new first")
-        insert_section_after(document, locator, heading="after target", paragraphs=[])
-        assert _texts(document) == ["new first", "A", "target", "after target", "C"]
-
-    def it_uses_exact_neighbor_evidence_to_resolve_duplicate_text(self):
-        document = _memory_doc("A", "target", "B", "target", "C")
-        locator = tuple(iter_blocks(document))[3].locator
-        assert locator is not None
-        insert_section_after(document, locator, heading="chosen", paragraphs=[])
-        assert _texts(document)[3:6] == ["target", "chosen", "C"]
-
-    def it_refuses_when_exact_content_or_required_context_changed(self):
-        content_changed = _memory_doc("A", "target", "C")
-        content_locator = tuple(iter_blocks(content_changed))[1].locator
-        assert content_locator is not None
-        content_changed.paragraphs[1].text = "TARGET"
-        with pytest.raises(TargetNotFoundError, match="stale"):
-            insert_section_after(
-                content_changed, content_locator, heading="wrong", paragraphs=[]
-            )
-
-        context_changed = _memory_doc("A", "target", "C")
-        context_locator = tuple(iter_blocks(context_changed))[1].locator
-        assert context_locator is not None
-        context_changed.paragraphs[0].text = "changed neighbor"
-        with pytest.raises(TargetNotFoundError, match="stale"):
-            insert_section_after(
-                context_changed, context_locator, heading="wrong", paragraphs=[]
-            )
-
-    @pytest.mark.parametrize(
-        "replacement",
-        ["TARGET", " target ", "target!", "tárget", "t\u00adarget"],
-    )
-    def it_never_normalizes_exact_candidate_evidence(self, replacement: str):
-        document = _memory_doc("A", "target", "C")
-        locator = tuple(iter_blocks(document))[1].locator
-        assert locator is not None
-        document.paragraphs[1].text = replacement
-        with pytest.raises(TargetNotFoundError, match="stale"):
-            insert_section_after(document, locator, heading="wrong", paragraphs=[])
-
-    def it_refuses_a_syntactically_valid_locator_for_a_missing_story(self):
-        document = _memory_doc("target")
-        locator = next(iter(iter_blocks(document))).locator
-        assert locator is not None
-        missing = replace(locator, story="word/missing.xml")
-        with pytest.raises(TargetNotFoundError, match="story part"):
-            insert_section_after(document, missing, heading="wrong", paragraphs=[])
-
-    def it_reports_multiple_complete_candidates_without_using_index_order(self):
-        document = _memory_doc("A", "target", "A", "target", "A")
-        locator = tuple(iter_blocks(document))[1].locator
-        assert locator is not None
-        before = document.element.xml
-        with pytest.raises(AmbiguousTargetError, match="matches 2 blocks"):
-            insert_section_after(document, locator, heading="wrong", paragraphs=[])
-        assert document.element.xml == before
-
-    def it_treats_word_id_as_supporting_not_overriding_evidence(self):
-        document = _memory_doc("A", "target", "C")
-        paragraph = document.paragraphs[1]._p
-        paragraph.set(qn("w14:paraId"), "AAAAAAAA")
-        locator = tuple(iter_blocks(document))[1].locator
-        assert locator is not None
-        paragraph.set(qn("w14:paraId"), "BBBBBBBB")
-        with pytest.raises(TargetNotFoundError, match="stale"):
-            insert_section_after(document, locator, heading="wrong", paragraphs=[])
-
-    def it_does_not_use_word_id_to_break_an_exact_evidence_tie(self):
-        document = _memory_doc("A", "target", "A", "target", "A")
-        document.paragraphs[1]._p.set(qn("w14:paraId"), "AAAAAAAA")
-        document.paragraphs[3]._p.set(qn("w14:paraId"), "BBBBBBBB")
-        locator = tuple(iter_blocks(document))[1].locator
-        assert locator is not None
-        with pytest.raises(AmbiguousTargetError, match="matches 2 blocks"):
-            insert_section_after(document, locator, heading="wrong", paragraphs=[])
-
-    def it_refuses_live_and_portable_table_targets_as_tables(self):
-        document = _memory_doc("same text")
-        document.add_table(rows=1, cols=1).cell(0, 0).text = "same text"
-        table_block = next(block for block in iter_blocks(document) if block.kind == "table")
-        assert table_block.locator is not None
-        for target in (table_block, table_block.locator):
-            with pytest.raises(UnsupportedStructureError, match="table block"):
-                insert_section_after(document, target, heading="wrong", paragraphs=[])
+    def it_refuses_a_live_table_block_as_a_paragraph_anchor(self):
+        document = _memory_doc("paragraph")
+        document.add_table(rows=1, cols=1).cell(0, 0).text = "cell"
+        table = next(block for block in iter_blocks(document) if block.kind == "table")
+        with pytest.raises(UnsupportedStructureError, match="table block"):
+            insert_section_after(document, table, heading="wrong", paragraphs=[])
 
 
 class DescribeLegacyAnchorRefusal:
@@ -282,16 +197,6 @@ class DescribeInsertSectionAfter:
             document, anchor, heading="Anchored Section", paragraphs=["Body."]
         )
         assert "Anchored Section" in _texts(document)
-
-    def it_refuses_a_stale_block_locator(self):
-        document = _doc(MINIMAL)
-        anchor = outline(document).blocks[1].locator
-        assert anchor is not None
-        from docx.search import find_one
-
-        find_one(document, "perfectly ordinary").replace("entirely different")
-        with pytest.raises(TargetNotFoundError, match="stale"):
-            insert_section_after(document, anchor, heading="X", paragraphs=[])
 
     def it_validates_style_ids_before_mutating(self):
         document = _doc(MINIMAL)

--- a/tests/paper/test_blocks.py
+++ b/tests/paper/test_blocks.py
@@ -2,23 +2,30 @@
 
 from __future__ import annotations
 
+import copy
 import datetime as dt
 import shutil
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 import docx
 from docx.blocks import (
+    RichParagraph,
+    TextRun,
+    insert_blocks_after,
     insert_section_after,
     tracked_delete_paragraphs,
     tracked_replace_paragraphs,
 )
 from docx.errors import (
+    AmbiguousTargetError,
     BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
+from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.story import iter_blocks, outline
 
@@ -42,6 +49,212 @@ def _texts(document, view: str = "current"):
     return [b.text for b in iter_blocks(document, view=view)]
 
 
+def _memory_doc(*texts: str):
+    document = docx.Document()
+    for text in texts:
+        document.add_paragraph(text)
+    return document
+
+
+class DescribeLiveBlockTargets:
+    def it_follows_the_exact_element_across_an_index_shift(self):
+        document = _memory_doc("A", "target", "C")
+        target = tuple(iter_blocks(document))[1]
+        document.paragraphs[0].insert_paragraph_before("new first")
+        insert_section_after(document, target, heading="after target", paragraphs=[])
+        assert _texts(document) == ["new first", "A", "target", "after target", "C"]
+
+    @pytest.mark.parametrize("replacement", ["target", "TARGET", " target ", "t­arget"])
+    def it_refuses_detached_or_replaced_elements_even_with_equivalent_text(
+        self, replacement: str
+    ):
+        document = _memory_doc("A", "target", "C")
+        target = tuple(iter_blocks(document))[1]
+        old = target._element  # noqa: SLF001
+        new = copy.deepcopy(old)
+        for text in new.iter(qn("w:t")):
+            text.text = replacement
+        old.getparent().replace(old, new)
+        before = document.element.xml
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(document, target, heading="wrong", paragraphs=[])
+        assert document.element.xml == before
+
+    def it_refuses_a_detached_element(self):
+        document = _memory_doc("A", "target", "C")
+        target = tuple(iter_blocks(document))[1]
+        target._element.getparent().remove(target._element)  # noqa: SLF001
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(document, target, heading="wrong", paragraphs=[])
+
+    def it_refuses_an_element_reparented_into_different_structure(self):
+        document = _memory_doc("A", "target", "C")
+        target = tuple(iter_blocks(document))[1]
+        wrapper = OxmlElement("w:sdt")
+        content = OxmlElement("w:sdtContent")
+        wrapper.append(content)
+        document.element.body.insert(1, wrapper)
+        content.append(target._element)  # noqa: SLF001
+        with pytest.raises(TargetNotFoundError, match="reparented"):
+            insert_section_after(document, target, heading="wrong", paragraphs=[])
+
+    def it_refuses_a_live_block_from_another_document(self):
+        source = _memory_doc("foreign")
+        destination = _memory_doc("local")
+        foreign = next(iter(iter_blocks(source)))
+        before = (source.element.xml, destination.element.xml)
+        with pytest.raises(BoundaryViolationError, match="different document"):
+            insert_section_after(destination, foreign, heading="wrong", paragraphs=[])
+        assert (source.element.xml, destination.element.xml) == before
+
+    def it_refuses_a_manually_detached_snapshot_instead_of_re_resolving_it(self):
+        document = _memory_doc("target")
+        snapshot = replace(
+            next(iter(iter_blocks(document))),
+            _document=None,
+            _element=None,
+            _story_root=None,
+            _parent=None,
+            _container_elements=(),
+        )
+        with pytest.raises(TargetNotFoundError, match="not a live block"):
+            insert_section_after(document, snapshot, heading="wrong", paragraphs=[])
+
+    @pytest.mark.parametrize(
+        "changes",
+        [
+            {"_view": "bogus"},
+            {"kind": "table"},
+            {"story": "word/missing.xml"},
+        ],
+    )
+    def it_refuses_live_blocks_with_contradictory_attachment_state(self, changes):
+        document = _memory_doc("target")
+        target = replace(next(iter(iter_blocks(document))), **changes)
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(document, target, heading="wrong", paragraphs=[])
+
+
+class DescribePortableBlockLocators:
+    def it_resolves_after_a_pure_index_shift_with_context_intact(self):
+        document = _memory_doc("A", "target", "C")
+        locator = tuple(iter_blocks(document))[1].locator
+        assert locator is not None
+        document.paragraphs[0].insert_paragraph_before("new first")
+        insert_section_after(document, locator, heading="after target", paragraphs=[])
+        assert _texts(document) == ["new first", "A", "target", "after target", "C"]
+
+    def it_uses_exact_neighbor_evidence_to_resolve_duplicate_text(self):
+        document = _memory_doc("A", "target", "B", "target", "C")
+        locator = tuple(iter_blocks(document))[3].locator
+        assert locator is not None
+        insert_section_after(document, locator, heading="chosen", paragraphs=[])
+        assert _texts(document)[3:6] == ["target", "chosen", "C"]
+
+    def it_refuses_when_exact_content_or_required_context_changed(self):
+        content_changed = _memory_doc("A", "target", "C")
+        content_locator = tuple(iter_blocks(content_changed))[1].locator
+        assert content_locator is not None
+        content_changed.paragraphs[1].text = "TARGET"
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(
+                content_changed, content_locator, heading="wrong", paragraphs=[]
+            )
+
+        context_changed = _memory_doc("A", "target", "C")
+        context_locator = tuple(iter_blocks(context_changed))[1].locator
+        assert context_locator is not None
+        context_changed.paragraphs[0].text = "changed neighbor"
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(
+                context_changed, context_locator, heading="wrong", paragraphs=[]
+            )
+
+    @pytest.mark.parametrize(
+        "replacement",
+        ["TARGET", " target ", "target!", "tárget", "t\u00adarget"],
+    )
+    def it_never_normalizes_exact_candidate_evidence(self, replacement: str):
+        document = _memory_doc("A", "target", "C")
+        locator = tuple(iter_blocks(document))[1].locator
+        assert locator is not None
+        document.paragraphs[1].text = replacement
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(document, locator, heading="wrong", paragraphs=[])
+
+    def it_refuses_a_syntactically_valid_locator_for_a_missing_story(self):
+        document = _memory_doc("target")
+        locator = next(iter(iter_blocks(document))).locator
+        assert locator is not None
+        missing = replace(locator, story="word/missing.xml")
+        with pytest.raises(TargetNotFoundError, match="story part"):
+            insert_section_after(document, missing, heading="wrong", paragraphs=[])
+
+    def it_reports_multiple_complete_candidates_without_using_index_order(self):
+        document = _memory_doc("A", "target", "A", "target", "A")
+        locator = tuple(iter_blocks(document))[1].locator
+        assert locator is not None
+        before = document.element.xml
+        with pytest.raises(AmbiguousTargetError, match="matches 2 blocks"):
+            insert_section_after(document, locator, heading="wrong", paragraphs=[])
+        assert document.element.xml == before
+
+    def it_treats_word_id_as_supporting_not_overriding_evidence(self):
+        document = _memory_doc("A", "target", "C")
+        paragraph = document.paragraphs[1]._p
+        paragraph.set(qn("w14:paraId"), "AAAAAAAA")
+        locator = tuple(iter_blocks(document))[1].locator
+        assert locator is not None
+        paragraph.set(qn("w14:paraId"), "BBBBBBBB")
+        with pytest.raises(TargetNotFoundError, match="stale"):
+            insert_section_after(document, locator, heading="wrong", paragraphs=[])
+
+    def it_does_not_use_word_id_to_break_an_exact_evidence_tie(self):
+        document = _memory_doc("A", "target", "A", "target", "A")
+        document.paragraphs[1]._p.set(qn("w14:paraId"), "AAAAAAAA")
+        document.paragraphs[3]._p.set(qn("w14:paraId"), "BBBBBBBB")
+        locator = tuple(iter_blocks(document))[1].locator
+        assert locator is not None
+        with pytest.raises(AmbiguousTargetError, match="matches 2 blocks"):
+            insert_section_after(document, locator, heading="wrong", paragraphs=[])
+
+    def it_refuses_live_and_portable_table_targets_as_tables(self):
+        document = _memory_doc("same text")
+        document.add_table(rows=1, cols=1).cell(0, 0).text = "same text"
+        table_block = next(block for block in iter_blocks(document) if block.kind == "table")
+        assert table_block.locator is not None
+        for target in (table_block, table_block.locator):
+            with pytest.raises(UnsupportedStructureError, match="table block"):
+                insert_section_after(document, target, heading="wrong", paragraphs=[])
+
+
+class DescribeLegacyAnchorRefusal:
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda document, anchor: insert_section_after(
+                document, anchor, heading="wrong", paragraphs=[]
+            ),
+            lambda document, anchor: tracked_delete_paragraphs(
+                document, anchor, author="A"
+            ),
+            lambda document, anchor: tracked_replace_paragraphs(
+                document, anchor, ["wrong"], author="A"
+            ),
+            lambda document, anchor: insert_blocks_after(
+                document, anchor, blocks=[RichParagraph(runs=[TextRun("valid")])]
+            ),
+        ],
+    )
+    def it_refuses_generic_anchor_evidence_for_every_mutation_family(self, operation):
+        document = _memory_doc("target")
+        anchor = next(iter(iter_blocks(document))).anchor
+        before = document.element.xml
+        with pytest.raises(UnsupportedStructureError, match="inert location evidence"):
+            operation(document, anchor)
+        assert document.element.xml == before
+
+
 class DescribeInsertSectionAfter:
     def it_inserts_a_heading_and_body_after_a_string_anchor(self, tmp_path: Path):
         document = _doc(MINIMAL)
@@ -62,17 +275,18 @@ class DescribeInsertSectionAfter:
         ]
         assert blocks[2].style_id == "Heading2"
 
-    def it_accepts_a_block_anchor_object(self):
+    def it_accepts_a_live_block_object(self):
         document = _doc(MINIMAL)
-        anchor = outline(document).blocks[1].anchor
+        anchor = outline(document).blocks[1]
         insert_section_after(
             document, anchor, heading="Anchored Section", paragraphs=["Body."]
         )
         assert "Anchored Section" in _texts(document)
 
-    def it_refuses_a_stale_block_anchor(self):
+    def it_refuses_a_stale_block_locator(self):
         document = _doc(MINIMAL)
-        anchor = outline(document).blocks[1].anchor
+        anchor = outline(document).blocks[1].locator
+        assert anchor is not None
         from docx.search import find_one
 
         find_one(document, "perfectly ordinary").replace("entirely different")
@@ -140,7 +354,8 @@ class DescribeTrackedDeleteParagraphs:
         (deletion,) = document.element.body.xpath("//w:p/w:del")
         runs = deletion.findall(qn("w:r"))
         assert len(runs) == 8, "each original run must survive inside w:del"
-        assert deletion.xpath(".//w:delText") and not deletion.xpath(".//w:t")
+        assert deletion.xpath(".//w:delText")
+        assert not deletion.xpath(".//w:t")
         bold_runs = [r for r in runs if r.find(qn("w:rPr")) is not None
                      and r.find(qn("w:rPr")).find(qn("w:b")) is not None]
         assert len(bold_runs) == 3, "bold formatting must survive deletion markup"
@@ -232,11 +447,13 @@ class DescribeTrackedReplaceParagraphs:
             author="Carol QA",
             date=FROZEN,
         )
-        assert result.deleted_blocks == 1 and result.inserted_blocks == 2
+        assert result.deleted_blocks == 1
+        assert result.inserted_blocks == 2
         assert len(result.revision_ids) == 3
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         texts = _texts(reopened)
-        assert "Replacement one." in texts and "Replacement two." in texts
+        assert "Replacement one." in texts
+        assert "Replacement two." in texts
 
     def it_keeps_the_changed_part_budget(self, tmp_path: Path):
         source = fixture_path(MINIMAL)

--- a/tests/paper/test_blocks.py
+++ b/tests/paper/test_blocks.py
@@ -7,11 +7,14 @@ import datetime as dt
 import shutil
 from dataclasses import replace
 from pathlib import Path
+from typing import Callable, Union
 
 import pytest
 
 import docx
 from docx.blocks import (
+    BlockEditResult,
+    BlockTarget,
     RichParagraph,
     TextRun,
     insert_blocks_after,
@@ -19,6 +22,7 @@ from docx.blocks import (
     tracked_delete_paragraphs,
     tracked_replace_paragraphs,
 )
+from docx.document import Document
 from docx.errors import (
     BoundaryViolationError,
     TargetNotFoundError,
@@ -26,7 +30,9 @@ from docx.errors import (
 )
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
-from docx.story import iter_blocks, outline
+from docx.protection import set_protection
+from docx.search import Span, find_one
+from docx.story import Block, iter_blocks, outline
 
 from .harness.contract import assert_changed_parts, assert_refusal_atomic, save_and_reopen
 from .harness.paths import fixture_path
@@ -141,6 +147,173 @@ class DescribeLiveBlockTargets:
         table = next(block for block in iter_blocks(document) if block.kind == "table")
         with pytest.raises(UnsupportedStructureError, match="table block"):
             insert_section_after(document, table, heading="wrong", paragraphs=[])
+
+
+LiveTarget = Union[Block, Span]
+BlockMutation = Callable[[Document, BlockTarget], BlockEditResult]
+
+
+def _live_paragraph_target(
+    document: Document, kind: str, view: str, text: str
+) -> LiveTarget:
+    if kind == "block":
+        return next(
+            block
+            for block in iter_blocks(document, view=view)
+            if block.kind == "paragraph" and block.text == text
+        )
+    return find_one(document, text, view=view)
+
+
+def _insert_section(document: Document, target: BlockTarget) -> BlockEditResult:
+    return insert_section_after(document, target, heading="new", paragraphs=[])
+
+
+def _insert_blocks(document: Document, target: BlockTarget) -> BlockEditResult:
+    return insert_blocks_after(
+        document,
+        target,
+        blocks=[RichParagraph(runs=[TextRun("new")])],
+    )
+
+
+def _tracked_delete(document: Document, target: BlockTarget) -> BlockEditResult:
+    return tracked_delete_paragraphs(document, target, author="A", date=FROZEN)
+
+
+def _tracked_replace(document: Document, target: BlockTarget) -> BlockEditResult:
+    return tracked_replace_paragraphs(
+        document, target, ["new"], author="A", date=FROZEN
+    )
+
+
+_BLOCK_MUTATIONS: tuple[object, ...] = (
+    pytest.param(_insert_section, id="insert-section"),
+    pytest.param(_insert_blocks, id="insert-blocks"),
+    pytest.param(_tracked_delete, id="tracked-delete"),
+    pytest.param(_tracked_replace, id="tracked-replace"),
+)
+
+
+class DescribeMutationProjectionAuthority:
+    @pytest.mark.parametrize("operation", _BLOCK_MUTATIONS)
+    @pytest.mark.parametrize("target_kind", ["block", "span"])
+    @pytest.mark.parametrize("view", ["original", "all"])
+    def it_refuses_historical_live_mutation_anchors_atomically(
+        self, operation: BlockMutation, target_kind: str, view: str
+    ):
+        document = _memory_doc("before", "target", "after")
+        target = _live_paragraph_target(document, target_kind, view, "target")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda doc: operation(doc, target),
+            UnsupportedStructureError,
+        )
+
+        assert f"view='{view}'" in str(refusal)
+        assert 'view="current"' in str(refusal)
+        if isinstance(target, Span):
+            target._validate_fresh()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        else:
+            assert target.text == "target"
+
+    @pytest.mark.parametrize("historical_endpoint", ["start", "end"])
+    def it_checks_both_range_projections_before_document_protection(
+        self, historical_endpoint: str
+    ):
+        document = _memory_doc("start", "end")
+        current_start = find_one(document, "start")
+        current_end = find_one(document, "end")
+        historical_start = find_one(document, "start", view="original")
+        historical_end = find_one(document, "end", view="original")
+        start = historical_start if historical_endpoint == "start" else current_start
+        end = historical_end if historical_endpoint == "end" else current_end
+        set_protection(document, edit="readOnly")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda doc: tracked_delete_paragraphs(
+                doc, start, end_anchor=end, author="A", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "view='original'" in str(refusal)
+
+    @pytest.mark.parametrize("operation", _BLOCK_MUTATIONS)
+    @pytest.mark.parametrize("target_kind", ["block", "span"])
+    def it_keeps_current_live_targets_authoritative(
+        self, operation: BlockMutation, target_kind: str
+    ):
+        document = _memory_doc("before", "target", "after")
+        target = _live_paragraph_target(document, target_kind, "current", "target")
+
+        result = operation(document, target)
+
+        assert result.inserted_blocks or result.deleted_blocks
+
+    def it_does_not_resolve_a_historical_only_exact_string_destination(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p  # pyright: ignore[reportPrivateUsage]
+        deletion = OxmlElement("w:del")
+        deletion.set(qn("w:id"), "1")
+        run = OxmlElement("w:r")
+        deleted_text = OxmlElement("w:delText")
+        deleted_text.text = "historical only"
+        run.append(deleted_text)
+        deletion.append(run)
+        paragraph.append(deletion)
+        assert find_one(document, "historical only", view="original")
+
+        assert_refusal_atomic(
+            document,
+            lambda doc: insert_section_after(
+                doc, "historical only", heading="new", paragraphs=[]
+            ),
+            TargetNotFoundError,
+        )
+
+    @pytest.mark.parametrize(
+        "operation",
+        [tracked_delete_paragraphs, tracked_replace_paragraphs],
+    )
+    @pytest.mark.parametrize("historical_endpoint", ["start", "end"])
+    @pytest.mark.parametrize("target_kind", ["block", "span"])
+    @pytest.mark.parametrize("view", ["original", "all"])
+    def it_validates_each_tracked_range_endpoint_before_mutation(
+        self,
+        operation: Callable[..., BlockEditResult],
+        historical_endpoint: str,
+        target_kind: str,
+        view: str,
+    ):
+        document = _memory_doc("start", "end", "after")
+        current_start = _live_paragraph_target(document, target_kind, "current", "start")
+        current_end = _live_paragraph_target(document, target_kind, "current", "end")
+        historical_start = _live_paragraph_target(document, target_kind, view, "start")
+        historical_end = _live_paragraph_target(document, target_kind, view, "end")
+        start = historical_start if historical_endpoint == "start" else current_start
+        end = historical_end if historical_endpoint == "end" else current_end
+
+        def mutate(doc: Document) -> BlockEditResult:
+            if operation is tracked_replace_paragraphs:
+                return operation(
+                    doc,
+                    start,
+                    ["replacement"],
+                    end_anchor=end,
+                    author="A",
+                    date=FROZEN,
+                )
+            return operation(doc, start, end_anchor=end, author="A", date=FROZEN)
+
+        refusal = assert_refusal_atomic(
+            document, mutate, UnsupportedStructureError
+        )
+
+        assert f"view='{view}'" in str(refusal)
+        assert 'view="current"' in str(refusal)
 
 
 class DescribeLegacyAnchorRefusal:

--- a/tests/paper/test_fields_bookmarks.py
+++ b/tests/paper/test_fields_bookmarks.py
@@ -28,8 +28,9 @@ from docx.fields import (
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.search import Span, find_one
+from docx.story import iter_blocks
 
-from .harness.contract import save_and_reopen
+from .harness.contract import assert_refusal_atomic, save_and_reopen
 from .harness.paths import fixture_path
 
 MINIMAL = "generated/minimal-clean/minimal.docx"
@@ -308,6 +309,32 @@ class DescribeFieldAuthoring:
         assert 'w:fldCharType="begin"' in xml and 'w:fldCharType="end"' in xml
         assert 'w:dirty="true"' in xml
         assert "w:updateFields" in self._settings_xml(reopened)
+
+    @pytest.mark.parametrize("view", ["original", "all"])
+    @pytest.mark.parametrize("target_kind", ["block", "span"])
+    def it_refuses_historical_live_toc_destinations_atomically(
+        self, view: str, target_kind: str
+    ):
+        document = _doc()
+        if target_kind == "block":
+            target = next(
+                block
+                for block in iter_blocks(document, view=view)
+                if block.text == "Minimal Clean Document"
+            )
+        else:
+            target = find_one(document, "Minimal Clean Document", view=view)
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda doc: insert_toc_after(doc, target),
+            UnsupportedStructureError,
+        )
+
+        assert f"view='{view}'" in str(refusal)
+        assert 'view="current"' in str(refusal)
+        if isinstance(target, Span):
+            target._validate_fresh()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 
     def it_validates_toc_levels(self):
         with pytest.raises(ValueError, match="levels"):

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -7,7 +7,6 @@ import datetime as dt
 from pathlib import Path
 
 import pytest
-from lxml import etree
 
 import docx
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
@@ -57,11 +56,12 @@ class DescribeKernelComparison:
             ("a", b'<!DOCTYPE x [<!ENTITY e "SAFE">]><x>&e;</x>'),
             ("b", b'<!DOCTYPE x [<!ENTITY e "EVIL">]><x>&e;</x>'),
         ):
-            with zipfile.ZipFile(source) as zin:
-                with zipfile.ZipFile(tmp_path / f"{label}.docx", "w") as zout:
-                    for name in zin.namelist():
-                        zout.writestr(name, zin.read(name))
-                    zout.writestr("word/custom.xml", payload)
+            with zipfile.ZipFile(source) as zin, zipfile.ZipFile(
+                tmp_path / f"{label}.docx", "w"
+            ) as zout:
+                for name in zin.namelist():
+                    zout.writestr(name, zin.read(name))
+                zout.writestr("word/custom.xml", payload)
         diff = diff_package(tmp_path / "a.docx", tmp_path / "b.docx")
         assert "word/custom.xml" in diff.semantic_changed_parts()
 
@@ -306,7 +306,8 @@ class DescribeTrackedReplaceRunIntegrity:
         result = find_one(document, "carries a footnote").replace(
             "bears a footnote", tracked=True, author="Carol QA", date=FROZEN
         )
-        assert result.tracked and result.revision_ids
+        assert result.tracked
+        assert result.revision_ids
 
 
 class DescribeParagraphMarkResolution:
@@ -347,7 +348,6 @@ class DescribeParagraphMarkResolution:
         """Accepting the deletion of a cell's only paragraph must leave a
         (possibly empty) paragraph — a block-less w:tc is schema-invalid."""
         from docx.blocks import tracked_delete_paragraphs
-        from docx.search import find_one as find
 
         document = _doc()
         table = document.add_table(rows=1, cols=1)
@@ -361,17 +361,30 @@ class DescribeParagraphMarkResolution:
 
 
 class DescribeRevisionAnchors:
-    def it_carries_block_anchors_usable_for_block_operations(self):
+    def it_carries_block_locators_usable_for_block_operations(self):
         from docx.blocks import insert_section_after
 
         document = _doc("generated/feature-isolated/tracked-ins-del.docx")
         revision = next(
             r for r in document.revisions if not r.is_paragraph_mark
         )
+        assert revision.block_locator is not None
         insert_section_after(
-            document, revision.anchor, heading="After Revision", paragraphs=[]
+            document, revision.block_locator, heading="After Revision", paragraphs=[]
         )
         assert "After Revision" in [b.text for b in iter_blocks(document)]
+
+    def it_refuses_a_revisions_legacy_location_evidence(self):
+        from docx.blocks import insert_section_after
+
+        document = _doc("generated/feature-isolated/tracked-ins-del.docx")
+        revision = next(r for r in document.revisions if not r.is_paragraph_mark)
+        before = document.element.xml
+        with pytest.raises(UnsupportedStructureError, match="inert location evidence"):
+            insert_section_after(
+                document, revision.anchor, heading="Wrong", paragraphs=[]
+            )
+        assert document.element.xml == before
 
 
 class DescribeTableGuardsAndFormatting:

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -361,19 +361,6 @@ class DescribeParagraphMarkResolution:
 
 
 class DescribeRevisionAnchors:
-    def it_carries_block_locators_usable_for_block_operations(self):
-        from docx.blocks import insert_section_after
-
-        document = _doc("generated/feature-isolated/tracked-ins-del.docx")
-        revision = next(
-            r for r in document.revisions if not r.is_paragraph_mark
-        )
-        assert revision.block_locator is not None
-        insert_section_after(
-            document, revision.block_locator, heading="After Revision", paragraphs=[]
-        )
-        assert "After Revision" in [b.text for b in iter_blocks(document)]
-
     def it_refuses_a_revisions_legacy_location_evidence(self):
         from docx.blocks import insert_section_after
 
@@ -382,7 +369,10 @@ class DescribeRevisionAnchors:
         before = document.element.xml
         with pytest.raises(UnsupportedStructureError, match="inert location evidence"):
             insert_section_after(
-                document, revision.anchor, heading="Wrong", paragraphs=[]
+                document,
+                revision.anchor,  # pyright: ignore[reportArgumentType]
+                heading="Wrong",
+                paragraphs=[],
             )
         assert document.element.xml == before
 

--- a/tests/paper/test_revisions.py
+++ b/tests/paper/test_revisions.py
@@ -15,6 +15,7 @@ from docx.blocks import tracked_delete_paragraphs, tracked_replace_paragraphs
 from docx.errors import UnsupportedStructureError
 from docx.oxml.ns import nsdecls
 from docx.oxml.parser import parse_xml
+from docx.revision import Revision
 from docx.search import find_one
 from docx.story import iter_blocks
 
@@ -63,9 +64,8 @@ class DescribeEnumeration:
     def it_carries_block_anchors(self):
         revision = _doc(TRACKED).revisions[0]
         assert revision.anchor.story == "word/document.xml"
-        assert revision.block_locator is not None
-        assert revision.block_locator.story == revision.story
         assert revision.story == "word/document.xml"
+        assert "block_" + "locator" not in Revision.__dataclass_fields__
 
     def it_serializes_deterministically(self):
         payload_1 = json.dumps(_doc(TRACKED).revisions.to_dict())
@@ -79,11 +79,9 @@ class DescribeEnumeration:
         assert parsed["revisions"][0]["anchor_role"] == (
             "legacy_inert_location_evidence"
         )
-        assert parsed["revisions"][0]["block_locator"]["schema"] == (
-            "paper_block_locator"
-        )
+        assert "block_" + "locator" not in parsed["revisions"][0]
 
-    def it_keeps_story_level_section_changes_outside_block_locator_space(self):
+    def it_keeps_story_level_section_changes_as_inert_evidence(self):
         document = docx.Document()
         document.sections[-1]._sectPr.append(  # noqa: SLF001
             parse_xml(
@@ -97,11 +95,11 @@ class DescribeEnumeration:
             if item.revision_type == "section_property_change"
         )
         assert revision.anchor.index == -1
-        assert revision.block_locator is None
+        assert "block_" + "locator" not in Revision.__dataclass_fields__
         assert revision.to_dict()["anchor_role"] == (
             "legacy_inert_location_evidence"
         )
-        assert revision.to_dict()["block_locator"] is None
+        assert "block_" + "locator" not in revision.to_dict()
 
 
 class DescribeAcceptReject:

--- a/tests/paper/test_revisions.py
+++ b/tests/paper/test_revisions.py
@@ -13,6 +13,8 @@ import pytest
 import docx
 from docx.blocks import tracked_delete_paragraphs, tracked_replace_paragraphs
 from docx.errors import UnsupportedStructureError
+from docx.oxml.ns import nsdecls
+from docx.oxml.parser import parse_xml
 from docx.search import find_one
 from docx.story import iter_blocks
 
@@ -61,6 +63,8 @@ class DescribeEnumeration:
     def it_carries_block_anchors(self):
         revision = _doc(TRACKED).revisions[0]
         assert revision.anchor.story == "word/document.xml"
+        assert revision.block_locator is not None
+        assert revision.block_locator.story == revision.story
         assert revision.story == "word/document.xml"
 
     def it_serializes_deterministically(self):
@@ -68,8 +72,36 @@ class DescribeEnumeration:
         payload_2 = json.dumps(_doc(TRACKED).revisions.to_dict())
         assert payload_1 == payload_2
         parsed = json.loads(payload_1)
-        assert parsed["schema"] == "paper_revisions" and parsed["version"] == 3
+        assert parsed["schema"] == "paper_revisions"
+        assert parsed["version"] == 4
         assert parsed["remaining_unsupported"] == {}
+        assert parsed["revisions"][0]["anchor"]
+        assert parsed["revisions"][0]["anchor_role"] == (
+            "legacy_inert_location_evidence"
+        )
+        assert parsed["revisions"][0]["block_locator"]["schema"] == (
+            "paper_block_locator"
+        )
+
+    def it_keeps_story_level_section_changes_outside_block_locator_space(self):
+        document = docx.Document()
+        document.sections[-1]._sectPr.append(  # noqa: SLF001
+            parse_xml(
+                f'<w:sectPrChange {nsdecls("w")} w:id="991" w:author="A">'
+                "<w:sectPr/></w:sectPrChange>"
+            )
+        )
+        revision = next(
+            item
+            for item in document.revisions
+            if item.revision_type == "section_property_change"
+        )
+        assert revision.anchor.index == -1
+        assert revision.block_locator is None
+        assert revision.to_dict()["anchor_role"] == (
+            "legacy_inert_location_evidence"
+        )
+        assert revision.to_dict()["block_locator"] is None
 
 
 class DescribeAcceptReject:

--- a/tests/paper/test_story.py
+++ b/tests/paper/test_story.py
@@ -9,16 +9,17 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import replace
 from pathlib import Path
 from typing import List
 
 import pytest
+from lxml.etree import SubElement
 
 import docx
 from docx._normalize import normalize_text
+from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
-from docx.story import Block, BlockLocator, iter_blocks, outline, story_parts
+from docx.story import Block, iter_blocks, outline, story_parts
 
 from .harness.paths import fixture_path, sidecar_path
 
@@ -241,7 +242,7 @@ class DescribeAnchors:
         assert block.anchor.index == block.index
 
 
-class DescribeLiveBlocksAndLocators:
+class DescribeLiveBlocks:
     def it_keeps_live_identity_private_and_out_of_serialization(self):
         document = _doc(MINIMAL)
         block = next(iter(iter_blocks(document)))
@@ -253,118 +254,44 @@ class DescribeLiveBlocksAndLocators:
         assert "_element" not in payload
         assert "memory" not in payload
 
-    def it_round_trips_every_exact_locator_field_without_becoming_live(self):
-        document = _doc(MINIMAL)
-        locator = tuple(iter_blocks(document, view="original"))[1].locator
-        assert locator is not None
-        payload = json.loads(json.dumps(locator.to_dict(), ensure_ascii=False))
-        restored = BlockLocator.from_dict(payload)
-        assert restored == locator
-        assert restored.to_dict() == payload
-        assert not hasattr(restored, "_document")
+    def it_exposes_no_portable_locator_surface(self):
+        from docx import story
+
+        block = next(iter(iter_blocks(_doc(MINIMAL))))
+        assert not hasattr(story, "Block" + "Locator")
+        assert not hasattr(block, "locator")
+        assert "locator" not in block.to_dict()
 
     @pytest.mark.parametrize(
-        "changes",
+        ("container_tag", "content_tag", "flag"),
         [
-            lambda locator: {"view": "bogus"},
-            lambda locator: {"position_hint": True},
-            lambda locator: {"paragraph_id": 42},
-            lambda locator: {
-                "evidence": replace(locator.evidence, container_path=[])
-            },
-            lambda locator: {
-                "previous": replace(locator.previous, boundary="end")
-            },
+            ("w:sdt", "w:sdtContent", "in_content_control"),
+            ("w:r", "w:txbxContent", "in_text_box"),
         ],
     )
-    def it_refuses_invalid_direct_locator_construction(self, changes):
-        locator = next(iter(iter_blocks(_doc(MINIMAL)))).locator
-        assert locator is not None
-        values = {
-            "story": locator.story,
-            "view": locator.view,
-            "kind": locator.kind,
-            "evidence": locator.evidence,
-            "previous": locator.previous,
-            "next": locator.next,
-            "position_hint": locator.position_hint,
-            "paragraph_id": locator.paragraph_id,
-        }
-        values.update(changes(locator))
-        with pytest.raises(ValueError, match="."):
-            BlockLocator(**values)
-
-    @pytest.mark.parametrize(
-        "mutate",
-        [
-            lambda payload: payload.update(schema="legacy_anchor"),
-            lambda payload: payload.update(version=99),
-            lambda payload: payload.pop("evidence"),
-            lambda payload: payload.update(position_hint=True),
-            lambda payload: payload["context"].update(previous={"boundary": "end"}),
-            lambda payload: payload.update(paragraph_id=42),
-        ],
-    )
-    def it_refuses_malformed_or_unsupported_locator_payloads(self, mutate):
-        locator = next(iter(iter_blocks(_doc(MINIMAL)))).locator
-        assert locator is not None
-        payload = json.loads(json.dumps(locator.to_dict()))
-        mutate(payload)
-        with pytest.raises(ValueError, match="."):
-            BlockLocator.from_dict(payload)
-
-    def it_never_upgrades_a_legacy_anchor_payload(self):
-        anchor = next(iter(iter_blocks(_doc(MINIMAL)))).anchor
-        with pytest.raises(ValueError, match="block locator"):
-            BlockLocator.from_dict(anchor.to_dict())
-
-    def it_records_exact_case_whitespace_punctuation_and_unicode(self):
+    def it_flags_empty_paragraphs_from_their_container_context(
+        self, container_tag: str, content_tag: str, flag: str
+    ):
         document = docx.Document()
-        document.add_paragraph("Case  — café\u00ad!")
-        locator = next(iter(iter_blocks(document))).locator
-        assert locator is not None
-        assert locator.to_dict()["evidence"]["text"] == "Case  — café\u00ad!"
+        host = document.add_paragraph("host")._p
+        container = OxmlElement(container_tag)
+        content = OxmlElement(content_tag)
+        content.append(OxmlElement("w:p"))
+        if content_tag == "w:sdtContent":
+            container.append(content)
+            body = document.element.find(qn("w:body"))
+            assert body is not None
+            body.insert(0, container)
+        else:
+            pict = OxmlElement("w:pict")
+            shape = SubElement(pict, "{urn:schemas-microsoft-com:vml}shape")
+            text_box = SubElement(shape, "{urn:schemas-microsoft-com:vml}textbox")
+            text_box.append(content)
+            container.append(pict)
+            host.append(container)
 
-    def it_keeps_table_cell_topology_beyond_flattened_text(self):
-        first = docx.Document()
-        table = first.add_table(rows=1, cols=2)
-        table.cell(0, 0).text = "A"
-        table.cell(0, 1).text = "B"
-        second = docx.Document()
-        second.add_table(rows=2, cols=1).cell(0, 0).text = "A"
-        second.tables[0].cell(1, 0).text = "B"
-        left = next(b for b in iter_blocks(first) if b.kind == "table")
-        right = next(b for b in iter_blocks(second) if b.kind == "table")
-        assert left.text == right.text == "A\nB"
-        assert left.locator is not None
-        assert right.locator is not None
-        assert left.locator.evidence != right.locator.evidence
-
-    def it_records_nested_table_topology_recursively(self):
-        document = docx.Document()
-        outer = document.add_table(rows=1, cols=1)
-        nested = outer.cell(0, 0).add_table(rows=1, cols=1)
-        nested.cell(0, 0).text = "nested"
-        locator = next(b for b in iter_blocks(document) if b.kind == "table").locator
-        assert locator is not None
-        table_evidence = locator.to_dict()["evidence"]["table"]
-        nested_evidence = table_evidence["rows"][0][0]["nested_tables"]
-        assert nested_evidence[0]["rows"][0][0]["text"] == "nested"
-        assert BlockLocator.from_dict(locator.to_dict()) == locator
-
-    def it_observes_but_does_not_generate_word_paragraph_ids(self):
-        document = docx.Document()
-        plain = document.add_paragraph("plain")._p
-        identified = document.add_paragraph("identified")._p
-        identified.set(qn("w14:paraId"), "1234ABCD")
-        before = document.element.xml
-        blocks = tuple(iter_blocks(document))
-        assert blocks[0].locator is not None
-        assert blocks[0].locator.paragraph_id is None
-        assert blocks[1].locator is not None
-        assert blocks[1].locator.paragraph_id == "1234ABCD"
-        assert document.element.xml == before
-        assert plain.get(qn("w14:paraId")) is None
+        empty = next(block for block in iter_blocks(document) if block.text == "")
+        assert getattr(empty, flag)
 
 
 class DescribeInspectionDeterminism:
@@ -384,14 +311,14 @@ class DescribeInspectionDeterminism:
             " tests/paper/golden/outline-minimal.json in the same reviewed commit"
         )
 
-    def it_marks_inert_anchor_and_portable_locator_data_separately(self):
+    def it_marks_anchor_data_as_inert_without_a_locator(self):
         payload = outline(_doc(MINIMAL)).to_dict()
         assert payload["version"] == 3
         assert payload["blocks"][0]["anchor"]
         assert payload["blocks"][0]["anchor_role"] == (
             "legacy_inert_location_evidence"
         )
-        assert payload["blocks"][0]["locator"]["schema"] == "paper_block_locator"
+        assert "locator" not in payload["blocks"][0]
 
 
 class DescribeBlindRegionCounts:

--- a/tests/paper/test_story.py
+++ b/tests/paper/test_story.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import List
 
@@ -16,7 +17,8 @@ import pytest
 
 import docx
 from docx._normalize import normalize_text
-from docx.story import Block, iter_blocks, outline, story_parts
+from docx.oxml.ns import qn
+from docx.story import Block, BlockLocator, iter_blocks, outline, story_parts
 
 from .harness.paths import fixture_path, sidecar_path
 
@@ -74,18 +76,22 @@ class DescribeTrackedViews:
         truth = _ground_truth(TRACKED)["revised_paragraph"]
         block = _blocks(TRACKED, "current")[1]
         assert block.text == truth["visible_text_current"]
-        assert block.in_insert and not block.in_delete
+        assert block.in_insert
+        assert not block.in_delete
 
     def it_shows_the_pre_change_text_in_the_original_view(self):
         truth = _ground_truth(TRACKED)["revised_paragraph"]
         block = _blocks(TRACKED, "original")[1]
         assert block.text == truth["visible_text_original"]
-        assert block.in_delete and not block.in_insert
+        assert block.in_delete
+        assert not block.in_insert
 
     def it_shows_everything_in_the_all_view(self):
         block = _blocks(TRACKED, "all")[1]
-        assert "forty-two" in block.text and "forty-seven" in block.text
-        assert block.in_insert and block.in_delete
+        assert "forty-two" in block.text
+        assert "forty-seven" in block.text
+        assert block.in_insert
+        assert block.in_delete
 
     def it_rejects_unknown_views(self):
         with pytest.raises(ValueError, match="view"):
@@ -231,7 +237,134 @@ class DescribeAnchors:
             normalize_text(block.text).encode("utf-8")
         ).hexdigest()[:8]
         assert block.anchor.content_hash == expected
-        assert block.anchor.story == block.story and block.anchor.index == block.index
+        assert block.anchor.story == block.story
+        assert block.anchor.index == block.index
+
+
+class DescribeLiveBlocksAndLocators:
+    def it_keeps_live_identity_private_and_out_of_serialization(self):
+        document = _doc(MINIMAL)
+        block = next(iter(iter_blocks(document)))
+        assert block._document is document  # noqa: SLF001
+        assert block._element is document.paragraphs[0]._p  # noqa: SLF001
+        assert block._story_root is document.element  # noqa: SLF001
+        payload = json.dumps(block.to_dict())
+        assert "_document" not in payload
+        assert "_element" not in payload
+        assert "memory" not in payload
+
+    def it_round_trips_every_exact_locator_field_without_becoming_live(self):
+        document = _doc(MINIMAL)
+        locator = tuple(iter_blocks(document, view="original"))[1].locator
+        assert locator is not None
+        payload = json.loads(json.dumps(locator.to_dict(), ensure_ascii=False))
+        restored = BlockLocator.from_dict(payload)
+        assert restored == locator
+        assert restored.to_dict() == payload
+        assert not hasattr(restored, "_document")
+
+    @pytest.mark.parametrize(
+        "changes",
+        [
+            lambda locator: {"view": "bogus"},
+            lambda locator: {"position_hint": True},
+            lambda locator: {"paragraph_id": 42},
+            lambda locator: {
+                "evidence": replace(locator.evidence, container_path=[])
+            },
+            lambda locator: {
+                "previous": replace(locator.previous, boundary="end")
+            },
+        ],
+    )
+    def it_refuses_invalid_direct_locator_construction(self, changes):
+        locator = next(iter(iter_blocks(_doc(MINIMAL)))).locator
+        assert locator is not None
+        values = {
+            "story": locator.story,
+            "view": locator.view,
+            "kind": locator.kind,
+            "evidence": locator.evidence,
+            "previous": locator.previous,
+            "next": locator.next,
+            "position_hint": locator.position_hint,
+            "paragraph_id": locator.paragraph_id,
+        }
+        values.update(changes(locator))
+        with pytest.raises(ValueError, match="."):
+            BlockLocator(**values)
+
+    @pytest.mark.parametrize(
+        "mutate",
+        [
+            lambda payload: payload.update(schema="legacy_anchor"),
+            lambda payload: payload.update(version=99),
+            lambda payload: payload.pop("evidence"),
+            lambda payload: payload.update(position_hint=True),
+            lambda payload: payload["context"].update(previous={"boundary": "end"}),
+            lambda payload: payload.update(paragraph_id=42),
+        ],
+    )
+    def it_refuses_malformed_or_unsupported_locator_payloads(self, mutate):
+        locator = next(iter(iter_blocks(_doc(MINIMAL)))).locator
+        assert locator is not None
+        payload = json.loads(json.dumps(locator.to_dict()))
+        mutate(payload)
+        with pytest.raises(ValueError, match="."):
+            BlockLocator.from_dict(payload)
+
+    def it_never_upgrades_a_legacy_anchor_payload(self):
+        anchor = next(iter(iter_blocks(_doc(MINIMAL)))).anchor
+        with pytest.raises(ValueError, match="block locator"):
+            BlockLocator.from_dict(anchor.to_dict())
+
+    def it_records_exact_case_whitespace_punctuation_and_unicode(self):
+        document = docx.Document()
+        document.add_paragraph("Case  — café\u00ad!")
+        locator = next(iter(iter_blocks(document))).locator
+        assert locator is not None
+        assert locator.to_dict()["evidence"]["text"] == "Case  — café\u00ad!"
+
+    def it_keeps_table_cell_topology_beyond_flattened_text(self):
+        first = docx.Document()
+        table = first.add_table(rows=1, cols=2)
+        table.cell(0, 0).text = "A"
+        table.cell(0, 1).text = "B"
+        second = docx.Document()
+        second.add_table(rows=2, cols=1).cell(0, 0).text = "A"
+        second.tables[0].cell(1, 0).text = "B"
+        left = next(b for b in iter_blocks(first) if b.kind == "table")
+        right = next(b for b in iter_blocks(second) if b.kind == "table")
+        assert left.text == right.text == "A\nB"
+        assert left.locator is not None
+        assert right.locator is not None
+        assert left.locator.evidence != right.locator.evidence
+
+    def it_records_nested_table_topology_recursively(self):
+        document = docx.Document()
+        outer = document.add_table(rows=1, cols=1)
+        nested = outer.cell(0, 0).add_table(rows=1, cols=1)
+        nested.cell(0, 0).text = "nested"
+        locator = next(b for b in iter_blocks(document) if b.kind == "table").locator
+        assert locator is not None
+        table_evidence = locator.to_dict()["evidence"]["table"]
+        nested_evidence = table_evidence["rows"][0][0]["nested_tables"]
+        assert nested_evidence[0]["rows"][0][0]["text"] == "nested"
+        assert BlockLocator.from_dict(locator.to_dict()) == locator
+
+    def it_observes_but_does_not_generate_word_paragraph_ids(self):
+        document = docx.Document()
+        plain = document.add_paragraph("plain")._p
+        identified = document.add_paragraph("identified")._p
+        identified.set(qn("w14:paraId"), "1234ABCD")
+        before = document.element.xml
+        blocks = tuple(iter_blocks(document))
+        assert blocks[0].locator is not None
+        assert blocks[0].locator.paragraph_id is None
+        assert blocks[1].locator is not None
+        assert blocks[1].locator.paragraph_id == "1234ABCD"
+        assert document.element.xml == before
+        assert plain.get(qn("w14:paraId")) is None
 
 
 class DescribeInspectionDeterminism:
@@ -250,6 +383,15 @@ class DescribeInspectionDeterminism:
             "outline JSON shape drifted from the golden; if deliberate, update"
             " tests/paper/golden/outline-minimal.json in the same reviewed commit"
         )
+
+    def it_marks_inert_anchor_and_portable_locator_data_separately(self):
+        payload = outline(_doc(MINIMAL)).to_dict()
+        assert payload["version"] == 3
+        assert payload["blocks"][0]["anchor"]
+        assert payload["blocks"][0]["anchor_role"] == (
+            "legacy_inert_location_evidence"
+        )
+        assert payload["blocks"][0]["locator"]["schema"] == "paper_block_locator"
 
 
 class DescribeBlindRegionCounts:

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -14,7 +14,12 @@ from docx.errors import (
     TargetNotFoundError,
     UnsupportedStructureError,
 )
-from docx.numbering import apply_list_style, apply_numbering, list_numbering
+from docx.numbering import (
+    apply_list_style,
+    apply_numbering,
+    ensure_bullet_definition,
+    list_numbering,
+)
 from docx.tableops import delete_row, find_table, insert_row_after, update_cell
 
 from .harness.contract import assert_refusal_atomic, save_and_reopen
@@ -169,7 +174,8 @@ class DescribeUpdateCell:
     def it_supports_tracked_updates(self, tmp_path: Path):
         document, table = _doc_with_simple_table()
         result = update_cell(table, 0, 0, "cell 99", tracked=True, author="Carol QA", date=FROZEN)
-        assert result.tracked and result.revision_ids
+        assert result.tracked
+        assert result.revision_ids
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert reopened.tables[0].cell(0, 0).text.startswith("cell")
         revisions = reopened.revisions
@@ -309,6 +315,17 @@ class DescribeListNumbering:
         assert payload["version"] == 2
         assert json.dumps(payload) == json.dumps(list_numbering(_doc(NUMBERING)).to_dict())
 
+    def it_reports_numbered_table_cell_paragraphs_without_top_level_block_identity(self):
+        document = docx.Document()
+        table = document.add_table(rows=1, cols=1)
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.add_run("numbered cell")
+        num_id = ensure_bullet_definition(document)
+        apply_numbering(paragraph, num_id=num_id)
+        (reported,) = list_numbering(document).numbered_paragraphs
+        assert reported.text == "numbered cell"
+        assert reported.table_cell == (0, 0, 0)
+
 
 class DescribeApplyNumbering:
     def it_applies_an_existing_definition(self, tmp_path: Path):
@@ -340,15 +357,16 @@ class DescribeApplyNumbering:
         import re
 
         stripped = tmp_path / "no-numbering.docx"
-        with zipfile.ZipFile(fixture_path(MINIMAL)) as zin:
-            with zipfile.ZipFile(stripped, "w") as zout:
-                for name in zin.namelist():
-                    if "numbering" in name:
-                        continue
-                    blob = zin.read(name)
-                    if name == "word/_rels/document.xml.rels":
-                        blob = re.sub(rb"<Relationship [^>]*numbering[^>]*/>", b"", blob)
-                    zout.writestr(name, blob)
+        with zipfile.ZipFile(fixture_path(MINIMAL)) as zin, zipfile.ZipFile(
+            stripped, "w"
+        ) as zout:
+            for name in zin.namelist():
+                if "numbering" in name:
+                    continue
+                blob = zin.read(name)
+                if name == "word/_rels/document.xml.rels":
+                    blob = re.sub(rb"<Relationship [^>]*numbering[^>]*/>", b"", blob)
+                zout.writestr(name, blob)
         document = docx.Document(str(stripped))
         paragraph = document.add_paragraph("target")
         with pytest.raises(TargetNotFoundError, match="does not exist"):


### PR DESCRIPTION
## Why

A story/index/text digest is not durable document identity: duplicate or normalization-equivalent content can make a serialized locator authorize the wrong block after edits.

## Final behavior

- Live `Block` objects retain owner and exact OOXML element identity.
- Mutation revalidates attachment, story, container, and supported block kind.
- Detached, replaced, reparented, foreign, stale-view, and serialized targets refuse.
- `BlockLocator` is removed; no replacement persistence abstraction is added.
- Legacy serialized anchors remain inert evidence only.

Schemas use `paper_outline` v3 and `paper_revisions` v4.

## Stack

Parent: #44. Child: #46. Published head: `b606189d579c47e0610001abd47581d85e8e34e7`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authority model for paragraph-level edits and TOC insertion across core `story`/`blocks` paths; incorrect validation could refuse valid edits or (previously) mis-target blocks, though the PR tightens identity checks and adds broad refusal tests.
> 
> **Overview**
> Paragraph and TOC mutations now authorize **live** `Block`/`Span` targets (exact OOXML element + document ownership), not serialized `Anchor` hashes or portable locators.
> 
> **Mutation resolution** in `blocks`/`fields` accepts exact strings, live blocks, or spans; legacy `Anchor` values refuse with migration guidance. Live targets revalidate story root, parent chain, container structure, and paragraph-vs-table kind; detached, reparented, foreign, or structurally changed blocks refuse. Only targets captured from `view="current"` may mutate—`original`/`all` projections stay inspection-only (composition sources remain view-neutral).
> 
> **Story traversal** builds blocks via `_build_story_blocks`, attaching private live identity fields; `to_dict()`/`outline` v3 and `revisions` v4 label anchors with `anchor_role="legacy_inert_location_evidence"`. Compare/numbering/revision enumeration use direct text extraction instead of full block builds where identity is unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d87c76a6834e0be33a6ce82d30a0062ce59b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->