### PR TITLE
fix: reject cross-paragraph block targets

### DIFF
--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -21,6 +21,12 @@ inspection, but they do not authorize a current-document mutation. Reacquire
 the intended target from the current view before editing. Exact strings use
 exact lookup in the current view.
 
+An exact string or live span used as a paragraph target must resolve wholly
+inside one paragraph. Search may return a multi-paragraph span for inspection,
+but block operations raise |BoundaryViolationError| rather than guessing its
+first or last paragraph. Select exact text inside the intended paragraph, or
+pass an explicit live block endpoint.
+
 Legacy |Anchor| values are inert location evidence and are refused with
 migration guidance. Reacquire a live block with ``iter_blocks()``/``outline()``,
 or pass an exact string or live span. Do not use an old index/hash payload as a

--- a/docs/api/paper-composition.rst
+++ b/docs/api/paper-composition.rst
@@ -67,6 +67,12 @@ endpoints are translated to the existing physical body slice, so unsupported
 children between them still reach composition preflight and refuse rather
 than disappearing silently.
 
+Every source endpoint and the destination insertion target must resolve wholly
+inside one paragraph. A multi-paragraph search span remains useful for
+inspection, but composition raises |BoundaryViolationError| instead of
+inferring its first or last block. Select exact text inside one paragraph, or
+pass an explicit live block for each endpoint.
+
 .. currentmodule:: docx.composition
 
 

--- a/docs/api/paper-composition.rst
+++ b/docs/api/paper-composition.rst
@@ -73,6 +73,18 @@ inspection, but composition raises |BoundaryViolationError| instead of
 inferring its first or last block. Select exact text inside one paragraph, or
 pass an explicit live block for each endpoint.
 
+Source endpoints are read-only evidence and may be live blocks or spans from
+any supported inspection view. A live destination authorizes mutation only
+when it was captured from ``view="current"``; reacquire a historical target
+from the current view rather than relying on matching text or position.
+
+Composition also refuses when insertion after the complete destination block
+would remain inside an open complex-field result. This applies equally to a
+paragraph destination and to the final table or block content control chosen
+by ``append_document()``. Choose a current-view paragraph after the matching
+field end, or deliberately close or unlink the field before retrying. The
+package does not move the insertion point or repair field markers implicitly.
+
 .. currentmodule:: docx.composition
 
 

--- a/docs/api/paper-fields.rst
+++ b/docs/api/paper-fields.rst
@@ -15,6 +15,11 @@ live |Block| or |Span| destination must be captured from ``view="current"``;
 historical projections remain inspection-only and must be reacquired before
 TOC insertion.
 
+The target passed to ``insert_toc_after()`` must resolve wholly inside one
+paragraph. A multi-paragraph string or live span raises
+|BoundaryViolationError|; choose exact text within the intended paragraph or
+pass an explicit live block.
+
 .. currentmodule:: docx.fields
 
 

--- a/docs/api/paper-formatting.rst
+++ b/docs/api/paper-formatting.rst
@@ -10,6 +10,11 @@ formatting, with correct toggle-property semantics. The operation is read-only.
 Every value in the returned |EffectiveFormat| names its source layer; anything
 the resolver cannot determine is reported as unresolved.
 
+``surrounding_format()`` requires its string or live-span target to resolve
+wholly inside one paragraph. Multi-paragraph spans remain valid search results
+for inspection, but this paragraph-level lookup raises
+|BoundaryViolationError| rather than choosing the first or last paragraph.
+
 .. currentmodule:: docx.formatting
 
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -226,7 +226,12 @@ pairing.
 :ref:`docx.composition <paper_composition_api>` copies formatted content
 between documents without corruption. It reconciles styles, numbering, media,
 hyperlinks and bookmarks, then returns a |CompositionReport| listing every
-part it touched.
+part it touched. Historical live blocks and spans remain valid read-only source
+range evidence, but a live destination must be reacquired from
+``view="current"``. Composition refuses rather than guessing when insertion
+after the destination paragraph, table, or block content control would remain
+inside an open field result; target a current block after the matching field
+end, or deliberately close or unlink that field first.
 
 
 Refusal handling

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -110,6 +110,13 @@ The normalized span is an intentional mutation target, not an inspection-only
 result. APIs outside ``docx.search`` do not repeat the ``match`` keyword; use
 this explicit preselection workflow when they need normalized targeting.
 
+Search can also return spans that cross paragraph boundaries, representing the
+boundary as a literal ``"\\n"``. Those spans are valid for inspection. APIs
+that need one paragraph—block edits, composition endpoints, TOC insertion,
+and ``surrounding_format()``—raise |BoundaryViolationError| instead of choosing
+the first or last paragraph. Refine the text to one paragraph or pass an
+explicit live block endpoint.
+
 When repeated text needs context, use ``near`` to rank the complete candidate
 set for inspection:
 

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -135,10 +135,10 @@ def _resolve_anchor_paragraph(
 ) -> "Tuple[str, _Element]":
     """(story, paragraph element) for `anchor`, staleness-verified.
 
-    Single-target block operations resolve their MUTATION anchor here.
-    Range operations locate every endpoint first, then call the same
-    protection gate. Read-only anchor resolution (e.g. a composition
-    SOURCE range) uses `_locate_anchor_paragraph` directly.
+    Single-target block operations resolve their mutation anchor here. Range
+    operations locate every endpoint first, then call the same protection
+    gate. Read-only resolution (e.g. a composition source range) uses
+    `_locate_anchor_paragraph` directly.
     """
     require_anchor_owner(document, anchor)
     located = _locate_anchor_paragraph(document, anchor)
@@ -174,17 +174,9 @@ def _locate_anchor_paragraph(
     """
     require_anchor_owner(document, anchor)
     if isinstance(anchor, str):
-        span = find_one(document, anchor)
-        paragraph = span._atoms[0].paragraph  # noqa: SLF001 - same-package access
-        if paragraph is None:
-            raise TargetNotFoundError(f"anchor text {anchor!r} is not inside a paragraph")
-        return span.story, paragraph
+        anchor = find_one(document, anchor)
     if isinstance(anchor, Span):
-        anchor._validate_fresh()  # noqa: SLF001 - same-package access
-        paragraph = anchor._atoms[0].paragraph  # noqa: SLF001
-        if paragraph is None:
-            raise TargetNotFoundError("span anchor is not inside a paragraph")
-        return anchor.story, paragraph
+        return _locate_span_paragraph(anchor)
     if isinstance(anchor, Anchor):
         raise UnsupportedStructureError(
             "legacy Anchor values are inert location evidence and cannot"
@@ -194,6 +186,26 @@ def _locate_anchor_paragraph(
     if isinstance(anchor, Block):
         return _locate_live_block(document, anchor)
     raise TypeError(f"unsupported block target {type(anchor).__name__!r}")
+
+
+def _locate_span_paragraph(span: Span) -> "Tuple[str, _Element]":
+    """Resolve `span` only when its complete live selection is one paragraph."""
+    span._validate_fresh()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    atoms = span._atoms  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    paragraph = atoms[0].paragraph
+    if paragraph is None:
+        raise TargetNotFoundError("span anchor is not inside a paragraph")
+    if span.crosses_paragraphs or any(
+        atom.paragraph is not paragraph
+        for atom in atoms
+    ):
+        raise BoundaryViolationError(
+            "this operation requires a target wholly within one paragraph and"
+            " cannot infer first-versus-last intent from a cross-paragraph"
+            " selection; select text wholly within one paragraph or supply an"
+            " explicit live Block endpoint"
+        )
+    return span.story, paragraph
 
 
 def _paragraph_block(story: str, kind: str, element: "_Element") -> "Tuple[str, _Element]":
@@ -555,7 +567,8 @@ def insert_section_after(
 
     With `tracked=True` each inserted paragraph is a real Word insertion attributed to
     `author` (required) and `date`. Refuses a protected document, an undefined heading
-    style, and an anchor that is missing, ambiguous, foreign or stale.
+    style, and an anchor that is missing, ambiguous, foreign, stale, or spans
+    more than one paragraph.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")
@@ -606,8 +619,8 @@ def tracked_delete_paragraphs(
 
     Runs move into `w:del` with formatting intact and the paragraph mark is stamped, so
     accepting removes the paragraphs and rejecting restores them exactly. Refuses a
-    protected document, a range crossing stories or parents, a bookmarked or non-plain run,
-    and an open field.
+    protected document, an endpoint spanning multiple paragraphs, a range
+    crossing stories or parents, a bookmarked or non-plain run, and an open field.
     """
     if not author:
         raise ValueError("author is required")
@@ -648,8 +661,8 @@ def tracked_replace_paragraphs(
     """Tracked-delete a paragraph range and tracked-insert replacements after it.
 
     Returns a `BlockEditResult`. Replacements land after the last deleted paragraph. Carries
-    the same refusals as `tracked_delete_paragraphs`: protection, a range crossing stories,
-    bookmarked or non-plain runs, an open field.
+    the same refusals as `tracked_delete_paragraphs`: protection, a multi-paragraph
+    endpoint, a range crossing stories, bookmarked or non-plain runs, an open field.
     """
     if not author:
         raise ValueError("author is required")
@@ -844,7 +857,7 @@ def insert_blocks_after(
     `blocks` mixes `RichParagraph` (styled runs), `ListBlock` (real bullet or decimal lists,
     numbering definition created on demand) and `TableBlock` (rectangular tables). Reach for
     this when you want structure rather than raw XML. Refuses a protected document, and an
-    anchor that is missing, ambiguous, foreign or stale.
+    anchor that is missing, ambiguous, foreign, stale, or spans more than one paragraph.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -339,20 +339,23 @@ def _field_open_flags(story: str, root: "_Element", element: "_Element"):
     """
     from docx.story import _count_fldchar_delta
 
+    body = root.find(qn("w:body"))
+    if (
+        body is not None
+        and element.tag == qn("w:sdt")
+        and element.getparent() is body
+    ):
+        depth = 0
+        for child in body:
+            if child is element:
+                return depth > 0, (depth + _count_fldchar_delta(element)) > 0
+            depth = max(0, depth + _count_fldchar_delta(child))
+
     depth = 0
     for _kind, _index, block, _sdt, _txbx in _iter_block_elements(story, root):
-        contains = (
-            any(node is block for node in element.iter())
-            if element.tag == qn("w:sdt")
-            else block is element
-            or any(node is element for node in block.iter(_P))
-        )
+        contains = block is element or any(node is element for node in block.iter(_P))
         if contains:
-            # A top-level content control is traversed through its descendant
-            # blocks. Judge its physical end once rather than choosing one of
-            # those descendants as an implied insertion target.
-            target = element if element.tag == qn("w:sdt") else block
-            delta = _count_fldchar_delta(target)
+            delta = _count_fldchar_delta(block)
             return depth > 0, (depth + delta) > 0
         delta = _count_fldchar_delta(block)
         depth = max(0, depth + delta)

--- a/src/docx/blocks.py
+++ b/src/docx/blocks.py
@@ -330,8 +330,8 @@ def _refuse_cell_anchor(paragraph: "_Element") -> None:
         )
 
 
-def _field_open_flags(story: str, root: "_Element", paragraph: "_Element"):
-    """(open_before, open_after) complex-field state around `paragraph`'s block.
+def _field_open_flags(story: str, root: "_Element", element: "_Element"):
+    """(open_before, open_after) complex-field state around `element`'s block.
 
     A multi-paragraph field (every Word TOC) keeps begin..end open across
     blocks; block operations inside that region would write content Word
@@ -340,13 +340,21 @@ def _field_open_flags(story: str, root: "_Element", paragraph: "_Element"):
     from docx.story import _count_fldchar_delta
 
     depth = 0
-    for _kind, _index, element, _sdt, _txbx in _iter_block_elements(story, root):
-        contains = element is paragraph or any(
-            node is paragraph for node in element.iter(_P)
+    for _kind, _index, block, _sdt, _txbx in _iter_block_elements(story, root):
+        contains = (
+            any(node is block for node in element.iter())
+            if element.tag == qn("w:sdt")
+            else block is element
+            or any(node is element for node in block.iter(_P))
         )
-        delta = _count_fldchar_delta(element)
         if contains:
+            # A top-level content control is traversed through its descendant
+            # blocks. Judge its physical end once rather than choosing one of
+            # those descendants as an implied insertion target.
+            target = element if element.tag == qn("w:sdt") else block
+            delta = _count_fldchar_delta(target)
             return depth > 0, (depth + delta) > 0
+        delta = _count_fldchar_delta(block)
         depth = max(0, depth + delta)
     return False, False
 
@@ -361,6 +369,21 @@ def _refuse_paragraph_in_open_field(
             "target lies inside a field result that spans paragraphs (a TOC or"
             " similar); Word regenerates field results on update, so content"
             " written there would silently vanish"
+        )
+
+
+def _refuse_block_in_open_field(  # pyright: ignore[reportUnusedFunction]
+    story: str, root: "_Element", element: "_Element", *, for_insertion: bool
+) -> None:
+    """Refuse a mutation boundary around a supported physical story block."""
+    open_before, open_after = _field_open_flags(story, root, element)
+    blocked = open_after if for_insertion else (open_before or open_after)
+    if blocked:
+        raise UnsupportedStructureError(
+            "the insertion boundary after the destination block remains inside"
+            " an open field result; Word may regenerate that result and remove"
+            " composed content. Use a current-view destination after the matching"
+            " field end, or deliberately close or unlink the field before retrying"
         )
 
 
@@ -486,10 +509,11 @@ def _select_paragraph_range(
     if end_anchor is not None:
         require_anchor_owner(document, end_anchor, argument="end_anchor")
     story, start_p = _locate_anchor_paragraph(document, start_anchor)
-    _require_current_mutation_view(start_anchor)
     end_location = None
     if end_anchor is not None:
         end_location = _locate_anchor_paragraph(document, end_anchor)
+    _require_current_mutation_view(start_anchor)
+    if end_anchor is not None:
         _require_current_mutation_view(end_anchor)
     _refuse_paragraph_mutation(document)
     root = dict(_story_elements(document))[story]

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -174,14 +174,20 @@ def insert_blocks_from(
     validated but does not limit the range. `include_end=False` without an end anchor raises
     `ValueError`. Refuses an empty adjusted range, a protected destination, an endpoint that is
     missing, ambiguous, or spans multiple paragraphs, and source content this package cannot
-    carry over: revisions, comments, OLE objects, EMF/WMF images.
+    carry over: revisions, comments, OLE objects, EMF/WMF images. Live source
+    endpoints may come from any supported inspection view. A live destination
+    must come from ``view="current"``; reacquire a historical destination before
+    composing.
     """
     _validate_styles_mode(styles)
     if end_anchor is None and not include_end:
         raise ValueError("include_end=False requires end_anchor")
     if count < 1:
         raise ValueError("count must be >= 1")
-    from docx.blocks import _locate_anchor_paragraph
+    from docx.blocks import (
+        _locate_anchor_paragraph,  # pyright: ignore[reportPrivateUsage]
+        _require_current_mutation_view,  # pyright: ignore[reportPrivateUsage]
+    )
 
     start_target = _locate_anchor_paragraph(source, start_anchor)
     end_target = (
@@ -190,6 +196,7 @@ def insert_blocks_from(
         else None
     )
     anchor_story, anchor_p = _locate_anchor_paragraph(document, anchor)
+    _require_current_mutation_view(anchor)  # pyright: ignore[reportUnknownArgumentType]
     _refuse_if_protected(document, "compose content into the document")
     range_elements = _source_range(
         source,
@@ -224,7 +231,8 @@ def append_document(
     `section="new_page"` prefixes a page break, `"continuous"` appends flush.
     `headers="source"` overwrites the destination's last-section header and footer and flips
     the document-wide even/odd setting. Refuses a protected document and an empty body on
-    either side.
+    either side. Also refuses when insertion after the destination's final paragraph,
+    table, or block content control would remain inside an open field result.
     """
     _validate_styles_mode(styles)
     if section not in ("new_page", "continuous"):
@@ -431,15 +439,15 @@ def _compose(
     document: "Document",
     source: "Document",
     range_elements: "List[_Element]",
-    anchor,
+    anchor: "_Element",
     styles_mode: str,
     *,
     anchor_story: str,
 ) -> CompositionReport:
     from docx.blocks import (
-        _insert_after,
-        _refuse_cell_anchor,
-        _refuse_paragraph_in_open_field,
+        _insert_after,  # pyright: ignore[reportPrivateUsage]
+        _refuse_block_in_open_field,  # pyright: ignore[reportPrivateUsage]
+        _refuse_cell_anchor,  # pyright: ignore[reportPrivateUsage]
     )
 
     report = CompositionReport()
@@ -455,8 +463,8 @@ def _compose(
         )
     if anchor_p.tag == _P:
         _refuse_cell_anchor(anchor_p)
-        root = next(r for s, r in _story_elements_of(document) if s == story)
-        _refuse_paragraph_in_open_field(story, root, anchor_p, for_insertion=True)
+    root = next(r for s, r in _story_elements_of(document) if s == story)
+    _refuse_block_in_open_field(story, root, anchor_p, for_insertion=True)
     _refuse_malformed_numeric_ids(document, range_elements)
     _preflight_bookmark_references(source, range_elements)
     _preflight_relationships(source.part, range_elements)

--- a/src/docx/composition.py
+++ b/src/docx/composition.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from docx._guard import check_install
-from docx._ownership import require_anchor_owner
 from docx._transaction import rollback_on_error
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.fields import _set_update_fields_on_open
@@ -173,28 +172,42 @@ def insert_blocks_from(
     that endpoint's block. With no `end_anchor`, `count` blocks are copied beginning at the start
     block or the following block when `include_start=False`. With an `end_anchor`, `count` is
     validated but does not limit the range. `include_end=False` without an end anchor raises
-    `ValueError`. Refuses an empty adjusted range, a protected destination, an anchor that is
-    missing or ambiguous, and source content this package cannot carry over: revisions,
-    comments, OLE objects, EMF/WMF images.
+    `ValueError`. Refuses an empty adjusted range, a protected destination, an endpoint that is
+    missing, ambiguous, or spans multiple paragraphs, and source content this package cannot
+    carry over: revisions, comments, OLE objects, EMF/WMF images.
     """
     _validate_styles_mode(styles)
     if end_anchor is None and not include_end:
         raise ValueError("include_end=False requires end_anchor")
-    require_anchor_owner(source, start_anchor, argument="start_anchor")
-    if end_anchor is not None:
-        require_anchor_owner(source, end_anchor, argument="end_anchor")
-    require_anchor_owner(document, anchor)
+    if count < 1:
+        raise ValueError("count must be >= 1")
+    from docx.blocks import _locate_anchor_paragraph
+
+    start_target = _locate_anchor_paragraph(source, start_anchor)
+    end_target = (
+        _locate_anchor_paragraph(source, end_anchor)
+        if end_anchor is not None
+        else None
+    )
+    anchor_story, anchor_p = _locate_anchor_paragraph(document, anchor)
     _refuse_if_protected(document, "compose content into the document")
     range_elements = _source_range(
         source,
-        start_anchor,
-        end_anchor,
+        start_target,
+        end_target,
         count,
         include_start=include_start,
         include_end=include_end,
     )
     with rollback_on_error(document):
-        return _compose(document, source, range_elements, anchor, styles)
+        return _compose(
+            document,
+            source,
+            range_elements,
+            anchor_p,
+            styles,
+            anchor_story=anchor_story,
+        )
 
 
 def append_document(
@@ -233,7 +246,7 @@ def append_document(
             range_elements,
             destination_blocks[-1],
             styles,
-            anchor_is_element=True,
+            anchor_story="word/document.xml",
         )
         if section == "new_page":
             break_paragraph = OxmlElement("w:p")
@@ -341,18 +354,14 @@ def _defined_header_footer(hf):
 
 def _source_range(
     source: "Document",
-    start_anchor,
-    end_anchor,
+    start_target: "Tuple[str, _Element]",
+    end_target: "Optional[Tuple[str, _Element]]",
     count: int,
     *,
     include_start: bool,
     include_end: bool,
 ) -> "List[_Element]":
-    from docx.blocks import _locate_anchor_paragraph
-
-    if count < 1:
-        raise ValueError("count must be >= 1")
-    story, start_p = _locate_anchor_paragraph(source, start_anchor)
+    story, start_p = start_target
     if story != "word/document.xml":
         raise UnsupportedStructureError(
             f"composition copies from the main document body only (start anchor is in {story})"
@@ -367,8 +376,8 @@ def _source_range(
             " table cells cannot anchor a composition range)"
         )
     start_index = blocks.index(start_block)
-    if end_anchor is not None:
-        end_story, end_p = _locate_anchor_paragraph(source, end_anchor)
+    if end_target is not None:
+        end_story, end_p = end_target
         end_block = _body_block_for_paragraph(body, end_p)
         if end_story != story or end_block not in blocks:
             raise UnsupportedStructureError(
@@ -425,13 +434,12 @@ def _compose(
     anchor,
     styles_mode: str,
     *,
-    anchor_is_element: bool = False,
+    anchor_story: str,
 ) -> CompositionReport:
     from docx.blocks import (
         _insert_after,
         _refuse_cell_anchor,
         _refuse_paragraph_in_open_field,
-        _resolve_anchor_paragraph,
     )
 
     report = CompositionReport()
@@ -440,14 +448,12 @@ def _compose(
     # importing styles/numbering/media first would leave orphaned
     # definitions behind when the destination anchor turns out invalid
     _refuse_unsupported_content(range_elements)
-    if anchor_is_element:
-        story, anchor_p = "word/document.xml", anchor
-    else:
-        story, anchor_p = _resolve_anchor_paragraph(document, anchor)
-        if story != "word/document.xml":
-            raise UnsupportedStructureError(
-                f"composition inserts into the main document body only (anchor is in {story})"
-            )
+    story, anchor_p = anchor_story, anchor
+    if story != "word/document.xml":
+        raise UnsupportedStructureError(
+            f"composition inserts into the main document body only (anchor is in {story})"
+        )
+    if anchor_p.tag == _P:
         _refuse_cell_anchor(anchor_p)
         root = next(r for s, r in _story_elements_of(document) if s == story)
         _refuse_paragraph_in_open_field(story, root, anchor_p, for_insertion=True)

--- a/src/docx/fields.py
+++ b/src/docx/fields.py
@@ -200,7 +200,7 @@ def insert_toc_after(
 
     Marked dirty so the renderer builds the real table on open; heading `levels` maps to the
     \\o "1-3" switch. Refuses a protected document, and an anchor that is missing, ambiguous
-    or foreign.
+    foreign, or spans more than one paragraph.
     """
     from docx.blocks import _insert_after, _resolve_anchor_paragraph
 

--- a/src/docx/formatting.py
+++ b/src/docx/formatting.py
@@ -161,7 +161,7 @@ def surrounding_format(document: "Document", anchor) -> EffectiveFormat:
 
     Use it so inserted text adopts its neighbours' look. Resolves the anchor paragraph's
     first text run; an empty paragraph resolves the paragraph's own properties. Refuses an
-    anchor that is missing or ambiguous.
+    anchor that is missing, ambiguous, or spans more than one paragraph.
     """
     from docx.blocks import _locate_anchor_paragraph
 

--- a/tests/paper/test_audit_composition.py
+++ b/tests/paper/test_audit_composition.py
@@ -163,6 +163,12 @@ def _field_boundary_destination(kind: str, *, closed: bool):
             )
         return document
 
+    if kind == "empty_control":
+        control = OxmlElement("w:sdt")
+        control.extend((OxmlElement("w:sdtPr"), OxmlElement("w:sdtContent")))
+        _insert_before_sect(document, control)
+        return document
+
     control = _top_level_control(text="Destination control")
     if closed:
         paragraph = next(control.iter(qn("w:p")))
@@ -313,7 +319,9 @@ def it_keeps_current_composition_destinations_authoritative(
     ]
 
 
-@pytest.mark.parametrize("kind", ["paragraph", "table", "control"])
+@pytest.mark.parametrize(
+    "kind", ["paragraph", "table", "control", "empty_control"]
+)
 def it_refuses_composition_at_every_open_top_level_field_boundary_before_imports(
     kind: str, monkeypatch: Any
 ) -> None:

--- a/tests/paper/test_audit_composition.py
+++ b/tests/paper/test_audit_composition.py
@@ -165,6 +165,43 @@ def it_refuses_foreign_span_anchors_before_destination_protection() -> None:
     assert _package_state(destination) == destination_before
 
 
+@pytest.mark.parametrize("invalid_endpoint", ["source_start", "source_end", "destination"])
+def it_preflights_every_composition_endpoint_before_destination_protection(
+    invalid_endpoint: str,
+) -> None:
+    source = docx.Document()
+    source.add_paragraph("Source before")
+    source.add_paragraph("source alpha end")
+    source.add_paragraph("source beta start")
+    source.add_paragraph("Source after")
+    destination = docx.Document()
+    destination.add_paragraph("Destination before")
+    destination.add_paragraph("destination alpha end")
+    destination.add_paragraph("destination beta start")
+    source_cross = find_one(source, "source alpha end\nsource beta start")
+    destination_cross = find_one(
+        destination, "destination alpha end\ndestination beta start"
+    )
+    start_anchor = source_cross if invalid_endpoint == "source_start" else "Source before"
+    end_anchor = source_cross if invalid_endpoint == "source_end" else None
+    anchor = destination_cross if invalid_endpoint == "destination" else "Destination before"
+    _protect(destination)
+    source_before = _package_state(source)
+    destination_before = _package_state(destination)
+
+    with pytest.raises(BoundaryViolationError, match="wholly within one paragraph"):
+        insert_blocks_from(
+            destination,
+            source,
+            start_anchor,
+            end_anchor=end_anchor,
+            anchor=anchor,
+        )
+
+    assert _package_state(source) == source_before
+    assert _package_state(destination) == destination_before
+
+
 def it_refuses_a_foreign_comment_proxy_even_with_a_colliding_id() -> None:
     source = docx.Document()
     source_run = source.add_paragraph("Source anchor").runs[0]

--- a/tests/paper/test_audit_composition.py
+++ b/tests/paper/test_audit_composition.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import docx
+import docx.composition as composition_module
 from docx.blocks import insert_section_after
 from docx.bookmarks import (
     _NAME_RE,
@@ -21,7 +23,7 @@ from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import BoundaryViolationError, UnsupportedStructureError
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
-from docx.search import find_one
+from docx.search import Span, find_one
 from docx.story import iter_blocks
 
 from .harness.contract import save_and_reopen
@@ -30,8 +32,8 @@ _SECT_PR = qn("w:sectPr")
 _SDT = qn("w:sdt")
 
 
-def _package_state(document) -> tuple:
-    parts = []
+def _package_state(document: Any) -> tuple[Any, ...]:
+    parts: list[Any] = []
     for part in document.part.package.iter_parts():
         relationships = tuple(
             sorted(
@@ -130,6 +132,45 @@ def _top_level_control(
     return control
 
 
+def _append_field_char(paragraph: Any, kind: str) -> None:
+    run = OxmlElement("w:r")
+    marker = OxmlElement("w:fldChar")
+    marker.set(qn("w:fldCharType"), kind)
+    run.append(marker)
+    paragraph.append(run)
+
+
+def _field_boundary_destination(kind: str, *, closed: bool):
+    document = docx.Document()
+    _clear_body(document)
+    if kind == "paragraph":
+        paragraph = document.add_paragraph()
+        _append_field_char(paragraph._p, "begin")  # pyright: ignore[reportPrivateUsage]
+        paragraph.add_run("Destination anchor")
+        if closed:
+            _append_field_char(paragraph._p, "end")  # pyright: ignore[reportPrivateUsage]
+        return document
+
+    opener = document.add_paragraph()
+    _append_field_char(opener._p, "begin")  # pyright: ignore[reportPrivateUsage]
+    if kind == "table":
+        table = document.add_table(rows=1, cols=1)
+        table.cell(0, 0).text = "Destination table"
+        if closed:
+            _append_field_char(
+                table.cell(0, 0).paragraphs[0]._p,  # pyright: ignore[reportPrivateUsage]
+                "end",
+            )
+        return document
+
+    control = _top_level_control(text="Destination control")
+    if closed:
+        paragraph = next(control.iter(qn("w:p")))
+        _append_field_char(paragraph, "end")
+    _insert_before_sect(document, control)
+    return document
+
+
 def _unsupported_top_level(kind: str):
     if kind == "customXml":
         wrapper = OxmlElement("w:customXml")
@@ -200,6 +241,130 @@ def it_preflights_every_composition_endpoint_before_destination_protection(
 
     assert _package_state(source) == source_before
     assert _package_state(destination) == destination_before
+
+
+@pytest.mark.parametrize("view", ["original", "all"])
+@pytest.mark.parametrize("target_kind", ["block", "span"])
+def it_requires_current_live_composition_destinations(
+    view: str, target_kind: str
+) -> None:
+    source = docx.Document()
+    source.add_paragraph("Source block")
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    if target_kind == "block":
+        target = next(
+            block
+            for block in iter_blocks(destination, view=view)
+            if block.kind == "paragraph" and block.text == "Destination anchor"
+        )
+    else:
+        target = find_one(destination, "Destination anchor", view=view)
+    source_before = _package_state(source)
+    destination_before = _package_state(destination)
+
+    with pytest.raises(UnsupportedStructureError) as raised:
+        insert_blocks_from(
+            destination,
+            source,
+            "Source block",
+            anchor=target,
+        )
+
+    assert f"view='{view}'" in str(raised.value)
+    assert 'view="current"' in str(raised.value)
+    assert _package_state(source) == source_before
+    assert _package_state(destination) == destination_before
+    if target_kind == "span":
+        assert isinstance(target, Span)
+        target._validate_fresh()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.parametrize("target_kind", ["string", "block", "span"])
+def it_keeps_current_composition_destinations_authoritative(
+    target_kind: str,
+) -> None:
+    source = docx.Document()
+    source.add_paragraph("Source block")
+    destination = docx.Document()
+    destination.add_paragraph("Destination anchor")
+    if target_kind == "string":
+        target = "Destination anchor"
+    elif target_kind == "block":
+        target = next(
+            block
+            for block in iter_blocks(destination)
+            if block.kind == "paragraph" and block.text == "Destination anchor"
+        )
+    else:
+        target = find_one(destination, "Destination anchor")
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        "Source block",
+        anchor=target,
+    )
+
+    assert report.inserted_blocks == 1
+    assert [paragraph.text for paragraph in destination.paragraphs] == [
+        "Destination anchor",
+        "Source block",
+    ]
+
+
+@pytest.mark.parametrize("kind", ["paragraph", "table", "control"])
+def it_refuses_composition_at_every_open_top_level_field_boundary_before_imports(
+    kind: str, monkeypatch: Any
+) -> None:
+    source = docx.Document()
+    source.add_paragraph("Source block")
+    destination = _field_boundary_destination(kind, closed=False)
+    source_before = _package_state(source)
+    destination_before = _package_state(destination)
+    entered_imports = False
+    def record_import(*args: Any, **kwargs: Any) -> None:
+        nonlocal entered_imports
+        entered_imports = True
+        raise AssertionError("composition imports began before destination preflight")
+
+    monkeypatch.setattr(composition_module, "_reconcile_styles", record_import)
+
+    def operation():
+        if kind == "paragraph":
+            return insert_blocks_from(
+                destination,
+                source,
+                "Source block",
+                anchor="Destination anchor",
+            )
+        return append_document(destination, source)
+
+    with pytest.raises(UnsupportedStructureError, match="matching field end"):
+        operation()
+
+    assert not entered_imports
+    assert _package_state(source) == source_before
+    assert _package_state(destination) == destination_before
+
+
+def it_composes_after_a_field_closed_inside_the_destination_paragraph() -> None:
+    source = docx.Document()
+    source.add_paragraph("Source block")
+    destination = _field_boundary_destination("paragraph", closed=True)
+
+    report = insert_blocks_from(
+        destination,
+        source,
+        "Source block",
+        anchor="Destination anchor",
+    )
+
+    assert report.inserted_blocks == 1
+    assert [paragraph.text for paragraph in destination.paragraphs] == [
+        "Destination anchor",
+        "Source block",
+    ]
 
 
 def it_refuses_a_foreign_comment_proxy_even_with_a_colliding_id() -> None:
@@ -274,7 +439,7 @@ def it_keeps_historical_live_composition_sources_view_neutral(
         end = find_one(source, "Second source block", view=view)
     destination = docx.Document()
     destination.add_paragraph("Destination anchor")
-    source_before = _package_state(source)  # pyright: ignore[reportUnknownVariableType]
+    source_before = _package_state(source)
 
     report = insert_blocks_from(
         destination,

--- a/tests/paper/test_blocks.py
+++ b/tests/paper/test_blocks.py
@@ -350,6 +350,38 @@ class DescribeMutationProjectionAuthority:
 
         assert "view='original'" in str(refusal)
 
+    @pytest.mark.parametrize("invalid_end", ["stale", "foreign"])
+    def it_checks_end_identity_before_historical_start_authority(
+        self, invalid_end: str
+    ):
+        document = _memory_doc("start", "end")
+        start = find_one(document, "start", view="original")
+        foreign = None
+        foreign_before = None
+        if invalid_end == "stale":
+            end = find_one(document, "end")
+            document.paragraphs[1].text = "changed end"
+            refusal_type = TargetNotFoundError
+        else:
+            foreign = _memory_doc("end")
+            end = find_one(foreign, "end")
+            foreign_before = foreign.element.xml
+            refusal_type = BoundaryViolationError
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda doc: tracked_delete_paragraphs(
+                doc, start, end_anchor=end, author="A", date=FROZEN
+            ),
+            refusal_type,
+        )
+
+        assert "view='original'" not in str(refusal)
+        if invalid_end == "foreign":
+            assert foreign is not None
+            assert foreign_before is not None
+            assert foreign.element.xml == foreign_before
+
     @pytest.mark.parametrize("operation", _BLOCK_MUTATIONS)
     @pytest.mark.parametrize("target_kind", ["block", "span"])
     def it_keeps_current_live_targets_authoritative(

--- a/tests/paper/test_blocks.py
+++ b/tests/paper/test_blocks.py
@@ -61,6 +61,115 @@ def _memory_doc(*texts: str):
     return document
 
 
+def _cross_paragraph_target(document):
+    return find_one(document, "alpha end\nbeta start")
+
+
+class DescribeOneParagraphTargets:
+    @pytest.mark.parametrize(
+        ("operation", "as_string"),
+        [
+            (
+                lambda document, target: insert_section_after(
+                    document, target, heading="wrong", paragraphs=[]
+                ),
+                True,
+            ),
+            (
+                lambda document, target: insert_blocks_after(
+                    document,
+                    target,
+                    blocks=[RichParagraph(runs=[TextRun("wrong")])],
+                ),
+                False,
+            ),
+        ],
+    )
+    def it_refuses_string_derived_and_supplied_cross_paragraph_targets_atomically(
+        self, operation, as_string: bool
+    ):
+        document = _memory_doc("alpha end", "beta start", "after")
+        span = _cross_paragraph_target(document)
+        target = span.text if as_string else span
+        set_protection(document, edit="readOnly")
+
+        error = assert_refusal_atomic(
+            document,
+            lambda doc: operation(doc, target),
+            BoundaryViolationError,
+        )
+
+        assert "wholly within one paragraph" in str(error)
+        assert "explicit live Block" in str(error)
+
+    @pytest.mark.parametrize("crosses_paragraphs", [False, True])
+    def it_checks_both_summary_evidence_and_concrete_atom_identity(
+        self, crosses_paragraphs: bool
+    ):
+        document = _memory_doc("alpha end", "beta start")
+        if crosses_paragraphs:
+            span = find_one(document, "alpha end")
+            span.crosses_paragraphs = True
+        else:
+            span = _cross_paragraph_target(document)
+            span.crosses_paragraphs = False
+
+        with pytest.raises(BoundaryViolationError, match="one paragraph"):
+            insert_section_after(document, span, heading="wrong", paragraphs=[])
+
+    @pytest.mark.parametrize("invalid_endpoint", ["start", "end"])
+    @pytest.mark.parametrize("operation", ["delete", "replace"])
+    def it_validates_both_range_endpoints_before_protection(
+        self, invalid_endpoint: str, operation: str
+    ):
+        document = _memory_doc("before", "alpha end", "beta start", "after")
+        cross = _cross_paragraph_target(document)
+        start = cross if invalid_endpoint == "start" else "before"
+        end = cross if invalid_endpoint == "end" else "after"
+        set_protection(document, edit="readOnly")
+
+        def mutate(doc):
+            if operation == "delete":
+                return tracked_delete_paragraphs(
+                    doc, start, end_anchor=end, author="Reviewer"
+                )
+            return tracked_replace_paragraphs(
+                doc, start, ["wrong"], end_anchor=end, author="Reviewer"
+            )
+
+        assert_refusal_atomic(document, mutate, BoundaryViolationError)
+
+    def it_keeps_a_live_one_paragraph_span_as_a_valid_target(self):
+        document = _memory_doc("before", "target text", "after")
+        target = find_one(document, "target")
+
+        insert_section_after(document, target, heading="inserted", paragraphs=[])
+
+        assert _texts(document) == ["before", "target text", "inserted", "after"]
+
+    def it_keeps_stale_span_taxonomy_before_protection(self):
+        document = _memory_doc("target text")
+        target = find_one(document, "target")
+        document.paragraphs[0].text = "changed text"
+        set_protection(document, edit="readOnly")
+
+        assert_refusal_atomic(
+            document,
+            lambda doc: insert_section_after(
+                doc, target, heading="wrong", paragraphs=[]
+            ),
+            TargetNotFoundError,
+        )
+
+    def it_keeps_missing_paragraph_taxonomy(self):
+        document = _memory_doc("target text")
+        target = find_one(document, "target")
+        target._atoms[0].paragraph = None  # noqa: SLF001 - defensive same-package shape
+
+        with pytest.raises(TargetNotFoundError, match="not inside a paragraph"):
+            insert_section_after(document, target, heading="wrong", paragraphs=[])
+
+
 class DescribeLiveBlockTargets:
     def it_follows_the_exact_element_across_an_index_shift(self):
         document = _memory_doc("A", "target", "C")

--- a/tests/paper/test_composition.py
+++ b/tests/paper/test_composition.py
@@ -519,9 +519,8 @@ class DescribeAppendDocument:
         report = append_document(destination, source, section="continuous")
 
         assert report.inserted_blocks == 1
-        report_payload = report.to_dict()
-        assert report_payload["schema"] == "paper_composition"  # pyright: ignore[reportUnknownMemberType]
-        assert report_payload["version"] == 1  # pyright: ignore[reportUnknownMemberType]
+        assert report.to_dict()["schema"] == "paper_composition"  # pyright: ignore[reportUnknownMemberType]
+        assert report.to_dict()["version"] == 1  # pyright: ignore[reportUnknownMemberType]
         out = _saved(destination, tmp_path / f"closed-field-{kind}.docx")
         assert_changed_parts(original, out, {"word/document.xml"})
         reopened = docx.Document(str(out))

--- a/tests/paper/test_composition.py
+++ b/tests/paper/test_composition.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
 import docx
 from docx.composition import append_document, insert_blocks_from
+from docx.document import Document
 from docx.errors import (
     DocumentProtectedError,
     UnsupportedStructureError,
 )
+from docx.oxml.ns import qn
+from docx.oxml.parser import OxmlElement
 
 from .harness import checks
 from .harness.paths import fixture_path
@@ -25,6 +29,55 @@ TINY_PNG = bytes.fromhex(
     "53de0000000c4944415408d763f8cfc000000301010018dd8db00000000049"
     "454e44ae426082"
 )
+
+_SECT_PR = qn("w:sectPr")
+
+
+def _clear_body(document: Document) -> None:
+    body = cast(Any, document.element).body
+    for child in list(body):
+        if child.tag != _SECT_PR:
+            body.remove(child)
+
+
+def _append_field_char(paragraph: Any, kind: str) -> None:
+    run = OxmlElement("w:r")
+    marker = OxmlElement("w:fldChar")
+    marker.set(qn("w:fldCharType"), kind)
+    run.append(marker)
+    paragraph.append(run)
+
+
+def _closed_field_append_destination(kind: str) -> Document:
+    document = docx.Document()
+    _clear_body(document)
+    opener = document.add_paragraph()
+    _append_field_char(opener._p, "begin")  # pyright: ignore[reportPrivateUsage]
+    opener.add_run("Field result begins")
+    if kind == "table":
+        table = document.add_table(rows=1, cols=1)
+        table.cell(0, 0).text = "Destination table"
+        _append_field_char(
+            table.cell(0, 0).paragraphs[0]._p,  # pyright: ignore[reportPrivateUsage]
+            "end",
+        )
+        return document
+
+    control = OxmlElement("w:sdt")
+    control.append(OxmlElement("w:sdtPr"))
+    content = OxmlElement("w:sdtContent")
+    paragraph = OxmlElement("w:p")
+    run = OxmlElement("w:r")
+    text = OxmlElement("w:t")
+    text.text = "Destination control"
+    run.append(text)
+    paragraph.append(run)
+    _append_field_char(paragraph, "end")
+    content.append(paragraph)
+    control.append(content)
+    body = cast(Any, document.element).body
+    body.insert(len(body) - 1, control)
+    return document
 
 
 def _saved(document, path: Path) -> Path:
@@ -451,6 +504,37 @@ class DescribeAppendDocument:
         destination = docx.Document(str(fixture_path(MINIMAL)))
         append_document(destination, _source_with_styles(), section="continuous")
         assert 'w:type="page"' not in destination.element.xml
+
+    @pytest.mark.parametrize("kind", ["table", "control"])
+    def it_appends_after_a_field_closed_inside_the_final_physical_block(
+        self, kind: str, tmp_path: Path
+    ):
+        source = docx.Document()
+        _clear_body(source)
+        source.add_paragraph("Appended after closed field")
+        destination = _closed_field_append_destination(kind)
+
+        report = append_document(destination, source, section="continuous")
+
+        assert report.inserted_blocks == 1
+        assert report.to_dict()["schema"] == "paper_composition"  # pyright: ignore[reportUnknownMemberType]
+        out = _saved(destination, tmp_path / f"closed-field-{kind}.docx")
+        reopened = docx.Document(str(out))
+        body = cast(Any, reopened.element).body
+        body_blocks: list[Any] = [
+            child
+            for child in body
+            if child.tag != _SECT_PR
+        ]
+        assert [child.tag.rsplit("}", 1)[-1] for child in body_blocks] == [
+            "p",
+            "tbl" if kind == "table" else "sdt",
+            "p",
+        ]
+        assert "".join(
+            node.text or "" for node in body_blocks[-1].iter(qn("w:t"))
+        ) == "Appended after closed field"
+        assert 'w:type="page"' not in reopened.element.xml
 
     def it_keeps_destination_headers(self, tmp_path: Path):
         destination = docx.Document(

--- a/tests/paper/test_composition.py
+++ b/tests/paper/test_composition.py
@@ -19,6 +19,7 @@ from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 
 from .harness import checks
+from .harness.contract import assert_changed_parts
 from .harness.paths import fixture_path
 
 MINIMAL = "generated/minimal-clean/minimal.docx"
@@ -513,12 +514,16 @@ class DescribeAppendDocument:
         _clear_body(source)
         source.add_paragraph("Appended after closed field")
         destination = _closed_field_append_destination(kind)
+        original = _saved(destination, tmp_path / f"closed-field-{kind}-before.docx")
 
         report = append_document(destination, source, section="continuous")
 
         assert report.inserted_blocks == 1
-        assert report.to_dict()["schema"] == "paper_composition"  # pyright: ignore[reportUnknownMemberType]
+        report_payload = report.to_dict()
+        assert report_payload["schema"] == "paper_composition"  # pyright: ignore[reportUnknownMemberType]
+        assert report_payload["version"] == 1  # pyright: ignore[reportUnknownMemberType]
         out = _saved(destination, tmp_path / f"closed-field-{kind}.docx")
+        assert_changed_parts(original, out, {"word/document.xml"})
         reopened = docx.Document(str(out))
         body = cast(Any, reopened.element).body
         body_blocks: list[Any] = [

--- a/tests/paper/test_formatting.py
+++ b/tests/paper/test_formatting.py
@@ -11,6 +11,7 @@ import pytest
 
 import docx
 from docx.enum.style import WD_STYLE_TYPE
+from docx.errors import BoundaryViolationError
 from docx.formatting import format_of, surrounding_format
 from docx.search import find_one
 from docx.shared import Pt
@@ -100,8 +101,8 @@ class DescribeStyleChainResolution:
         assert resolved["size_pt"].source == "character_style:Emph"
 
     def it_survives_a_based_on_cycle(self):
-        from docx.oxml.parser import parse_xml
         from docx.oxml.ns import nsdecls
+        from docx.oxml.parser import parse_xml
 
         document = _doc()
         styles = document.styles.element
@@ -197,3 +198,14 @@ class DescribeSurroundingFormat:
         assert resolved["style_name"].value == "Heading 1"
         # Heading 1 in the default template resolves sz through its chain
         assert resolved["size_pt"].value is not None
+
+    @pytest.mark.parametrize("as_string", [True, False])
+    def it_refuses_a_cross_paragraph_target(self, as_string: bool):
+        document = docx.Document()
+        document.add_paragraph("alpha end")
+        document.add_paragraph("beta start")
+        span = find_one(document, "alpha end\nbeta start")
+        target = span.text if as_string else span
+
+        with pytest.raises(BoundaryViolationError, match="one paragraph"):
+            surrounding_format(document, target)

--- a/tests/paper/test_missing_apis.py
+++ b/tests/paper/test_missing_apis.py
@@ -15,14 +15,14 @@ from docx.commentops import COMMENTS_IDS_RELATIONSHIP_TYPE, delete_comment
 from docx.composition import CompositionReport, _copy_letterhead, append_document
 from docx.controls import _part_root, get_control, set_control_value
 from docx.drawing import Drawing
+from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import (
     BoundaryViolationError,
     DocumentProtectedError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
-from docx.fields import add_caption
-from docx.enum.style import WD_STYLE_TYPE
+from docx.fields import add_caption, insert_toc_after
 from docx.links import add_hyperlink
 from docx.notes import add_endnote, add_footnote
 from docx.numbering import apply_numbering, ensure_decimal_definition, list_numbering
@@ -35,7 +35,7 @@ from docx.oxml.parser import OxmlElement, parse_xml
 from docx.protection import acknowledge_protection, set_protection
 from docx.search import find_one
 
-from .harness.contract import save_and_reopen
+from .harness.contract import assert_refusal_atomic, save_and_reopen
 from .harness.paths import fixture_path
 
 MINIMAL = "generated/minimal-clean/minimal.docx"
@@ -44,6 +44,24 @@ STORE_ID = "{11111111-1111-1111-1111-111111111111}"
 
 def _doc(relpath: str = MINIMAL):
     return docx.Document(str(fixture_path(relpath)))
+
+
+@pytest.mark.parametrize("as_string", [True, False])
+def it_toc_refuses_cross_paragraph_targets_before_protection(as_string: bool):
+    document = docx.Document()
+    document.add_paragraph("alpha end")
+    document.add_paragraph("beta start")
+    span = find_one(document, "alpha end\nbeta start")
+    target = span.text if as_string else span
+    set_protection(document, edit="readOnly")
+
+    error = assert_refusal_atomic(
+        document,
+        lambda doc: insert_toc_after(doc, target),
+        BoundaryViolationError,
+    )
+
+    assert "one paragraph" in str(error)
 
 
 def _bmp(red: int, green: int, blue: int) -> bytes:

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -87,12 +87,13 @@ class DescribeFindText:
         assert "Net 30" in span.text  # captured text preserves the raw NBSP
 
     def it_matches_across_a_paragraph_boundary(self):
-        spans = find_text(
-            _doc(MINIMAL), "ordinary text.\nSecond body paragraph"
-        )
+        document = _doc(MINIMAL)
+        needle = "ordinary text.\nSecond body paragraph"
+        spans = find_text(document, needle)
         assert len(spans) == 1
-        assert spans[0].text == "ordinary text.\nSecond body paragraph"
+        assert spans[0].text == needle
         assert spans[0].crosses_paragraphs
+        assert find_one(document, needle).crosses_paragraphs
 
     @pytest.mark.parametrize(
         ("document_text", "needle"),
@@ -695,6 +696,19 @@ class DescribePreservationPolicies:
 
 
 class DescribeReplaceRefusals:
+    def it_narrows_a_cross_paragraph_match_to_a_same_paragraph_change(self):
+        document = docx.Document()
+        document.add_paragraph("alpha end")
+        document.add_paragraph("beta start")
+        span = find_one(document, "alpha end\nbeta start")
+
+        span.replace("ALPHA end beta start")
+
+        assert [paragraph.text for paragraph in document.paragraphs] == [
+            "ALPHA end",
+            "beta start",
+        ]
+
     def it_refuses_spans_over_deleted_text(self):
         document = _doc(TRACKED)
         span = find_one(document, "forty-two", view="all")


### PR DESCRIPTION
## Why

A span may cross paragraphs for inspection, but a paragraph mutation must not silently choose its first paragraph or infer an endpoint.

## Final behavior

- Paragraph-level edits require a target wholly inside one paragraph.
- Composition and field-boundary checks use current-view, canonical boundary evidence.
- Cross-paragraph, detached, foreign, stale-view, and unsupported targets refuse before mutation.
- Empty top-level content-control boundaries are handled explicitly.

## Stack

Parent: #45. Child: #47. Published head: `80a88af6208303fd8f7a3b1478e776b4cdd3aaed`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes anchor resolution and composition preflight across core editing paths; mistakes could block valid edits or miss unsafe insertions, but behavior is explicit refusals with broad new tests.
> 
> **Overview**
> Paragraph-level APIs now **require anchors that resolve wholly inside one paragraph**. Cross-paragraph search spans stay valid for inspection, but block edits, `surrounding_format()`, `insert_toc_after()`, and composition endpoints raise **`BoundaryViolationError`** instead of picking the first or last paragraph. String targets follow the same rule via `find_one` → `_locate_span_paragraph`.
> 
> **Composition** resolves and validates every source endpoint and the destination **before** protection or imports: multi-paragraph endpoints refuse atomically; live destinations must come from **`view="current"`** (historical views remain OK for read-only source ranges). Insertion after the destination block uses **`_refuse_block_in_open_field`**, including `append_document()` when the final paragraph, table, or top-level content control still sits inside an open complex-field result; **`_field_open_flags`** also accounts for body-level SDTs.
> 
> Range block operations validate **both** endpoints (including foreign/stale ends) before the current-view gate. User and API docs describe these contracts; tests cover refusal ordering, field boundaries, and happy paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24fe1454207c9d7e5d54db5cbf820726fae8f5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->