### PR TITLE
fix: preserve formatting regions and consume mutated spans

### DIFF
--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -71,12 +71,13 @@ before the document is searched. To use contextual ranking for inspection:
 Choose a replacement policy
 ---------------------------
 
-Ordinary replacement is preservation-safe by default. It first leaves the
-longest exact unchanged prefix and suffix in their existing text atoms, then
-changes only the residual interval. That interval must be one materially
-uniform formatting and structural region. Complete run-property XML, resolved
-effective values and provenance, and live semantic scopes must agree; a
-positional marker or non-text run node cannot sit inside the changed interval.
+Ordinary replacement is preservation-safe by default. It considers every exact
+prefix/suffix split that preserves the maximal number of characters, then
+changes a residual interval only when all maximal alignments agree on that
+interval and one writable formatting/inline-ancestry destination. One changed
+text node supplies local evidence; multiple changed nodes must have identical
+complete run-property XML and full inline ancestry. A positional marker or
+non-text run node cannot sit inside the changed interval.
 
 .. list-table::
    :header-rows: 1

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -71,8 +71,12 @@ before the document is searched. To use contextual ranking for inspection:
 Choose a replacement policy
 ---------------------------
 
-All preservation modes are opt-in. Existing calls retain the ordinary
-untracked behavior.
+Ordinary replacement is preservation-safe by default. It first leaves the
+longest exact unchanged prefix and suffix in their existing text atoms, then
+changes only the residual interval. That interval must be one materially
+uniform formatting and structural region. Complete run-property XML, resolved
+effective values and provenance, and live semantic scopes must agree; a
+positional marker or non-text run node cannot sit inside the changed interval.
 
 .. list-table::
    :header-rows: 1
@@ -83,8 +87,9 @@ untracked behavior.
      - Contract
    * - Ordinary untracked edit
      - ``span.replace(text)``
-     - The replacement takes the start run's formatting. Untouched runs keep
-       their formatting, but selected text may be redistributed between runs.
+     - Preserves exact unchanged affixes and replaces one proved uniform
+       formatting/structural region. Mixed, unresolved, scope-crossing, or
+       marker-crossing intent refuses before mutation.
    * - Author a new redline
      - ``span.replace(text, tracked=True, author=...)``
      - Emits a minimal ``w:del``/``w:ins`` pair and consumes the span. A direct
@@ -124,17 +129,34 @@ no longer describe the same text. A no-op still runs the full preflight and
 reports preservation evidence, but changes nothing and leaves the span
 reusable.
 
-|ReplaceResult| sets ``preserved_structure`` when exact topology was requested
-and satisfied. ``preserved_revision_ids`` contains the existing insertion ID
-only when an insertion was actually retained; it is empty for base text.
+|ReplaceResult| sets ``preserved_formatting_regions`` only when the ordinary
+untracked planner proved this regional contract, including a fully preflighted
+no-op. Tracked edits and empty-cell creation report false. The flag is
+orthogonal to ``preserved_revision_ids``: an authorized correction inside one
+existing insertion reports both the preserved insertion ID and formatting-
+region evidence. ``preserved_structure`` remains separate, and
 ``revision_ids`` continues to identify only newly authored revisions.
 ``replace_all`` accepts the same replacement options plus the same exact-by-
 default ``match`` policy, records each per-match
 |PaperRefusal| while continuing independent matches, and retains one batch
 transaction. A stale target aborts and rolls back the batch. Matches already
 equal to the replacement are skipped rather than producing no-op results.
-The direct and batch ``to_dict()`` payloads retain their schema discriminators
-and earlier keys.
+After an ordinary no-op the span remains reusable. After mutation, the span is
+refreshed to the exact live contributing atoms and offsets when that interval
+is still representable after empty atoms are removed. A complete deletion or
+other unrepresentable result consumes it; re-find the text before another
+operation. No successful span retains stale coordinates. Because a no-op has
+no text assignments, it does not apply a hypothetical mutation's bookmark-
+hollowing check; all non-bookmark safety and uniform-region preflight still
+runs.
+
+When a replacement refuses because the changed interval is mixed or crosses a
+marker, target a smaller span wholly inside one formatting/structural region.
+Markers and differently formatted text wholly contained in exact unchanged
+affixes remain in their original elements and order.
+
+The direct and batch ``to_dict()`` payloads use schema version 2 and retain
+their earlier keys while adding ``preserved_formatting_regions``.
 
 These contracts describe the edited XML structure. They do not promise raw
 byte identity inside a changed package part; use :func:`docx.package.patch_save`

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -74,10 +74,10 @@ Choose a replacement policy
 Ordinary replacement is preservation-safe by default. It considers every exact
 prefix/suffix split that preserves the maximal number of characters, then
 changes a residual interval only when all maximal alignments agree on that
-interval and one writable formatting/inline-ancestry destination. One changed
-text node supplies local evidence; multiple changed nodes must have identical
-complete run-property XML and full inline ancestry. A positional marker or
-non-text run node cannot sit inside the changed interval.
+interval. A nonempty residual inherits the complete direct formatting of its
+starting text run. All changed text must remain within one concrete inline
+wrapper chain. A positional marker or non-text run node cannot sit inside the
+changed interval.
 
 .. list-table::
    :header-rows: 1
@@ -89,14 +89,16 @@ non-text run node cannot sit inside the changed interval.
    * - Ordinary untracked edit
      - ``span.replace(text)``
      - Preserves exact unchanged affixes only when maximal alignment identifies
-       one changed interval and one formatting/inline-ancestry destination.
-       Ambiguous, mixed, scope-crossing, or marker-crossing intent refuses.
+       one changed interval. Replacement text takes the starting run's direct
+       formatting. Ambiguous alignment, wrapper-owner crossings, or marker
+       crossings refuse.
    * - Author a new redline
      - ``span.replace(text, tracked=True, author=...)``
      - Uses the same unique maximal affix localization, then emits a minimal
-       ``w:del``/``w:ins`` pair only when inserted text has one complete
-       formatting/inline-ancestry destination. A direct tracked no-op is
-       refused and a successful change consumes the span.
+       ``w:del``/``w:ins`` pair. Inserted text takes the changed interval's
+       starting run properties; deleted pieces retain their source properties.
+       A direct tracked no-op is refused and a successful change consumes the
+       span.
    * - Correct one existing insertion
      - ``span.replace(text, preserve_revision=True)``
      - For a current-view span wholly owned by one ``w:ins``, keeps that
@@ -128,17 +130,19 @@ ancestry agree; otherwise the operation refuses with guidance to re-find and
 replace only the intended exact substring. This private narrowing is an
 optimization, not a text selector or proof of author intent.
 
-A changed interval inside one text node keeps that node's complete formatting.
-When it spans multiple text nodes, their complete canonical ``w:rPr`` and full
-inline ancestry must agree. This comparison includes generic wrappers such as
-hyperlinks, revisions, controls, smart tags, ``customXml``, and directional
-containers; it does not infer equivalence from a partial effective-format model.
-For tracked edits that insert text, this proof determines the one run-property
-and ancestry outcome for the new ``w:ins``. A deletion-only tracked edit needs
-unique localization but may cross differently formatted source runs because
-each ``w:del/w:r`` retains its own complete source properties. When the proof
-is ambiguous, target a smaller uniform substring or construct the intended
-formatting and structure explicitly.
+A nonempty replacement takes the complete direct ``w:rPr`` of the text run
+where the uniquely localized changed interval starts. Later consumed runs may
+have different direct formatting; their changed text intentionally collapses
+into that starting format. Unchanged affixes and untouched boundary fragments
+remain in their original runs. Tracked deletion markup retains each source
+run's own properties, while inserted markup uses the same start-run rule.
+
+Formatting differences alone do not authorize moving text between wrapper
+objects. A changed interval spanning distinct hyperlinks, revisions, controls,
+smart tags, ``customXml`` elements, or other inline wrapper owners refuses even
+when their serialized XML is identical. Pure insertions at a boundary also
+refuse unless both sides prove the same complete formatting and concrete
+wrapper destination.
 
 Exact topology means structural preservation, not preservation of inferred
 formatting intent. Replacement text fills each selected text-node slice from
@@ -152,10 +156,22 @@ no longer describe the same text. A no-op still runs the full preflight and
 reports preservation evidence, but changes nothing and leaves the span
 reusable.
 
-|ReplaceResult| sets ``preserved_formatting_regions`` for a successful ordinary
-untracked replacement. For a no-op, it records that no formatting changed; a
-no-op is not a formatting probe and leaves the span reusable. Tracked edits and
-empty-cell creation report false. The flag is
+For example, if ``Alpha`` consists of bold ``Al`` followed by italic ``pha``,
+replacing the whole word with ``Omega`` produces bold ``Omega`` because the
+changed interval starts in the bold run. Starting the same match in the italic
+run instead produces italic replacement text.
+
+Ordinary replacement never distributes new text according to prior text-node
+lengths. Existing field,
+content-control, hyperlink, revision, protection, bookmark, and paragraph-
+boundary guards still apply. Required ``xml:space`` updates and placeholder
+cleanup are part of a successful ordinary edit.
+
+|ReplaceResult| sets ``preserved_formatting_regions`` only when a successful
+ordinary untracked replacement did not collapse differently formatted changed
+runs into the starting run. For a no-op, it records that no formatting changed;
+a no-op is not a formatting probe and leaves the span reusable. Tracked edits
+and empty-cell creation report false. The flag is
 orthogonal to ``preserved_revision_ids``: an authorized correction inside one
 existing insertion reports both the preserved insertion ID and formatting-
 region evidence. ``preserved_structure`` remains separate, and
@@ -173,10 +189,10 @@ does not return or expose the private spans it uses for each match. Because a
 no-op has no text assignments, it does not apply a hypothetical mutation's
 bookmark-hollowing or changed-region checks.
 
-When a replacement refuses because the changed interval is mixed or crosses a
-marker, target a smaller span wholly inside one formatting/structural region.
-Markers and differently formatted text wholly contained in exact unchanged
-affixes remain in their original elements and order.
+When a replacement refuses because the changed interval crosses wrapper owners
+or a marker, target a smaller span wholly inside one structural region. Markers
+and differently formatted text wholly contained in exact unchanged affixes
+remain in their original elements and order.
 
 The direct and batch ``to_dict()`` payloads use schema version 2 and retain
 their earlier keys while adding ``preserved_formatting_regions``.

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -141,14 +141,14 @@ default ``match`` policy, records each per-match
 |PaperRefusal| while continuing independent matches, and retains one batch
 transaction. A stale target aborts and rolls back the batch. Matches already
 equal to the replacement are skipped rather than producing no-op results.
-After an ordinary no-op the span remains reusable. After mutation, the span is
-refreshed to the exact live contributing atoms and offsets when that interval
-is still representable after empty atoms are removed. A complete deletion or
-other unrepresentable result consumes it; re-find the text before another
-operation. No successful span retains stale coordinates. Because a no-op has
-no text assignments, it does not apply a hypothetical mutation's bookmark-
-hollowing check; all non-bookmark safety and uniform-region preflight still
-runs.
+Every successful text-changing direct ``Span.replace()`` consumes the supplied
+span. Use the returned result as the mutation evidence and re-find the text
+before another operation. A direct no-op, preflight refusal, or rolled-back
+mutation changes nothing and leaves the supplied span reusable. ``replace_all``
+does not return or expose the private spans it uses for each match. Because a
+no-op has no text assignments, it does not apply a hypothetical mutation's
+bookmark-hollowing check; all non-bookmark safety and uniform-region preflight
+still runs.
 
 When a replacement refuses because the changed interval is mixed or crosses a
 marker, target a smaller span wholly inside one formatting/structural region.

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -87,9 +87,9 @@ positional marker or non-text run node cannot sit inside the changed interval.
      - Contract
    * - Ordinary untracked edit
      - ``span.replace(text)``
-     - Preserves exact unchanged affixes and replaces one proved uniform
-       formatting/structural region. Mixed, unresolved, scope-crossing, or
-       marker-crossing intent refuses before mutation.
+     - Preserves exact unchanged affixes only when maximal alignment identifies
+       one changed interval and one formatting/inline-ancestry destination.
+       Ambiguous, mixed, scope-crossing, or marker-crossing intent refuses.
    * - Author a new redline
      - ``span.replace(text, tracked=True, author=...)``
      - Emits a minimal ``w:del``/``w:ins`` pair and consumes the span. A direct
@@ -117,6 +117,20 @@ lets ``replace_all`` apply one policy to both base text and insertion-owned
 matches. ``preserve_structure=True`` alone does not authorize an edit inside
 an insertion; request both guarantees for that case.
 
+Ordinary replacement considers every non-overlapping exact prefix/suffix split
+that preserves the maximal number of characters. It narrows only when all
+maximal splits identify the same changed interval. A pure insertion may choose
+between adjacent text nodes only when their complete run properties and inline
+ancestry agree; otherwise the operation refuses with guidance to re-find and
+replace only the intended exact substring. This private narrowing is not a text
+selector and does not change tracked replacement behavior.
+
+A changed interval inside one text node keeps that node's complete formatting.
+When it spans multiple text nodes, their complete canonical ``w:rPr`` and full
+inline ancestry must agree. This comparison includes generic wrappers such as
+hyperlinks, revisions, controls, smart tags, ``customXml``, and directional
+containers; it does not infer equivalence from a partial effective-format model.
+
 Exact topology means structural preservation, not preservation of inferred
 formatting intent. Replacement text fills each selected text-node slice from
 left to right up to that slice's original capacity; the final selected node
@@ -129,9 +143,10 @@ no longer describe the same text. A no-op still runs the full preflight and
 reports preservation evidence, but changes nothing and leaves the span
 reusable.
 
-|ReplaceResult| sets ``preserved_formatting_regions`` only when the ordinary
-untracked planner proved this regional contract, including a fully preflighted
-no-op. Tracked edits and empty-cell creation report false. The flag is
+|ReplaceResult| sets ``preserved_formatting_regions`` for a successful ordinary
+untracked replacement. For a no-op, it records that no formatting changed; a
+no-op is not a formatting probe and leaves the span reusable. Tracked edits and
+empty-cell creation report false. The flag is
 orthogonal to ``preserved_revision_ids``: an authorized correction inside one
 existing insertion reports both the preserved insertion ID and formatting-
 region evidence. ``preserved_structure`` remains separate, and
@@ -147,8 +162,7 @@ before another operation. A direct no-op, preflight refusal, or rolled-back
 mutation changes nothing and leaves the supplied span reusable. ``replace_all``
 does not return or expose the private spans it uses for each match. Because a
 no-op has no text assignments, it does not apply a hypothetical mutation's
-bookmark-hollowing check; all non-bookmark safety and uniform-region preflight
-still runs.
+bookmark-hollowing or changed-region checks.
 
 When a replacement refuses because the changed interval is mixed or crosses a
 marker, target a smaller span wholly inside one formatting/structural region.

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -93,8 +93,10 @@ non-text run node cannot sit inside the changed interval.
        Ambiguous, mixed, scope-crossing, or marker-crossing intent refuses.
    * - Author a new redline
      - ``span.replace(text, tracked=True, author=...)``
-     - Emits a minimal ``w:del``/``w:ins`` pair and consumes the span. A direct
-       tracked no-op is refused.
+     - Uses the same unique maximal affix localization, then emits a minimal
+       ``w:del``/``w:ins`` pair only when inserted text has one complete
+       formatting/inline-ancestry destination. A direct tracked no-op is
+       refused and a successful change consumes the span.
    * - Correct one existing insertion
      - ``span.replace(text, preserve_revision=True)``
      - For a current-view span wholly owned by one ``w:ins``, keeps that
@@ -118,19 +120,25 @@ lets ``replace_all`` apply one policy to both base text and insertion-owned
 matches. ``preserve_structure=True`` alone does not authorize an edit inside
 an insertion; request both guarantees for that case.
 
-Ordinary replacement considers every non-overlapping exact prefix/suffix split
+Ordinary and tracked replacement consider every non-overlapping exact prefix/suffix split
 that preserves the maximal number of characters. It narrows only when all
 maximal splits identify the same changed interval. A pure insertion may choose
 between adjacent text nodes only when their complete run properties and inline
 ancestry agree; otherwise the operation refuses with guidance to re-find and
-replace only the intended exact substring. This private narrowing is not a text
-selector and does not change tracked replacement behavior.
+replace only the intended exact substring. This private narrowing is an
+optimization, not a text selector or proof of author intent.
 
 A changed interval inside one text node keeps that node's complete formatting.
 When it spans multiple text nodes, their complete canonical ``w:rPr`` and full
 inline ancestry must agree. This comparison includes generic wrappers such as
 hyperlinks, revisions, controls, smart tags, ``customXml``, and directional
 containers; it does not infer equivalence from a partial effective-format model.
+For tracked edits that insert text, this proof determines the one run-property
+and ancestry outcome for the new ``w:ins``. A deletion-only tracked edit needs
+unique localization but may cross differently formatted source runs because
+each ``w:del/w:r`` retains its own complete source properties. When the proof
+is ambiguous, target a smaller uniform substring or construct the intended
+formatting and structure explicitly.
 
 Exact topology means structural preservation, not preservation of inferred
 formatting intent. Replacement text fills each selected text-node slice from

--- a/docs/api/paper-tableops.rst
+++ b/docs/api/paper-tableops.rst
@@ -33,6 +33,17 @@ simpler uniform template. Complex templates are never repaired or flattened.
 Rows with ``gridBefore``/``gridAfter``, omitted grid columns, or horizontal
 merges are not positional templates and refuse before the table is mutated.
 
+``insert_row_after()`` copies row, cell, and paragraph properties, then fills
+each physical cell as one run. A copied cell is accepted only when it contains
+exactly one direct paragraph of plain direct text runs and all text-bearing
+runs have identical complete explicit run properties; an ordinary unformatted
+empty cell is also accepted. Every cell is checked while the copied row is
+detached, before any cell is populated or the row is attached. Conflicting run
+properties, extra paragraphs, fields, controls, revisions, hyperlinks,
+markers, drawings, nested content, and unknown wrappers raise
+|UnsupportedStructureError| with the template row/cell and guidance to use a
+simpler uniform template. Complex templates are never repaired or flattened.
+
 .. currentmodule:: docx.tableops
 
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -162,7 +162,11 @@ Choose the option that matches the edit's preservation contract:
 
 - Use the default for an ordinary untracked correction inside one proved
   uniform region. Arbitrary same-format run fragmentation is supported; the
-  first run is never treated as representative of mixed text.
+  first run is never treated as representative of mixed text. Exact unchanged
+  affixes stay in place only when maximal alignment identifies one changed
+  interval and one complete formatting/inline-ancestry destination. If repeated
+  affixes or an insertion boundary leave more than one outcome, re-find and
+  replace only the intended exact substring.
 - Use ``tracked=True`` with ``author=...`` to author a new ``w:ins``/``w:del``
   redline.
 - Use ``preserve_revision=True`` only to correct current-view text wholly

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -183,10 +183,10 @@ evidence are in :ref:`docx.search <paper_search_api>`.
 Successful ordinary results report ``preserved_formatting_regions=True``.
 That evidence is independent of ``preserved_revision_ids``: correcting text
 inside one authorized existing insertion reports both. Tracked edits and
-empty-cell creation report false. A no-op leaves its span reusable; a mutating
-ordinary span refreshes to the exact live result when possible and is consumed
-with re-find guidance after an unrepresentable result such as complete
-deletion.
+empty-cell creation report false. Every successful text-changing direct
+replacement consumes its supplied span; use the returned result and re-find
+before another operation. A direct no-op, refusal, or rolled-back mutation
+leaves the span reusable.
 
 :ref:`docx.blocks <paper_blocks_api>` does the clause-level equivalent (insert,
 delete or replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -168,7 +168,12 @@ Choose the option that matches the edit's preservation contract:
   affixes or an insertion boundary leave more than one outcome, re-find and
   replace only the intended exact substring.
 - Use ``tracked=True`` with ``author=...`` to author a new ``w:ins``/``w:del``
-  redline.
+  redline. Tracked edits use the same unique maximal affix localization. Any
+  inserted text requires one complete formatting and inline-ancestry
+  destination; if the selected changed text has competing outcomes, target a
+  smaller uniform substring or construct the intended formatting explicitly.
+  Deletion-only tracked edits may cross differently formatted source runs
+  because each deleted run retains its own properties.
 - Use ``preserve_revision=True`` only to correct current-view text wholly
   inside one existing insertion while retaining that insertion's attribution
   and accept/reject behavior. The correction remains attributed to the

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -101,12 +101,14 @@ does not search strings or resolve blocks.
 Edit one document
 -----------------
 
-|Span| replaces matched text only when the changed interval is one materially
-uniform formatting and structural region. Exact unchanged prefix and suffix
-text stays in its original runs, formatting, semantic scopes, and marker
-order. A mixed or unresolved region, semantic-scope boundary, or positional
-marker inside the changed interval raises |UnsupportedStructureError| before
-mutation; find and replace a smaller span on one side.
+|Span| replaces matched text only when exact affix alignment identifies one
+changed interval within one concrete wrapper owner. Exact unchanged prefix and
+suffix text stays in its original runs, formatting, semantic scopes, and marker
+order. Nonempty replacement text takes the complete direct formatting of the
+changed interval's starting run. Ambiguous alignment, a wrapper-owner boundary,
+or a positional marker inside the changed interval raises
+|UnsupportedStructureError| before mutation; find and replace a smaller span
+on one side.
 
 ::
 
@@ -160,20 +162,18 @@ evidence, retain the deliberately chosen live span, or refine an ordinary
 
 Choose the option that matches the edit's preservation contract:
 
-- Use the default for an ordinary untracked correction inside one proved
-  uniform region. Arbitrary same-format run fragmentation is supported; the
-  first run is never treated as representative of mixed text. Exact unchanged
-  affixes stay in place only when maximal alignment identifies one changed
-  interval and one complete formatting/inline-ancestry destination. If repeated
-  affixes or an insertion boundary leave more than one outcome, re-find and
-  replace only the intended exact substring.
+- Use the default for an ordinary untracked correction inside one concrete
+  wrapper owner. Exact unchanged affixes stay in place when maximal alignment
+  identifies one changed interval. Nonempty replacement text takes the complete
+  direct formatting of that interval's starting run, even when it consumes
+  later runs with different formatting. If repeated affixes or an insertion
+  boundary leave more than one outcome, re-find and replace only the intended
+  exact substring.
 - Use ``tracked=True`` with ``author=...`` to author a new ``w:ins``/``w:del``
   redline. Tracked edits use the same unique maximal affix localization. Any
-  inserted text requires one complete formatting and inline-ancestry
-  destination; if the selected changed text has competing outcomes, target a
-  smaller uniform substring or construct the intended formatting explicitly.
-  Deletion-only tracked edits may cross differently formatted source runs
-  because each deleted run retains its own properties.
+  inserted text follows the same start-run formatting rule. Separate inline
+  wrapper owners still refuse; deletion markup retains each source run's own
+  properties.
 - Use ``preserve_revision=True`` only to correct current-view text wholly
   inside one existing insertion while retaining that insertion's attribution
   and accept/reject behavior. The correction remains attributed to the
@@ -185,17 +185,21 @@ Choose the option that matches the edit's preservation contract:
 - Combine the two preservation options when both contracts apply. Neither can
   be combined with ``tracked=True``.
 
+Ordinary replacement changes the proved regional interval without allocating
+text according to old text-node lengths. If structural ownership is ambiguous,
+target a smaller span inside one wrapper owner.
+
 These are text-structure contracts, not a promise that the serialized bytes of
 the changed XML part remain identical. The full refusal rules and result
 evidence are in :ref:`docx.search <paper_search_api>`.
 
-Successful ordinary results report ``preserved_formatting_regions=True``.
-That evidence is independent of ``preserved_revision_ids``: correcting text
-inside one authorized existing insertion reports both. Tracked edits and
-empty-cell creation report false. Every successful text-changing direct
-replacement consumes its supplied span; use the returned result and re-find
-before another operation. A direct no-op, refusal, or rolled-back mutation
-leaves the span reusable.
+Successful ordinary results report ``preserved_formatting_regions=True`` only
+when the changed text did not collapse multiple direct formatting regions into
+the starting run. That evidence is independent of ``preserved_revision_ids``.
+Tracked edits and empty-cell creation report false. Every successful
+text-changing direct replacement consumes its supplied span; use the returned
+result and re-find before another operation. A direct no-op, refusal, or
+rolled-back mutation leaves the span reusable.
 
 :ref:`docx.blocks <paper_blocks_api>` does the clause-level equivalent (insert,
 delete or replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -101,7 +101,12 @@ does not search strings or resolve blocks.
 Edit one document
 -----------------
 
-|Span| replaces matched text while untouched runs retain their formatting.
+|Span| replaces matched text only when the changed interval is one materially
+uniform formatting and structural region. Exact unchanged prefix and suffix
+text stays in its original runs, formatting, semantic scopes, and marker
+order. A mixed or unresolved region, semantic-scope boundary, or positional
+marker inside the changed interval raises |UnsupportedStructureError| before
+mutation; find and replace a smaller span on one side.
 
 ::
 
@@ -155,8 +160,9 @@ evidence, retain the deliberately chosen live span, or refine an ordinary
 
 Choose the option that matches the edit's preservation contract:
 
-- Use the default for an ordinary untracked correction. The replacement takes
-  the start run's formatting.
+- Use the default for an ordinary untracked correction inside one proved
+  uniform region. Arbitrary same-format run fragmentation is supported; the
+  first run is never treated as representative of mixed text.
 - Use ``tracked=True`` with ``author=...`` to author a new ``w:ins``/``w:del``
   redline.
 - Use ``preserve_revision=True`` only to correct current-view text wholly
@@ -173,6 +179,14 @@ Choose the option that matches the edit's preservation contract:
 These are text-structure contracts, not a promise that the serialized bytes of
 the changed XML part remain identical. The full refusal rules and result
 evidence are in :ref:`docx.search <paper_search_api>`.
+
+Successful ordinary results report ``preserved_formatting_regions=True``.
+That evidence is independent of ``preserved_revision_ids``: correcting text
+inside one authorized existing insertion reports both. Tracked edits and
+empty-cell creation report false. A no-op leaves its span reusable; a mutating
+ordinary span refreshes to the exact live result when possible and is consumed
+with re-find guidance after an unrepresentable result such as complete
+deletion.
 
 :ref:`docx.blocks <paper_blocks_api>` does the clause-level equivalent (insert,
 delete or replace whole paragraphs). :ref:`docx.tableops <paper_tableops_api>` and

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -419,6 +419,8 @@ class _OrdinaryOutcome:
 
     replacement: str
     segments: "Tuple[Tuple[int, int, int], ...]"
+    changed_start: int
+    changed_end: int
 
 
 def _maximal_affix_decompositions(
@@ -451,6 +453,14 @@ def _refuse_ambiguous_affix_alignment() -> None:
         "exact affix alignment is ambiguous; re-find and replace only the"
         " exact substring you intend to change (for example, 'payment' with"
         " 'settlement')"
+    )
+
+
+def _refuse_ambiguous_insertion_destination() -> None:
+    raise UnsupportedStructureError(
+        "the insertion point has competing formatting or structural"
+        " destinations; re-find a smaller span with one uniform destination"
+        " or construct the intended formatting and structure explicitly"
     )
 
 
@@ -557,7 +567,7 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
             not _same_destination(first_evidence, _destination_evidence(atom))
             for atom in candidate_atoms[1:]
         ):
-            _refuse_ambiguous_affix_alignment()
+            _refuse_ambiguous_insertion_destination()
         _refuse_intervening_positional_nodes(candidate_atoms)
         destination_index, destination_offset = candidates[0]
         segments = ((destination_index, destination_offset, destination_offset),)
@@ -589,6 +599,8 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
     return _OrdinaryOutcome(
         replacement=replacement,
         segments=segments,
+        changed_start=changed_start,
+        changed_end=changed_end,
     )
 
 
@@ -644,7 +656,8 @@ def _validate_one_formatting_region(atoms: "Sequence[_Atom]") -> None:
     if any(not _same_destination(evidence[0], item) for item in evidence[1:]):
         raise UnsupportedStructureError(
             "the changed interval crosses formatting or structural regions;"
-            " target and replace a smaller span within one uniform region"
+            " target and replace a smaller span within one uniform region,"
+            " or construct the intended formatting and structure explicitly"
         )
 
 
@@ -897,9 +910,7 @@ class Span:
             cursor += len(text)
         return positions
 
-    def _narrow_to_change(
-        self, new_text: str, *, ambiguity_safe: bool = False
-    ) -> "Optional[Tuple[Span, str]]":
+    def _narrow_to_change(self, new_text: str) -> "Optional[Tuple[Span, str]]":
         """A sub-span covering only the changed region, or None if the trim
         cannot shrink this span (caller falls through to normal validation).
 
@@ -907,9 +918,8 @@ class Span:
         aligns with an existing tab/break: callers cannot write `\\t`,
         so "Section 4. Termination" against "Section 3.<TAB>Termination"
         keeps the document's tab and changes only the "3" — matching is
-        normalized, documents keep their original characters. Ordinary edits
-        require one maximal alignment; tracked edits retain their established
-        greedy alignment.
+        normalized, documents keep their original characters. Every edit
+        requires one maximal alignment.
         """
         synthetic = self._synthetic_positions()
         old = self.text
@@ -919,27 +929,10 @@ class Span:
                 old_pos in synthetic and new_text[new_pos].isspace()
             )
 
-        if ambiguity_safe:
-            decompositions = _maximal_affix_decompositions(old, new_text, aligned)
-            if len(decompositions) != 1:
-                _refuse_ambiguous_affix_alignment()
-            prefix_len, suffix_len = decompositions[0]
-        else:
-            # Tracked replacement retains its established greedy narrowing.
-            prefix_len = 0
-            limit = min(len(old), len(new_text))
-            while prefix_len < limit and aligned(prefix_len, prefix_len):
-                prefix_len += 1
-            suffix_len = 0
-            while (
-                suffix_len < len(old) - prefix_len
-                and suffix_len < len(new_text) - prefix_len
-                and aligned(
-                    len(old) - suffix_len - 1,
-                    len(new_text) - suffix_len - 1,
-                )
-            ):
-                suffix_len += 1
+        decompositions = _maximal_affix_decompositions(old, new_text, aligned)
+        if len(decompositions) != 1:
+            _refuse_ambiguous_affix_alignment()
+        prefix_len, suffix_len = decompositions[0]
         if prefix_len == 0 and suffix_len == 0:
             return None
         changed_old = self.text[prefix_len : len(self.text) - suffix_len]
@@ -1216,8 +1209,12 @@ class Span:
         affix text stays in its existing atoms. Ambiguous alignments, changed intervals spanning
         different complete run properties or inline ancestry, semantic-scope crossings, and
         positional-marker crossings refuse instead of adopting one run's formatting. A changed
-        interval inside one text node uses that node's formatting. `tracked=True` instead emits
-        a minimal `w:del`/`w:ins` pair and consumes the span; a direct tracked no-op is refused.
+        interval inside one text node uses that node's formatting. `tracked=True` uses the same
+        unique localization and emits a minimal `w:del`/`w:ins` pair only when nonempty inserted
+        text has one complete formatting/inline-ancestry destination. Deletion-only tracked edits
+        retain each source run's properties. Ambiguity tells the caller to target a smaller
+        uniform substring or construct explicit formatting; it is never repaired internally.
+        A successful tracked change consumes the span; a direct tracked no-op is refused.
 
         `preserve_revision=True` explicitly permits a current-view span wholly owned by one
         existing `w:ins` to be corrected without changing that insertion's id, author, date,
@@ -1260,6 +1257,7 @@ class Span:
         preserve_structure: bool,
         preserve_revision: bool,
         use_transaction: bool,
+        tracked_context: "Optional[Tuple[Tuple[Optional[_Element], ...], bool]]" = None,
     ) -> ReplaceResult:
         """Implementation shared with the already-transactional batch path."""
         _validate_replacement_options(
@@ -1267,9 +1265,9 @@ class Span:
             preserve_structure=preserve_structure,
             preserve_revision=preserve_revision,
         )
-        if tracked and not author:
-            raise ValueError("author is required when tracked=True")
         if tracked:
+            if not author:
+                raise ValueError("author is required when tracked=True")
             # the w:ins/w:del identity attributes are stamped AFTER mutation
             # begins; malformed values must refuse before anything changes
             _validate_xml_characters(author, argument="author")
@@ -1278,17 +1276,29 @@ class Span:
         _validate_writable_text(new_text, argument="new_text")
         _refuse_if_protected(self._document, "replace text")
         self._validate_fresh()
-        if (
-            not preserve_structure
-            and (any(atom.is_synthetic for atom in self._atoms) or self.crosses_paragraphs)
+        if tracked and tracked_context is None:
+            tracked_context = _tracked_layering_context(self, author)  # type: ignore[arg-type]
+        if tracked and self.text == new_text:
+            raise TargetNotFoundError(
+                "replacement equals the existing text; nothing to change"
+            )
+        if not preserve_structure and (
+            tracked
+            or any(atom.is_synthetic for atom in self._atoms)
+            or self.crosses_paragraphs
         ):
+            if tracked and not (
+                any(atom.is_synthetic for atom in self._atoms)
+                or self.crosses_paragraphs
+            ):
+                # Retained affixes may stay outside the changed interval, but
+                # they cannot make a cross-scope target authoritative.
+                self._validate_replaceable(validate_bookmarks=False)
             # spans matched ACROSS a tab/break/paragraph boundary may still
             # edit safely when the actual change lies within one segment:
             # narrow to the changed region; if the change itself crosses a
             # break or boundary, validation below refuses as before
-            narrowed = self._narrow_to_change(
-                new_text, ambiguity_safe=not tracked
-            )
+            narrowed = self._narrow_to_change(new_text)
             if narrowed is not None:
                 sub_span, sub_new = narrowed
 
@@ -1301,6 +1311,7 @@ class Span:
                         preserve_structure=False,
                         preserve_revision=preserve_revision,
                         use_transaction=False,
+                        tracked_context=tracked_context,
                     )
                     self._consumed = True
                     return result
@@ -1418,7 +1429,13 @@ class Span:
                 preserved_formatting_regions=True,
             )
         if tracked:
-            result = self._tracked_replace(new_text, author=author, date=date)  # type: ignore[arg-type]
+            assert author is not None
+            result = self._tracked_replace(
+                new_text,
+                author=author,
+                date=date,
+                tracked_context=tracked_context,
+            )
         else:
             return self._plain_replace(
                 new_text,
@@ -1469,7 +1486,12 @@ class Span:
         return result
 
     def _tracked_replace(
-        self, new_text: str, *, author: str, date: Optional[dt.datetime]
+        self,
+        new_text: str,
+        *,
+        author: str,
+        date: Optional[dt.datetime],
+        tracked_context: "Optional[Tuple[Tuple[Optional[_Element], ...], bool]]",
     ) -> ReplaceResult:
         from docx.oxml.revision import CT_RunTrackChange
 
@@ -1490,44 +1512,21 @@ class Span:
         # extending their own insertion where the span starts in base
         # text and ends in/at their insertion (their inserted text is simply
         # removed, never re-marked as a base-text deletion).
-        enclosing = [_enclosing_insertion(atom.element) for atom in self._atoms]
-        scopes = {id(e) if e is not None else None for e in enclosing}
-        extends_own_insertion = False
-        if len(scopes) > 1:
-            non_none = [e for e in enclosing if e is not None]
-            all_own = all(
-                e.tag == _INS and (e.get(_W_AUTHOR) or "") == author for e in non_none
-            )
-            inside_seen = False
-            contiguous_tail = True
-            for e in enclosing:
-                if e is not None:
-                    inside_seen = True
-                elif inside_seen:
-                    contiguous_tail = False
-                    break
-            if not (all_own and enclosing[0] is None and contiguous_tail):
-                raise UnsupportedStructureError(
-                    "span overlaps a pending tracked insertion it cannot layer"
-                    " over (different author, a tracked move, or base text"
-                    " following the insertion); accept or reject the existing"
-                    " revision first, or target text inside or outside it"
-                )
-            extends_own_insertion = True
-        if self.text == new_text:
-            raise TargetNotFoundError(
-                "replacement equals the existing text; nothing to change"
-            )
-        prefix_len, suffix_len = _common_affix_lengths(self.text, new_text)
+        if tracked_context is None:
+            tracked_context = _tracked_layering_context(self, author)
+        enclosing, extends_own_insertion = tracked_context
+        outcome = _ordinary_outcome(self, new_text)
+        prefix_len = outcome.changed_start
+        suffix_len = len(self.text) - outcome.changed_end
         first, last = self._atoms[0], self._atoms[-1]
-        if first is not last:
-            # kept characters must never cross run boundaries (they would
-            # silently adopt another run's formatting): clamp the trim so the
-            # prefix stays in the first run and the suffix in the last
-            prefix_len = min(prefix_len, len(first.text) - self._start_offset)
-            suffix_len = min(suffix_len, self._end_offset)
-        old_mid = self.text[prefix_len : len(self.text) - suffix_len]
-        new_mid = new_text[prefix_len : len(new_text) - suffix_len]
+        old_mid = self.text[outcome.changed_start : outcome.changed_end]
+        new_mid = outcome.replacement
+        changed_atoms = [
+            self._atoms[index] for index, _start, _end in outcome.segments
+        ]
+        _refuse_intervening_positional_nodes(changed_atoms)
+        if new_mid:
+            _validate_one_formatting_region(changed_atoms)
         stamp = date if date is not None else _clock.now()
         next_id = _next_revision_id(self._document)
         rpr = first.run.find(_RPR) if first.run is not None else None
@@ -1543,8 +1542,9 @@ class Span:
         deleted_pieces = _pieces_in_range(
             span_pieces, prefix_len, len(self.text) - suffix_len
         )
-        # the inserted text renders with the first CHANGED run's formatting
-        ins_source_run = deleted_pieces[0][0] if deleted_pieces else first.run
+        # Formatting/ancestry equality above proves that any changed source
+        # atom describes the same insertion destination.
+        ins_source_run = changed_atoms[0].run if changed_atoms else first.run
         ins_rpr = (
             ins_source_run.find(_RPR) if ins_source_run is not None else None
         )
@@ -1670,6 +1670,41 @@ def _enclosing_insertion(element: "_Element") -> "Optional[_Element]":
             return node
         node = node.getparent()
     return None
+
+
+def _tracked_layering_context(
+    span: Span, author: str
+) -> "Tuple[Tuple[Optional[_Element], ...], bool]":
+    """Validate revision scopes before affix narrowing hides retained text."""
+    enclosing = tuple(
+        _enclosing_insertion(atom.element)
+        for atom in span._atoms  # pyright: ignore[reportPrivateUsage]
+    )
+    scopes = {id(element) if element is not None else None for element in enclosing}
+    if len(scopes) <= 1:
+        return enclosing, False
+
+    non_none = [element for element in enclosing if element is not None]
+    all_own = all(
+        element.tag == _INS and (element.get(_W_AUTHOR) or "") == author
+        for element in non_none
+    )
+    inside_seen = False
+    contiguous_tail = True
+    for element in enclosing:
+        if element is not None:
+            inside_seen = True
+        elif inside_seen:
+            contiguous_tail = False
+            break
+    if not (all_own and enclosing[0] is None and contiguous_tail):
+        raise UnsupportedStructureError(
+            "span overlaps a pending tracked insertion it cannot layer over"
+            " (different author, a tracked move, or base text following the"
+            " insertion); accept or reject the existing revision first, or"
+            " target text inside or outside it"
+        )
+    return enclosing, True
 
 
 def _revision_ancestors(element: "_Element") -> "Tuple[_Element, ...]":
@@ -2066,21 +2101,6 @@ def _set_preserved_text(element: "_Element", text: str) -> None:
         element.set(_XML_SPACE, "preserve")
     elif _XML_SPACE in element.attrib:
         del element.attrib[_XML_SPACE]
-
-
-def _common_affix_lengths(old: str, new: str) -> Tuple[int, int]:
-    prefix = 0
-    limit = min(len(old), len(new))
-    while prefix < limit and old[prefix] == new[prefix]:
-        prefix += 1
-    suffix = 0
-    while (
-        suffix < len(old) - prefix
-        and suffix < len(new) - prefix
-        and old[len(old) - suffix - 1] == new[len(new) - suffix - 1]
-    ):
-        suffix += 1
-    return prefix, suffix
 
 
 def _spans_for_story(

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -939,33 +939,57 @@ class Span:
         changed_new = new_text[prefix_len : len(new_text) - suffix_len]
         if not changed_old and not changed_new:
             return None
-        # map the changed char range onto the atom slice (paragraph
-        # separators are None pieces: a change touching one cannot narrow —
-        # validation will refuse it as a cross-paragraph change)
+        # Map the changed char range onto the atom slice. A zero-width change
+        # keeps every writable atom touching that boundary so destination
+        # proof sees both sides without retaining unrelated affix atoms.
+        # Paragraph separators are None pieces: a change touching one cannot
+        # narrow, so validation will refuse it as a cross-paragraph change.
         target_start = prefix_len
         target_end = len(self.text) - suffix_len
-        position = 0
-        start_idx = end_idx = None
-        start_off = end_off = 0
-        for atom_index, text in self._in_span_pieces():
-            length = len(text)
-            base = 0
-            if atom_index == 0:
-                base = self._start_offset
-            if start_idx is None and position + length > target_start:
-                if atom_index is None:
-                    return None  # change begins on a paragraph separator
-                start_idx = atom_index
-                start_off = base + (target_start - position)
-            if position + length >= target_end:
-                if atom_index is None and end_idx is None:
-                    return None  # change ends on a paragraph separator
-                end_idx = atom_index if atom_index is not None else end_idx
-                end_off = base + (target_end - position) if atom_index is not None else end_off
-                break
-            position += length
-        if start_idx is None or end_idx is None:
-            return None  # zero-length change at an edge; let validation decide
+        if target_start == target_end:
+            candidates: "List[Tuple[int, int]]" = []
+            position = 0
+            for atom_index, text in self._in_span_pieces():
+                piece_end = position + len(text)
+                if atom_index is not None and position <= target_start <= piece_end:
+                    atom = self._atoms[atom_index]
+                    if not atom.is_synthetic:
+                        base = self._start_offset if atom_index == 0 else 0
+                        candidates.append(
+                            (atom_index, base + target_start - position)
+                        )
+                position = piece_end
+            if not candidates:
+                return None
+            start_idx, start_off = candidates[0]
+            end_idx, end_off = candidates[-1]
+        else:
+            start_idx = end_idx = None
+            start_off = end_off = 0
+            position = 0
+            for atom_index, text in self._in_span_pieces():
+                length = len(text)
+                base = 0
+                if atom_index == 0:
+                    base = self._start_offset
+                if start_idx is None and position + length > target_start:
+                    if atom_index is None:
+                        return None  # change begins on a paragraph separator
+                    start_idx = atom_index
+                    start_off = base + (target_start - position)
+                if position + length >= target_end:
+                    if atom_index is None and end_idx is None:
+                        return None  # change ends on a paragraph separator
+                    end_idx = atom_index if atom_index is not None else end_idx
+                    end_off = (
+                        base + (target_end - position)
+                        if atom_index is not None
+                        else end_off
+                    )
+                    break
+                position += length
+            if start_idx is None or end_idx is None:
+                return None
         sub_atoms = self._atoms[start_idx : end_idx + 1]
         sub_span = Span(
             text=changed_old,
@@ -1120,9 +1144,14 @@ class Span:
                 " interval has changed"
             )
 
-    def _validate_replaceable(self, *, validate_bookmarks: bool = True) -> None:
+    def _validate_replaceable(
+        self,
+        *,
+        validate_bookmarks: bool = True,
+        validate_text_boundaries: bool = True,
+    ) -> None:
         for atom in self._atoms:
-            if atom.is_synthetic:
+            if validate_text_boundaries and atom.is_synthetic:
                 detail = (
                     "unmodeled visible run content"
                     if atom.barrier
@@ -1148,7 +1177,7 @@ class Span:
                     " date, cross-reference, …); Word regenerates field results"
                     " on update, so the edit would silently vanish"
                 )
-        if self.crosses_paragraphs:
+        if validate_text_boundaries and self.crosses_paragraphs:
             raise BoundaryViolationError(
                 "span crosses a paragraph boundary; character-level replace is"
                 " same-paragraph only (use docx.blocks for clause-level edits)"
@@ -1287,13 +1316,13 @@ class Span:
             or any(atom.is_synthetic for atom in self._atoms)
             or self.crosses_paragraphs
         ):
-            if tracked and not (
-                any(atom.is_synthetic for atom in self._atoms)
-                or self.crosses_paragraphs
-            ):
-                # Retained affixes may stay outside the changed interval, but
-                # they cannot make a cross-scope target authoritative.
-                self._validate_replaceable(validate_bookmarks=False)
+            # Retained affixes may stay outside the changed interval, but they
+            # cannot make a field, control, hyperlink, or revision crossing
+            # authoritative. The narrowed span validates text boundaries.
+            self._validate_replaceable(
+                validate_bookmarks=False,
+                validate_text_boundaries=False,
+            )
             # spans matched ACROSS a tab/break/paragraph boundary may still
             # edit safely when the actual change lies within one segment:
             # narrow to the changed region; if the change itself crosses a

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -548,14 +548,17 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
                 "the insertion point has no writable text region; re-find text"
                 " on one side of the insertion point"
             )
-        first_evidence = _destination_evidence(span._atoms[candidates[0][0]])
+        candidate_atoms = [
+            span._atoms[atom_index]  # pyright: ignore[reportPrivateUsage]
+            for atom_index, _offset in candidates
+        ]
+        first_evidence = _destination_evidence(candidate_atoms[0])
         if any(
-            not _same_destination(
-                first_evidence, _destination_evidence(span._atoms[atom_index])
-            )
-            for atom_index, _offset in candidates[1:]
+            not _same_destination(first_evidence, _destination_evidence(atom))
+            for atom in candidate_atoms[1:]
         ):
             _refuse_ambiguous_affix_alignment()
+        _refuse_intervening_positional_nodes(candidate_atoms)
         destination_index, destination_offset = candidates[0]
         segments = ((destination_index, destination_offset, destination_offset),)
     else:

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -1212,10 +1212,12 @@ class Span:
         """Replace this span's text and return machine-readable change evidence.
 
         The default is an untracked edit over one proved formatting and structural region.
-        Exact unchanged prefix and suffix text stays in its existing atoms; mixed formatting,
-        semantic-scope crossings, unresolved run formatting, and positional-marker crossings
-        refuse instead of adopting one run's formatting. `tracked=True` instead emits a minimal
-        `w:del`/`w:ins` pair and consumes the span; a direct tracked no-op is refused.
+        When maximal exact prefix/suffix alignment identifies one changed interval, unchanged
+        affix text stays in its existing atoms. Ambiguous alignments, changed intervals spanning
+        different complete run properties or inline ancestry, semantic-scope crossings, and
+        positional-marker crossings refuse instead of adopting one run's formatting. A changed
+        interval inside one text node uses that node's formatting. `tracked=True` instead emits
+        a minimal `w:del`/`w:ins` pair and consumes the span; a direct tracked no-op is refused.
 
         `preserve_revision=True` explicitly permits a current-view span wholly owned by one
         existing `w:ins` to be corrected without changing that insertion's id, author, date,

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime as dt
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Sequence, Tuple
 
 from docx import _clock, _textatoms
 from docx._guard import check_install
@@ -373,7 +373,8 @@ class ReplaceResult:
     `deleted_text` and `inserted_text` cover the whole span for an untracked replace but only
     the affix-trimmed middle for a tracked one, so comparing them against `Span.text` is
     wrong for tracked edits. `preserved_formatting_regions` reports that the ordinary planner
-    proved one safe material region; it is independent of revision and topology evidence.
+    preserved formatting; for a no-op, it records that no formatting changed. It is independent
+    of revision and topology evidence.
     """
 
     story: str
@@ -412,81 +413,203 @@ class _TextAssignment:
     after_xml_space: "Optional[str]" = None
 
 
+@dataclass(frozen=True)
+class _OrdinaryOutcome:
+    """One uniquely localized ordinary replacement plan."""
+
+    replacement: str
+    segments: "Tuple[Tuple[int, int, int], ...]"
+
+
+def _maximal_affix_decompositions(
+    old: str,
+    new: str,
+    aligned: "Callable[[int, int], bool]",
+) -> "Tuple[Tuple[int, int], ...]":
+    """All non-overlapping prefix/suffix pairs preserving maximal text."""
+    limit = min(len(old), len(new))
+    prefix_limit = 0
+    while prefix_limit < limit and aligned(prefix_limit, prefix_limit):
+        prefix_limit += 1
+    suffix_limit = 0
+    while suffix_limit < limit and aligned(
+        len(old) - suffix_limit - 1, len(new) - suffix_limit - 1
+    ):
+        suffix_limit += 1
+
+    preserved = min(prefix_limit + suffix_limit, limit)
+    first_prefix = max(0, preserved - suffix_limit)
+    last_prefix = min(prefix_limit, preserved)
+    return tuple(
+        (prefix_len, preserved - prefix_len)
+        for prefix_len in range(first_prefix, last_prefix + 1)
+    )
+
+
+def _refuse_ambiguous_affix_alignment() -> None:
+    raise UnsupportedStructureError(
+        "exact affix alignment is ambiguous; re-find and replace only the"
+        " exact substring you intend to change (for example, 'payment' with"
+        " 'settlement')"
+    )
+
+
+def _canonical_inline_shell(element: "_Element", path_child: "_Element") -> bytes:
+    """Canonical wrapper XML with its selected content branch replaced."""
+    import copy
+
+    from lxml import etree
+
+    child_index = next(index for index, child in enumerate(element) if child is path_child)
+    clone = copy.deepcopy(element)
+    clone.remove(clone[child_index])
+    clone.insert(child_index, etree.Element("{urn:paper-docx:selection}path"))
+    return etree.tostring(clone, method="c14n")
+
+
+def _destination_evidence(
+    atom: _Atom,
+) -> "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]":
+    """Complete run-property and inline-ancestry evidence for one text atom."""
+    from lxml import etree
+
+    if atom.run is None or atom.paragraph is None:
+        raise UnsupportedStructureError(
+            "the changed interval is not ordinary run text; target a smaller"
+            " plain-text span"
+        )
+    rpr = atom.run.find(_RPR)
+    ancestry: "List[Tuple[_Element, bytes]]" = []
+    path_child = atom.run
+    current = atom.run.getparent()
+    while current is not None and current is not atom.paragraph:
+        ancestry.append((current, _canonical_inline_shell(current, path_child)))
+        path_child = current
+        current = current.getparent()
+    if current is not atom.paragraph:
+        raise UnsupportedStructureError(
+            "the changed interval is detached from its owning paragraph;"
+            " re-find the text"
+        )
+    return (
+        b"" if rpr is None else etree.tostring(rpr, method="c14n"),
+        tuple(ancestry),
+    )
+
+
+def _same_destination(
+    left: "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]",
+    right: "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]",
+) -> bool:
+    """Whether two atoms have the same complete formatting/ancestry outcome."""
+    left_rpr, left_ancestry = left
+    right_rpr, right_ancestry = right
+    if left_rpr != right_rpr or len(left_ancestry) != len(right_ancestry):
+        return False
+    return all(
+        left_element is right_element or left_shell == right_shell
+        for (left_element, left_shell), (right_element, right_shell) in zip(
+            left_ancestry, right_ancestry
+        )
+    )
+
+
+def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
+    """Resolve the one maximal exact-affix outcome, or refuse ambiguity."""
+    old_text = span.text
+    decompositions = _maximal_affix_decompositions(
+        old_text, new_text, lambda old_pos, new_pos: old_text[old_pos] == new_text[new_pos]
+    )
+    if len(decompositions) != 1:
+        _refuse_ambiguous_affix_alignment()
+    prefix_len, suffix_len = decompositions[0]
+    changed_start = prefix_len
+    changed_end = len(old_text) - suffix_len
+    replacement = new_text[prefix_len : len(new_text) - suffix_len]
+    pieces = span._in_span_pieces()
+
+    if changed_start == changed_end:
+        candidates: "List[Tuple[int, int]]" = []
+        position = 0
+        for atom_index, piece in pieces:
+            piece_end = position + len(piece)
+            if atom_index is not None and position <= changed_start <= piece_end:
+                atom = span._atoms[atom_index]
+                if not atom.is_synthetic and all(
+                    atom_index != existing[0] for existing in candidates
+                ):
+                    base = span._start_offset if atom_index == 0 else 0
+                    candidates.append(
+                        (atom_index, base + changed_start - position)
+                    )
+            position = piece_end
+        if not candidates:
+            raise UnsupportedStructureError(
+                "the insertion point has no writable text region; re-find text"
+                " on one side of the insertion point"
+            )
+        first_evidence = _destination_evidence(span._atoms[candidates[0][0]])
+        if any(
+            not _same_destination(
+                first_evidence, _destination_evidence(span._atoms[atom_index])
+            )
+            for atom_index, _offset in candidates[1:]
+        ):
+            _refuse_ambiguous_affix_alignment()
+        destination_index, destination_offset = candidates[0]
+        segments = ((destination_index, destination_offset, destination_offset),)
+    else:
+        writable: "List[Tuple[int, int, int]]" = []
+        position = 0
+        for atom_index, piece in pieces:
+            piece_end = position + len(piece)
+            start = max(changed_start, position)
+            end = min(changed_end, piece_end)
+            if end > start:
+                if atom_index is None:
+                    raise BoundaryViolationError(
+                        "the changed interval crosses a paragraph boundary;"
+                        " replace one paragraph at a time"
+                    )
+                base = span._start_offset if atom_index == 0 else 0
+                writable.append(
+                    (atom_index, base + start - position, base + end - position)
+                )
+            position = piece_end
+        segments = tuple(writable)
+        if not segments:
+            raise UnsupportedStructureError(
+                "the changed interval has no writable text region; re-find and"
+                " replace only the exact substring you intend to change"
+            )
+
+    return _OrdinaryOutcome(
+        replacement=replacement,
+        segments=segments,
+    )
+
+
 def _regional_text_assignments(
     span: "Span", new_text: str
 ) -> "Tuple[_TextAssignment, ...]":
     """Preflight one materially uniform ordinary replacement region."""
     old_text = span.text
-    prefix_len, suffix_len = _common_affix_lengths(old_text, new_text)
     if old_text == new_text:
         return ()
-
-    changed_start = prefix_len
-    changed_end = len(old_text) - suffix_len
-    pieces = span._in_span_pieces()
-    segments: "List[Tuple[int, int, int]]" = []
-    position = 0
-    for atom_index, piece in pieces:
-        piece_end = position + len(piece)
-        lo = max(changed_start, position)
-        hi = min(changed_end, piece_end)
-        if hi > lo:
-            if atom_index is None:
-                raise BoundaryViolationError(
-                    "the changed interval crosses a paragraph boundary;"
-                    " replace one paragraph at a time"
-                )
-            atom = span._atoms[atom_index]
-            base = span._start_offset if atom_index == 0 else 0
-            segments.append((atom_index, base + lo - position, base + hi - position))
-        position = piece_end
-
-    region_atoms: "Sequence[_Atom]"
-    if changed_start == changed_end:
-        insertion_candidates: "List[Tuple[int, int]]" = []
-        position = 0
-        for atom_index, piece in pieces:
-            piece_end = position + len(piece)
-            if atom_index is not None:
-                atom = span._atoms[atom_index]
-                base = span._start_offset if atom_index == 0 else 0
-                if position <= changed_start <= piece_end:
-                    insertion_candidates.append(
-                        (atom_index, base + changed_start - position)
-                    )
-            position = piece_end
-        unique_candidates: "List[Tuple[int, int]]" = []
-        for candidate in insertion_candidates:
-            if all(candidate[0] != existing[0] for existing in unique_candidates):
-                unique_candidates.append(candidate)
-        if not unique_candidates:
-            raise UnsupportedStructureError(
-                "the insertion point has no writable text region; re-find text"
-                " on one side of the insertion point"
-            )
-        candidate_atoms = [span._atoms[index] for index, _ in unique_candidates]
-        region_atoms = candidate_atoms
-        chosen_index, chosen_offset = unique_candidates[0]
-        segments.append((chosen_index, chosen_offset, chosen_offset))
-    else:
-        region_atoms = [
-            span._atoms[index] for index, _start, _end in segments
-        ]
-
-    changed_atoms = [span._atoms[index] for index, _start, _end in segments]
+    outcome = _ordinary_outcome(span, new_text)
+    changed_atoms = [span._atoms[index] for index, _start, _end in outcome.segments]
     if any(atom.is_synthetic for atom in changed_atoms):
         raise UnsupportedStructureError(
             "the changed interval crosses a tab or line break, a no-break"
             " hyphen, or other non-text run content; replace the text"
             " segments on either side individually"
         )
-    _validate_one_formatting_region(span, region_atoms)
+    _validate_one_formatting_region(changed_atoms)
 
-    replacement = new_text[prefix_len : len(new_text) - suffix_len]
     assignments: "List[_TextAssignment]" = []
-    for segment_index, (atom_index, start, end) in enumerate(segments):
+    for segment_index, (atom_index, start, end) in enumerate(outcome.segments):
         atom = span._atoms[atom_index]
-        inserted = replacement if segment_index == 0 else ""
+        inserted = outcome.replacement if segment_index == 0 else ""
         after = atom.text[:start] + inserted + atom.text[end:]
         if after == atom.text:
             continue
@@ -508,65 +631,14 @@ def _regional_text_assignments(
     _refuse_hollowed_bookmarks(
         _hollowed_bookmarks_after(planned, span._atoms)
     )
-    _refuse_intervening_positional_nodes(region_atoms)
+    _refuse_intervening_positional_nodes(changed_atoms)
     return planned
 
 
-def _validate_one_formatting_region(span: "Span", atoms: "Sequence[_Atom]") -> None:
-    """Refuse unless every atom carries complete comparable region evidence."""
-    from lxml import etree
-
-    from docx.formatting import _resolve_run
-
-    supported_rpr_tags = {
-        qn(name)
-        for name in (
-            "w:b", "w:bCs", "w:i", "w:iCs", "w:caps", "w:smallCaps",
-            "w:strike", "w:emboss", "w:imprint", "w:outline", "w:shadow",
-            "w:vanish", "w:u", "w:sz", "w:rFonts", "w:color",
-            "w:highlight", "w:vertAlign", "w:rStyle", "w:rtl",
-        )
-    }
-    evidence = []
-    for atom in atoms:
-        if atom.run is None or atom.paragraph is None:
-            raise UnsupportedStructureError(
-                "the changed interval is not ordinary run text; target a"
-                " smaller plain-text span"
-            )
-        rpr = atom.run.find(_RPR)
-        unsupported = [] if rpr is None else [
-            child.tag.rpartition("}")[2]
-            for child in rpr
-            if child.tag not in supported_rpr_tags
-        ]
-        if unsupported:
-            raise UnsupportedStructureError(
-                "the changed interval contains run formatting the effective"
-                f" formatter cannot compare ({sorted(set(unsupported))});"
-                " target a smaller span with resolvable formatting"
-            )
-        effective = _resolve_run(span._document, atom.run, atom.paragraph)
-        if any(value.source == "mixed" for value in effective.properties.values()):
-            raise UnsupportedStructureError(
-                "the changed interval has mixed effective formatting; target"
-                " a smaller uniformly formatted span"
-            )
-        scopes = tuple(
-            (id(scope[0]), scope[1], scope[2], scope[3])
-            for scope in _atom_context_signature(atom)[-1]
-        )
-        evidence.append(
-            (
-                None if rpr is None else etree.tostring(rpr, method="c14n"),
-                effective,
-                atom.story,
-                id(atom.paragraph),
-                atom.in_field,
-                scopes,
-            )
-        )
-    if evidence and any(item != evidence[0] for item in evidence[1:]):
+def _validate_one_formatting_region(atoms: "Sequence[_Atom]") -> None:
+    """Fragmented edits require complete formatting and ancestry equality."""
+    evidence = [_destination_evidence(atom) for atom in atoms]
+    if any(not _same_destination(evidence[0], item) for item in evidence[1:]):
         raise UnsupportedStructureError(
             "the changed interval crosses formatting or structural regions;"
             " target and replace a smaller span within one uniform region"
@@ -822,7 +894,9 @@ class Span:
             cursor += len(text)
         return positions
 
-    def _narrow_to_change(self, new_text: str) -> "Optional[Tuple[Span, str]]":
+    def _narrow_to_change(
+        self, new_text: str, *, ambiguity_safe: bool = False
+    ) -> "Optional[Tuple[Span, str]]":
         """A sub-span covering only the changed region, or None if the trim
         cannot shrink this span (caller falls through to normal validation).
 
@@ -830,27 +904,39 @@ class Span:
         aligns with an existing tab/break: callers cannot write `\\t`,
         so "Section 4. Termination" against "Section 3.<TAB>Termination"
         keeps the document's tab and changes only the "3" — matching is
-        normalized, documents keep their original characters.
+        normalized, documents keep their original characters. Ordinary edits
+        require one maximal alignment; tracked edits retain their established
+        greedy alignment.
         """
         synthetic = self._synthetic_positions()
         old = self.text
 
-        def aligned(old_pos: int, new_char: str) -> bool:
-            return old[old_pos] == new_char or (
-                old_pos in synthetic and new_char.isspace()
+        def aligned(old_pos: int, new_pos: int) -> bool:
+            return old[old_pos] == new_text[new_pos] or (
+                old_pos in synthetic and new_text[new_pos].isspace()
             )
 
-        prefix_len = 0
-        limit = min(len(old), len(new_text))
-        while prefix_len < limit and aligned(prefix_len, new_text[prefix_len]):
-            prefix_len += 1
-        suffix_len = 0
-        while (
-            suffix_len < len(old) - prefix_len
-            and suffix_len < len(new_text) - prefix_len
-            and aligned(len(old) - suffix_len - 1, new_text[len(new_text) - suffix_len - 1])
-        ):
-            suffix_len += 1
+        if ambiguity_safe:
+            decompositions = _maximal_affix_decompositions(old, new_text, aligned)
+            if len(decompositions) != 1:
+                _refuse_ambiguous_affix_alignment()
+            prefix_len, suffix_len = decompositions[0]
+        else:
+            # Tracked replacement retains its established greedy narrowing.
+            prefix_len = 0
+            limit = min(len(old), len(new_text))
+            while prefix_len < limit and aligned(prefix_len, prefix_len):
+                prefix_len += 1
+            suffix_len = 0
+            while (
+                suffix_len < len(old) - prefix_len
+                and suffix_len < len(new_text) - prefix_len
+                and aligned(
+                    len(old) - suffix_len - 1,
+                    len(new_text) - suffix_len - 1,
+                )
+            ):
+                suffix_len += 1
         if prefix_len == 0 and suffix_len == 0:
             return None
         changed_old = self.text[prefix_len : len(self.text) - suffix_len]
@@ -1195,7 +1281,9 @@ class Span:
             # edit safely when the actual change lies within one segment:
             # narrow to the changed region; if the change itself crosses a
             # break or boundary, validation below refuses as before
-            narrowed = self._narrow_to_change(new_text)
+            narrowed = self._narrow_to_change(
+                new_text, ambiguity_safe=not tracked
+            )
             if narrowed is not None:
                 sub_span, sub_new = narrowed
 

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -372,7 +372,8 @@ class ReplaceResult:
 
     `deleted_text` and `inserted_text` cover the whole span for an untracked replace but only
     the affix-trimmed middle for a tracked one, so comparing them against `Span.text` is
-    wrong for tracked edits.
+    wrong for tracked edits. `preserved_formatting_regions` reports that the ordinary planner
+    proved one safe material region; it is independent of revision and topology evidence.
     """
 
     story: str
@@ -382,11 +383,12 @@ class ReplaceResult:
     revision_ids: Tuple[int, ...]
     preserved_structure: bool = False
     preserved_revision_ids: Tuple[int, ...] = ()
+    preserved_formatting_regions: bool = False
 
     def to_dict(self) -> dict:
         return {
             "schema": "paper_replace",
-            "version": 1,
+            "version": 2,
             "story": self.story,
             "deleted_text": self.deleted_text,
             "inserted_text": self.inserted_text,
@@ -394,16 +396,237 @@ class ReplaceResult:
             "revision_ids": list(self.revision_ids),
             "preserved_structure": self.preserved_structure,
             "preserved_revision_ids": list(self.preserved_revision_ids),
+            "preserved_formatting_regions": self.preserved_formatting_regions,
         }
 
 
 @dataclass(frozen=True)
 class _TextAssignment:
-    """One preflighted text-only mutation for exact-structure replacement."""
+    """One preflighted text-only mutation."""
 
     element: "_Element"
     before: str
     after: str
+    update_xml_space: bool = False
+    before_xml_space: "Optional[str]" = None
+    after_xml_space: "Optional[str]" = None
+
+
+@dataclass(frozen=True)
+class _FormattingRegionPlan:
+    """A complete ordinary-replacement plan plus its live-span boundaries."""
+
+    assignments: "Tuple[_TextAssignment, ...]"
+    before_prefix: str
+    after_suffix: str
+
+
+def _regional_text_assignments(
+    span: "Span", new_text: str
+) -> _FormattingRegionPlan:
+    """Preflight one materially uniform ordinary replacement region."""
+    old_text = span.text
+    prefix_len, suffix_len = _common_affix_lengths(old_text, new_text)
+    before_prefix = span._atoms[0].text[: span._start_offset]
+    after_suffix = span._atoms[-1].text[span._end_offset :]
+    if old_text == new_text:
+        return _FormattingRegionPlan((), before_prefix, after_suffix)
+
+    changed_start = prefix_len
+    changed_end = len(old_text) - suffix_len
+    pieces = span._in_span_pieces()
+    segments: "List[Tuple[int, int, int]]" = []
+    position = 0
+    for atom_index, piece in pieces:
+        piece_end = position + len(piece)
+        lo = max(changed_start, position)
+        hi = min(changed_end, piece_end)
+        if hi > lo:
+            if atom_index is None:
+                raise BoundaryViolationError(
+                    "the changed interval crosses a paragraph boundary;"
+                    " replace one paragraph at a time"
+                )
+            atom = span._atoms[atom_index]
+            base = span._start_offset if atom_index == 0 else 0
+            segments.append((atom_index, base + lo - position, base + hi - position))
+        position = piece_end
+
+    region_atoms: "Sequence[_Atom]"
+    if changed_start == changed_end:
+        insertion_candidates: "List[Tuple[int, int]]" = []
+        position = 0
+        for atom_index, piece in pieces:
+            piece_end = position + len(piece)
+            if atom_index is not None:
+                atom = span._atoms[atom_index]
+                base = span._start_offset if atom_index == 0 else 0
+                if position <= changed_start <= piece_end:
+                    insertion_candidates.append(
+                        (atom_index, base + changed_start - position)
+                    )
+            position = piece_end
+        unique_candidates: "List[Tuple[int, int]]" = []
+        for candidate in insertion_candidates:
+            if all(candidate[0] != existing[0] for existing in unique_candidates):
+                unique_candidates.append(candidate)
+        if not unique_candidates:
+            raise UnsupportedStructureError(
+                "the insertion point has no writable text region; re-find text"
+                " on one side of the insertion point"
+            )
+        candidate_atoms = [span._atoms[index] for index, _ in unique_candidates]
+        region_atoms = candidate_atoms
+        chosen_index, chosen_offset = unique_candidates[0]
+        segments.append((chosen_index, chosen_offset, chosen_offset))
+    else:
+        region_atoms = [
+            span._atoms[index] for index, _start, _end in segments
+        ]
+
+    changed_atoms = [span._atoms[index] for index, _start, _end in segments]
+    if any(atom.is_synthetic for atom in changed_atoms):
+        raise UnsupportedStructureError(
+            "the changed interval crosses a tab or line break, a no-break"
+            " hyphen, or other non-text run content; replace the text"
+            " segments on either side individually"
+        )
+    _validate_one_formatting_region(span, region_atoms)
+
+    replacement = new_text[prefix_len : len(new_text) - suffix_len]
+    assignments: "List[_TextAssignment]" = []
+    for segment_index, (atom_index, start, end) in enumerate(segments):
+        atom = span._atoms[atom_index]
+        inserted = replacement if segment_index == 0 else ""
+        after = atom.text[:start] + inserted + atom.text[end:]
+        if after == atom.text:
+            continue
+        assignments.append(
+            _TextAssignment(
+                element=atom.element,
+                before=atom.text,
+                after=after,
+                update_xml_space=True,
+                before_xml_space=atom.element.get(_XML_SPACE),
+                after_xml_space=(
+                    "preserve"
+                    if after[:1].isspace() or after[-1:].isspace()
+                    else None
+                ),
+            )
+        )
+    planned = tuple(assignments)
+    _refuse_hollowed_bookmarks(
+        _hollowed_bookmarks_after(planned, span._atoms)
+    )
+    _refuse_intervening_positional_nodes(region_atoms)
+    return _FormattingRegionPlan(planned, before_prefix, after_suffix)
+
+
+def _validate_one_formatting_region(span: "Span", atoms: "Sequence[_Atom]") -> None:
+    """Refuse unless every atom carries complete comparable region evidence."""
+    from lxml import etree
+
+    from docx.formatting import _resolve_run
+
+    supported_rpr_tags = {
+        qn(name)
+        for name in (
+            "w:b", "w:bCs", "w:i", "w:iCs", "w:caps", "w:smallCaps",
+            "w:strike", "w:emboss", "w:imprint", "w:outline", "w:shadow",
+            "w:vanish", "w:u", "w:sz", "w:rFonts", "w:color",
+            "w:highlight", "w:vertAlign", "w:rStyle", "w:rtl",
+        )
+    }
+    evidence = []
+    for atom in atoms:
+        if atom.run is None or atom.paragraph is None:
+            raise UnsupportedStructureError(
+                "the changed interval is not ordinary run text; target a"
+                " smaller plain-text span"
+            )
+        rpr = atom.run.find(_RPR)
+        unsupported = [] if rpr is None else [
+            child.tag.rpartition("}")[2]
+            for child in rpr
+            if child.tag not in supported_rpr_tags
+        ]
+        if unsupported:
+            raise UnsupportedStructureError(
+                "the changed interval contains run formatting the effective"
+                f" formatter cannot compare ({sorted(set(unsupported))});"
+                " target a smaller span with resolvable formatting"
+            )
+        effective = _resolve_run(span._document, atom.run, atom.paragraph)
+        if any(value.source == "mixed" for value in effective.properties.values()):
+            raise UnsupportedStructureError(
+                "the changed interval has mixed effective formatting; target"
+                " a smaller uniformly formatted span"
+            )
+        scopes = tuple(
+            (id(scope[0]), scope[1], scope[2], scope[3])
+            for scope in _atom_context_signature(atom)[-1]
+        )
+        evidence.append(
+            (
+                None if rpr is None else etree.tostring(rpr, method="c14n"),
+                effective,
+                atom.story,
+                id(atom.paragraph),
+                atom.in_field,
+                scopes,
+            )
+        )
+    if evidence and any(item != evidence[0] for item in evidence[1:]):
+        raise UnsupportedStructureError(
+            "the changed interval crosses formatting or structural regions;"
+            " target and replace a smaller span within one uniform region"
+        )
+
+
+def _refuse_intervening_positional_nodes(atoms: "Sequence[_Atom]") -> None:
+    """Refuse nodes between changed text atoms whose anchoring could move."""
+    if len(atoms) < 2:
+        return
+    paragraph = atoms[0].paragraph
+    if paragraph is None or any(atom.paragraph is not paragraph for atom in atoms):
+        return
+    stream = list(paragraph.iter())
+    positions = {id(node): index for index, node in enumerate(stream)}
+    bookmark_names = {
+        node.get(_W_ID): node.get(_W_NAME) or "<unnamed>"
+        for node in stream
+        if node.tag == _BOOKMARK_START
+    }
+    first = positions[id(atoms[0].element)]
+    last = positions[id(atoms[-1].element)]
+    changed_elements = tuple(atom.element for atom in atoms)
+
+    def is_ancestor_of_changed(node: "_Element") -> bool:
+        return any(
+            any(node is ancestor for ancestor in element.iterancestors())
+            for element in changed_elements
+        )
+
+    def is_run_property_markup(node: "_Element") -> bool:
+        return node.tag == _RPR or any(parent.tag == _RPR for parent in node.iterancestors())
+
+    for node in stream[first + 1 : last]:
+        if any(node is element for element in changed_elements):
+            continue
+        if is_ancestor_of_changed(node) or is_run_property_markup(node):
+            continue
+        if node.tag in (_BOOKMARK_START, _BOOKMARK_END):
+            name = bookmark_names.get(node.get(_W_ID), "<unnamed>")
+            raise UnsupportedStructureError(
+                f"the changed interval crosses bookmark {name!r}; target a"
+                " smaller span wholly inside or outside that bookmark"
+            )
+        raise UnsupportedStructureError(
+            "the changed interval crosses a positional marker or non-text"
+            " run node whose anchoring cannot be preserved; target a smaller"
+            " span on one side"
+        )
 
 
 @dataclass
@@ -743,8 +966,8 @@ class Span:
     def _validate_fresh(self) -> None:
         if self._consumed:
             raise TargetNotFoundError(
-                "span was consumed by a tracked or structure-preserving"
-                " replace; re-find the text"
+                "span was consumed by a tracked, structure-preserving, or"
+                " unrepresentable replacement; re-find the text"
             )
         if self._current_slice() != self.text:
             raise TargetNotFoundError(
@@ -911,10 +1134,11 @@ class Span:
     ) -> ReplaceResult:
         """Replace this span's text and return machine-readable change evidence.
 
-        The default is an untracked edit: untouched runs retain their run properties, the
-        replacement takes the start run's formatting, and the span stays usable. `tracked=True`
-        instead emits a minimal `w:del`/`w:ins` pair and consumes the span; a direct tracked
-        no-op is refused.
+        The default is an untracked edit over one proved formatting and structural region.
+        Exact unchanged prefix and suffix text stays in its existing atoms; mixed formatting,
+        semantic-scope crossings, unresolved run formatting, and positional-marker crossings
+        refuse instead of adopting one run's formatting. `tracked=True` instead emits a minimal
+        `w:del`/`w:ins` pair and consumes the span; a direct tracked no-op is refused.
 
         `preserve_revision=True` explicitly permits a current-view span wholly owned by one
         existing `w:ins` to be corrected without changing that insertion's id, author, date,
@@ -928,10 +1152,13 @@ class Span:
         but does not consume the span. The two preservation options can be combined, but neither
         can be combined with `tracked=True`.
 
-        `preserved_structure` and `preserved_revision_ids` report the guarantees applied;
-        `revision_ids` remains reserved for newly authored tracked revisions. Refuses a protected
-        document, a stale or foreign span, and unsafe field, control, revision, bookmark,
-        whitespace, or paragraph-boundary structures before mutation.
+        `preserved_formatting_regions`, `preserved_structure`, and
+        `preserved_revision_ids` report independent guarantees; `revision_ids` remains reserved
+        for newly authored tracked revisions. A successful ordinary mutation refreshes the live
+        span when its result remains exactly representable, otherwise consumes it with re-find
+        guidance. Refuses a protected document, a stale or foreign span, and unsafe field,
+        control, revision, bookmark, whitespace, or paragraph-boundary structures before
+        mutation.
         """
         return self._replace(
             new_text,
@@ -982,21 +1209,55 @@ class Span:
             narrowed = self._narrow_to_change(new_text)
             if narrowed is not None:
                 sub_span, sub_new = narrowed
-                return sub_span._replace(
-                    sub_new,
-                    tracked=tracked,
-                    author=author,
-                    date=date,
-                    preserve_structure=False,
-                    preserve_revision=preserve_revision,
-                    use_transaction=use_transaction,
+                before_prefix = self._atoms[0].text[: self._start_offset]
+                after_suffix = self._atoms[-1].text[self._end_offset :]
+
+                def apply_narrowed() -> ReplaceResult:
+                    result = sub_span._replace(
+                        sub_new,
+                        tracked=tracked,
+                        author=author,
+                        date=date,
+                        preserve_structure=False,
+                        preserve_revision=preserve_revision,
+                        use_transaction=False,
+                    )
+                    if not tracked:
+                        self._refresh_after_ordinary_mutation(
+                            before_prefix=before_prefix,
+                            after_suffix=after_suffix,
+                        )
+                    return result
+
+                if use_transaction:
+                    with rollback_on_error(self._document, self):
+                        return apply_narrowed()
+                text_state = tuple(
+                    _TextAssignment(
+                        element=atom.element,
+                        before=atom.text,
+                        after=atom.text,
+                        update_xml_space=True,
+                        before_xml_space=atom.element.get(_XML_SPACE),
+                        after_xml_space=atom.element.get(_XML_SPACE),
+                    )
+                    for atom in sub_span._atoms
+                    if not atom.is_synthetic
                 )
+                span_state = dict(self.__dict__)
+                try:
+                    return apply_narrowed()
+                except BaseException:
+                    _restore_text_assignments(text_state)
+                    self.__dict__.clear()
+                    self.__dict__.update(span_state)
+                    raise
         preserved_revision_ids = _preserved_insertion_ids(
             self, authorize=preserve_revision
         )
         preservation_noop = bool(preserved_revision_ids) and new_text == self.text
         self._validate_replaceable(
-            validate_bookmarks=not preserve_structure and not preservation_noop
+            validate_bookmarks=tracked and not preserve_structure
         )
         if not tracked:
             for atom in self._atoms:
@@ -1080,12 +1341,16 @@ class Span:
                 tracked=False,
                 revision_ids=(),
                 preserved_revision_ids=preserved_revision_ids,
+                preserved_formatting_regions=True,
             )
         if tracked:
             result = self._tracked_replace(new_text, author=author, date=date)  # type: ignore[arg-type]
         else:
-            result = self._plain_replace(
-                new_text, preserved_revision_ids=preserved_revision_ids
+            return self._plain_replace(
+                new_text,
+                preserved_revision_ids=preserved_revision_ids,
+                placeholder_sdts=placeholder_sdts,
+                use_transaction=use_transaction,
             )
         for sdt in placeholder_sdts:
             _clear_placeholder_state(sdt)
@@ -1096,21 +1361,10 @@ class Span:
         new_text: str,
         *,
         preserved_revision_ids: "Tuple[int, ...]" = (),
+        placeholder_sdts: "Sequence[_Element]" = (),
+        use_transaction: bool,
     ) -> ReplaceResult:
-        first, last = self._atoms[0], self._atoms[-1]
-        if first is last:
-            text = first.text
-            _set_preserved_text(
-                first.element,
-                text[: self._start_offset] + new_text + text[self._end_offset :],
-            )
-        else:
-            _set_preserved_text(
-                first.element, first.text[: self._start_offset] + new_text
-            )
-            for atom in self._atoms[1:-1]:
-                _set_preserved_text(atom.element, "")
-            _set_preserved_text(last.element, last.text[self._end_offset :])
+        plan = _regional_text_assignments(self, new_text)
         result = ReplaceResult(
             story=self.story,
             deleted_text=self.text,
@@ -1118,17 +1372,141 @@ class Span:
             tracked=False,
             revision_ids=(),
             preserved_revision_ids=preserved_revision_ids,
+            preserved_formatting_regions=True,
         )
-        self.text = new_text
-        self._end_offset = self._start_offset + len(new_text)
-        del self._atoms[1:]
-        self._context_signatures = tuple(
-            _atom_context_signature(atom) for atom in self._atoms
-        )
-        self._atom_sequence = (first.element,)
-        self._sequence_view = "current"
-        self._view = "current"
+        if not plan.assignments:
+            return result
+
+        def apply() -> None:
+            _apply_text_assignments(plan.assignments)
+            for sdt in placeholder_sdts:
+                _clear_placeholder_state(sdt)
+            self._refresh_after_ordinary_mutation(
+                before_prefix=plan.before_prefix,
+                after_suffix=plan.after_suffix,
+            )
+
+        if use_transaction:
+            with rollback_on_error(self._document, self):
+                apply()
+        else:
+            try:
+                apply()
+            except BaseException:
+                _restore_text_assignments(plan.assignments)
+                raise
         return result
+
+    def _refresh_after_ordinary_mutation(
+        self, *, before_prefix: str, after_suffix: str
+    ) -> None:
+        """Refresh this span to its exact live result, or consume it."""
+        story_root = next(
+            (
+                root
+                for story_name, root in _story_elements(self._document)
+                if story_name == self.story
+            ),
+            None,
+        )
+        if story_root is None:
+            self._consumed = True
+            return
+        all_atoms = (
+            tuple(_story_atoms(self._document, self.story, story_root))
+            if self._freshness_census is None
+            else tuple(
+                atom
+                for atom in self._freshness_census.atoms
+                if atom.text or atom.is_synthetic
+            )
+        )
+        current_by_element = {id(atom.element): atom for atom in all_atoms}
+        pieces: "List[Tuple[_Atom, int, int]]" = []
+        for index, captured in enumerate(self._atoms):
+            current = current_by_element.get(id(captured.element))
+            if current is None:
+                continue
+            start = len(before_prefix) if index == 0 else 0
+            end = (
+                len(current.text) - len(after_suffix)
+                if index == len(self._atoms) - 1
+                else len(current.text)
+            )
+            if start < 0 or end < start or end > len(current.text):
+                self._consumed = True
+                return
+            if end > start:
+                pieces.append((current, start, end))
+        if not pieces:
+            self.text = ""
+            self._consumed = True
+            return
+        visible_atoms = [atom for atom in all_atoms if _include_atom(atom, "current")]
+        visible_positions = {id(atom.element): index for index, atom in enumerate(visible_atoms)}
+        positions = [
+            visible_positions.get(id(atom.element))
+            for atom, _start, _end in pieces
+        ]
+        if any(position is None for position in positions):
+            self._consumed = True
+            return
+        first_position = positions[0]
+        assert first_position is not None
+        if positions != list(range(first_position, first_position + len(positions))):
+            self._consumed = True
+            return
+        text_parts: "List[str]" = []
+        previous: "Optional[_Atom]" = None
+        for atom, start, end in pieces:
+            if previous is not None and atom.paragraph is not previous.paragraph:
+                text_parts.append("\n")
+            text_parts.append(atom.text[start:end])
+            previous = atom
+        refreshed_text = "".join(text_parts)
+        selected_atoms = [atom for atom, _start, _end in pieces]
+        first_atom, first_start, _ = pieces[0]
+        last_atom, _, last_end = pieces[-1]
+        all_positions = {id(atom.element): index for index, atom in enumerate(all_atoms)}
+        sequence_start = all_positions[id(first_atom.element)]
+        sequence_end = all_positions[id(last_atom.element)]
+        raw_start = first_start
+        previous = None
+        for atom in visible_atoms[:first_position]:
+            if previous is not None and atom.paragraph is not previous.paragraph:
+                raw_start += 1
+            raw_start += len(atom.text)
+            previous = atom
+        if previous is not None and first_atom.paragraph is not previous.paragraph:
+            raw_start += 1
+        self.text = refreshed_text
+        self.anchor = Anchor(
+            story=self.story,
+            index=first_atom.block_index,
+            content_hash=content_hash(refreshed_text),
+        )
+        self.in_insert = any(atom.in_insert for atom in selected_atoms)
+        self.in_delete = any(atom.in_delete or atom.tag == _DEL_TEXT for atom in selected_atoms)
+        self.in_content_control = any(atom.sdt is not None for atom in selected_atoms)
+        self.in_text_box = any(atom.in_text_box for atom in selected_atoms)
+        self.in_field = any(atom.in_field for atom in selected_atoms)
+        self.crosses_paragraphs = any(
+            atom.paragraph is not first_atom.paragraph for atom in selected_atoms
+        )
+        self._atoms = selected_atoms
+        self._start_offset = first_start
+        self._end_offset = last_end
+        self._raw_start = raw_start
+        self._match_start = raw_start
+        self._context_signatures = tuple(
+            _atom_context_signature(atom) for atom in selected_atoms
+        )
+        self._atom_sequence = tuple(
+            atom.element for atom in all_atoms[sequence_start : sequence_end + 1]
+        )
+        self._sequence_view = None
+        self._view = "current"
+        self.match_policy = None
 
     def _tracked_replace(
         self, new_text: str, *, author: str, date: Optional[dt.datetime]
@@ -1616,9 +1994,26 @@ def _exact_text_assignments(span: Span, new_text: str) -> "Tuple[_TextAssignment
 
 
 def _apply_text_assignments(assignments: "Sequence[_TextAssignment]") -> None:
-    """Apply a fully validated exact-structure assignment collection."""
+    """Apply a fully validated text-assignment collection."""
     for assignment in assignments:
-        assignment.element.text = assignment.after
+        if assignment.update_xml_space:
+            assignment.element.text = assignment.after
+            if assignment.after_xml_space is None:
+                assignment.element.attrib.pop(_XML_SPACE, None)
+            else:
+                assignment.element.set(_XML_SPACE, assignment.after_xml_space)
+        else:
+            assignment.element.text = assignment.after
+
+
+def _restore_text_assignments(assignments: "Sequence[_TextAssignment]") -> None:
+    """Restore text and whitespace attributes after a local batch failure."""
+    for assignment in assignments:
+        assignment.element.text = assignment.before
+        if assignment.before_xml_space is None:
+            assignment.element.attrib.pop(_XML_SPACE, None)
+        else:
+            assignment.element.set(_XML_SPACE, assignment.before_xml_space)
 
 
 def _hollowed_bookmarks_after(
@@ -1942,7 +2337,7 @@ class ReplaceAllResult:
     def to_dict(self) -> dict:
         return {
             "schema": "paper_replace_all",
-            "version": 1,
+            "version": 2,
             "replaced_count": self.replaced_count,
             "results": [result.to_dict() for result in self.results],
             "refused": list(self.refused),

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -372,9 +372,10 @@ class ReplaceResult:
 
     `deleted_text` and `inserted_text` cover the whole span for an untracked replace but only
     the affix-trimmed middle for a tracked one, so comparing them against `Span.text` is
-    wrong for tracked edits. `preserved_formatting_regions` reports that the ordinary planner
-    preserved formatting; for a no-op, it records that no formatting changed. It is independent
-    of revision and topology evidence.
+    wrong for tracked edits. `preserved_formatting_regions` reports whether an ordinary
+    replacement kept every changed formatting region rather than intentionally inheriting the
+    changed interval's starting run properties; for a no-op, it records that no formatting
+    changed. It is independent of revision and topology evidence.
     """
 
     story: str
@@ -464,42 +465,25 @@ def _refuse_ambiguous_insertion_destination() -> None:
     )
 
 
-def _canonical_inline_shell(element: "_Element", path_child: "_Element") -> bytes:
-    """Canonical wrapper XML with its selected content branch replaced."""
-    import copy
-
-    from lxml import etree
-
-    child_index = next(index for index, child in enumerate(element) if child is path_child)
-    clone = copy.deepcopy(element)
-    clone.remove(clone[child_index])
-    clone.insert(child_index, etree.Element("{urn:paper-docx:selection}path"))
-    return etree.tostring(clone, method="c14n")
-
-
 def _destination_evidence(
     atom: _Atom,
-) -> "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]":
+) -> "Tuple[bytes, Tuple[_Element, ...]]":
     """Complete run-property and inline-ancestry evidence for one text atom."""
     from lxml import etree
 
     if atom.run is None or atom.paragraph is None:
         raise UnsupportedStructureError(
-            "the changed interval is not ordinary run text; target a smaller"
-            " plain-text span"
+            "the changed interval is not ordinary run text; target a smaller plain-text span"
         )
     rpr = atom.run.find(_RPR)
-    ancestry: "List[Tuple[_Element, bytes]]" = []
-    path_child = atom.run
+    ancestry: "List[_Element]" = []
     current = atom.run.getparent()
     while current is not None and current is not atom.paragraph:
-        ancestry.append((current, _canonical_inline_shell(current, path_child)))
-        path_child = current
+        ancestry.append(current)
         current = current.getparent()
     if current is not atom.paragraph:
         raise UnsupportedStructureError(
-            "the changed interval is detached from its owning paragraph;"
-            " re-find the text"
+            "the changed interval is detached from its owning paragraph; re-find the text"
         )
     return (
         b"" if rpr is None else etree.tostring(rpr, method="c14n"),
@@ -508,20 +492,32 @@ def _destination_evidence(
 
 
 def _same_destination(
-    left: "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]",
-    right: "Tuple[bytes, Tuple[Tuple[_Element, bytes], ...]]",
+    left: "Tuple[bytes, Tuple[_Element, ...]]",
+    right: "Tuple[bytes, Tuple[_Element, ...]]",
 ) -> bool:
     """Whether two atoms have the same complete formatting/ancestry outcome."""
-    left_rpr, left_ancestry = left
-    right_rpr, right_ancestry = right
-    if left_rpr != right_rpr or len(left_ancestry) != len(right_ancestry):
-        return False
-    return all(
-        left_element is right_element or left_shell == right_shell
-        for (left_element, left_shell), (right_element, right_shell) in zip(
-            left_ancestry, right_ancestry
-        )
+    return left[0] == right[0] and _same_inline_ancestry(left, right)
+
+
+def _same_inline_ancestry(
+    left: "Tuple[bytes, Tuple[_Element, ...]]",
+    right: "Tuple[bytes, Tuple[_Element, ...]]",
+) -> bool:
+    """Whether two atoms retain text in the same concrete wrapper chain."""
+    left_ancestry = left[1]
+    right_ancestry = right[1]
+    return len(left_ancestry) == len(right_ancestry) and all(
+        left_element is right_element
+        for left_element, right_element in zip(left_ancestry, right_ancestry)
     )
+
+
+def _has_multiple_direct_rpr(atoms: "Sequence[_Atom]") -> bool:
+    """Whether writable atoms carry differing complete direct run properties."""
+    if any(atom.is_synthetic for atom in atoms):
+        return False
+    starting_rpr = _destination_evidence(atoms[0])[0]
+    return any(_destination_evidence(atom)[0] != starting_rpr for atom in atoms[1:])
 
 
 def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
@@ -538,6 +534,30 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
     replacement = new_text[prefix_len : len(new_text) - suffix_len]
     pieces = span._in_span_pieces()
 
+    def writable_segments(start_offset: int, end_offset: int):
+        writable: "List[Tuple[int, int, int]]" = []
+        position = 0
+        for atom_index, piece in pieces:
+            piece_end = position + len(piece)
+            start = max(start_offset, position)
+            end = min(end_offset, piece_end)
+            if end > start:
+                if atom_index is None:
+                    raise BoundaryViolationError(
+                        "the changed interval crosses a paragraph boundary;"
+                        " replace one paragraph at a time"
+                    )
+                base = span._start_offset if atom_index == 0 else 0
+                writable.append((atom_index, base + start - position, base + end - position))
+            position = piece_end
+        segments = tuple(writable)
+        if not segments:
+            raise UnsupportedStructureError(
+                "the changed interval has no writable text region; re-find and"
+                " replace only the exact substring you intend to change"
+            )
+        return segments
+
     if changed_start == changed_end:
         candidates: "List[Tuple[int, int]]" = []
         position = 0
@@ -549,9 +569,7 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
                     atom_index != existing[0] for existing in candidates
                 ):
                     base = span._start_offset if atom_index == 0 else 0
-                    candidates.append(
-                        (atom_index, base + changed_start - position)
-                    )
+                    candidates.append((atom_index, base + changed_start - position))
             position = piece_end
         if not candidates:
             raise UnsupportedStructureError(
@@ -572,29 +590,27 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
         destination_index, destination_offset = candidates[0]
         segments = ((destination_index, destination_offset, destination_offset),)
     else:
-        writable: "List[Tuple[int, int, int]]" = []
-        position = 0
-        for atom_index, piece in pieces:
-            piece_end = position + len(piece)
-            start = max(changed_start, position)
-            end = min(changed_end, piece_end)
-            if end > start:
-                if atom_index is None:
-                    raise BoundaryViolationError(
-                        "the changed interval crosses a paragraph boundary;"
-                        " replace one paragraph at a time"
-                    )
-                base = span._start_offset if atom_index == 0 else 0
-                writable.append(
-                    (atom_index, base + start - position, base + end - position)
-                )
-            position = piece_end
-        segments = tuple(writable)
-        if not segments:
-            raise UnsupportedStructureError(
-                "the changed interval has no writable text region; re-find and"
-                " replace only the exact substring you intend to change"
-            )
+        segments = writable_segments(changed_start, changed_end)
+        changed_atoms = [span._atoms[index] for index, _start, _end in segments]
+        if replacement and _has_multiple_direct_rpr(changed_atoms):
+            # A shared suffix character is not formatting intent. If the
+            # narrowed changed interval already crosses direct run-property
+            # regions, consume the remaining selected fragment of its final
+            # changed run rather than leaving a misleading fragment (for
+            # example bold "Omeg" + italic "a"). Later suffix runs remain
+            # untouched in their original formatting.
+            final_atom_index = segments[-1][0]
+            position = 0
+            for atom_index, piece in pieces:
+                piece_end = position + len(piece)
+                if atom_index == final_atom_index:
+                    changed_end = piece_end
+                    break
+                position = piece_end
+            suffix_to_keep = len(old_text) - changed_end
+            replacement_end = len(new_text) - suffix_to_keep
+            replacement = new_text[prefix_len:replacement_end]
+            segments = writable_segments(changed_start, changed_end)
 
     return _OrdinaryOutcome(
         replacement=replacement,
@@ -606,11 +622,11 @@ def _ordinary_outcome(span: "Span", new_text: str) -> _OrdinaryOutcome:
 
 def _regional_text_assignments(
     span: "Span", new_text: str
-) -> "Tuple[_TextAssignment, ...]":
-    """Preflight one materially uniform ordinary replacement region."""
+) -> "Tuple[Tuple[_TextAssignment, ...], bool]":
+    """Preflight one owner-safe replacement and report formatting preservation."""
     old_text = span.text
     if old_text == new_text:
-        return ()
+        return (), True
     outcome = _ordinary_outcome(span, new_text)
     changed_atoms = [span._atoms[index] for index, _start, _end in outcome.segments]
     if any(atom.is_synthetic for atom in changed_atoms):
@@ -619,7 +635,11 @@ def _regional_text_assignments(
             " hyphen, or other non-text run content; replace the text"
             " segments on either side individually"
         )
-    _validate_one_formatting_region(changed_atoms)
+    _validate_one_inline_ancestry(changed_atoms)
+    evidence = [_destination_evidence(atom) for atom in changed_atoms]
+    preserved_formatting_regions = all(
+        _same_destination(evidence[0], item) for item in evidence[1:]
+    )
 
     assignments: "List[_TextAssignment]" = []
     for segment_index, (atom_index, start, end) in enumerate(outcome.segments):
@@ -644,20 +664,26 @@ def _regional_text_assignments(
         )
     planned = tuple(assignments)
     _refuse_hollowed_bookmarks(
-        _hollowed_bookmarks_after(planned, span._atoms)
+        _hollowed_bookmarks_after(
+            planned,
+            span._atoms,
+            census=(
+                span._freshness_census.bookmarks if span._freshness_census is not None else None
+            ),
+        )
     )
     _refuse_intervening_positional_nodes(changed_atoms)
-    return planned
+    return planned, preserved_formatting_regions
 
 
-def _validate_one_formatting_region(atoms: "Sequence[_Atom]") -> None:
-    """Fragmented edits require complete formatting and ancestry equality."""
+def _validate_one_inline_ancestry(atoms: "Sequence[_Atom]") -> None:
+    """A replacement must not move text between separate wrapper owners."""
     evidence = [_destination_evidence(atom) for atom in atoms]
-    if any(not _same_destination(evidence[0], item) for item in evidence[1:]):
+    if any(not _same_inline_ancestry(evidence[0], item) for item in evidence[1:]):
         raise UnsupportedStructureError(
-            "the changed interval crosses formatting or structural regions;"
-            " target and replace a smaller span within one uniform region,"
-            " or construct the intended formatting and structure explicitly"
+            "the changed interval crosses separate inline wrapper owners;"
+            " target and replace a smaller span within one wrapper, or edit"
+            " each wrapper separately"
         )
 
 
@@ -955,9 +981,7 @@ class Span:
                     atom = self._atoms[atom_index]
                     if not atom.is_synthetic:
                         base = self._start_offset if atom_index == 0 else 0
-                        candidates.append(
-                            (atom_index, base + target_start - position)
-                        )
+                        candidates.append((atom_index, base + target_start - position))
                 position = piece_end
             if not candidates:
                 return None
@@ -981,16 +1005,33 @@ class Span:
                     if atom_index is None and end_idx is None:
                         return None  # change ends on a paragraph separator
                     end_idx = atom_index if atom_index is not None else end_idx
-                    end_off = (
-                        base + (target_end - position)
-                        if atom_index is not None
-                        else end_off
-                    )
+                    end_off = base + (target_end - position) if atom_index is not None else end_off
                     break
                 position += length
             if start_idx is None or end_idx is None:
                 return None
         sub_atoms = self._atoms[start_idx : end_idx + 1]
+        if changed_new and changed_old and _has_multiple_direct_rpr(sub_atoms):
+            # Keep retained prefix atoms outside the tracked edit. Expand only
+            # through the selected fragment of the final changed atom so the
+            # ordinary planner can apply match-start formatting without
+            # collapsing later suffix runs.
+            expanded_end = 0
+            for atom_index, text in self._in_span_pieces():
+                expanded_end += len(text)
+                if atom_index == end_idx:
+                    break
+            suffix_to_keep = len(old) - expanded_end
+            changed_old = old[prefix_len:expanded_end]
+            replacement_end = len(new_text) - suffix_to_keep
+            changed_new = new_text[prefix_len:replacement_end]
+            end_off = (
+                self._end_offset
+                if end_idx == len(self._atoms) - 1
+                else len(self._atoms[end_idx].text)
+            )
+            if prefix_len == 0 and expanded_end == len(old):
+                return None
         sub_span = Span(
             text=changed_old,
             story=self.story,
@@ -1004,9 +1045,7 @@ class Span:
             in_content_control=any(a.sdt is not None for a in sub_atoms),
             in_text_box=any(a.in_text_box for a in sub_atoms),
             in_field=any(a.in_field for a in sub_atoms),
-            crosses_paragraphs=any(
-                a.paragraph is not sub_atoms[0].paragraph for a in sub_atoms
-            ),
+            crosses_paragraphs=any(a.paragraph is not sub_atoms[0].paragraph for a in sub_atoms),
             _document=self._document,
             _atoms=list(sub_atoms),
             _start_offset=start_off,
@@ -1027,9 +1066,7 @@ class Span:
             and sequence_end is not None
             and sequence_start <= sequence_end
         ):
-            sub_span._atom_sequence = self._atom_sequence[
-                sequence_start : sequence_end + 1
-            ]
+            sub_span._atom_sequence = self._atom_sequence[sequence_start : sequence_end + 1]
         return sub_span, changed_new
 
     # -- validation -------------------------------------------------------
@@ -1233,16 +1270,14 @@ class Span:
     ) -> ReplaceResult:
         """Replace this span's text and return machine-readable change evidence.
 
-        The default is an untracked edit over one proved formatting and structural region.
+        The default is an untracked edit over one proved structural-owner region.
         When maximal exact prefix/suffix alignment identifies one changed interval, unchanged
-        affix text stays in its existing atoms. Ambiguous alignments, changed intervals spanning
-        different complete run properties or inline ancestry, semantic-scope crossings, and
-        positional-marker crossings refuse instead of adopting one run's formatting. A changed
-        interval inside one text node uses that node's formatting. `tracked=True` uses the same
-        unique localization and emits a minimal `w:del`/`w:ins` pair only when nonempty inserted
-        text has one complete formatting/inline-ancestry destination. Deletion-only tracked edits
-        retain each source run's properties. Ambiguity tells the caller to target a smaller
-        uniform substring or construct explicit formatting; it is never repaired internally.
+        affix text stays in its existing atoms. A nonempty replacement inherits the complete
+        direct run properties of the changed interval's starting text run; consumed later runs
+        may therefore collapse intentionally. Distinct inline wrapper owners, semantic-scope
+        crossings, positional-marker crossings, and ambiguous affix or pure-insertion boundaries
+        refuse. `tracked=True` uses the same unique localization and formatting inheritance;
+        tracked deletion pieces retain each source run's properties.
         A successful tracked change consumes the span; a direct tracked no-op is refused.
 
         `preserve_revision=True` explicitly permits a current-view span wholly owned by one
@@ -1305,12 +1340,12 @@ class Span:
         _validate_writable_text(new_text, argument="new_text")
         _refuse_if_protected(self._document, "replace text")
         self._validate_fresh()
-        if tracked and tracked_context is None:
-            tracked_context = _tracked_layering_context(self, author)  # type: ignore[arg-type]
-        if tracked and self.text == new_text:
-            raise TargetNotFoundError(
-                "replacement equals the existing text; nothing to change"
-            )
+        if tracked:
+            assert author is not None
+            if tracked_context is None:
+                tracked_context = _tracked_layering_context(self, author)
+            if self.text == new_text:
+                raise TargetNotFoundError("replacement equals the existing text; nothing to change")
         if not preserve_structure and (
             tracked
             or any(atom.is_synthetic for atom in self._atoms)
@@ -1368,9 +1403,7 @@ class Span:
                     self.__dict__.clear()
                     self.__dict__.update(span_state)
                     raise
-        preserved_revision_ids = _preserved_insertion_ids(
-            self, authorize=preserve_revision
-        )
+        preserved_revision_ids = _preserved_insertion_ids(self, authorize=preserve_revision)
         preservation_noop = bool(preserved_revision_ids) and new_text == self.text
         self._validate_replaceable(
             validate_bookmarks=tracked and not preserve_structure
@@ -1459,22 +1492,26 @@ class Span:
             )
         if tracked:
             assert author is not None
-            result = self._tracked_replace(
+            if use_transaction:
+                with rollback_on_error(self._document, self):
+                    return self._tracked_replace(
+                        new_text,
+                        author=author,
+                        date=date,
+                        tracked_context=tracked_context,
+                    )
+            return self._tracked_replace(
                 new_text,
                 author=author,
                 date=date,
                 tracked_context=tracked_context,
             )
-        else:
-            return self._plain_replace(
-                new_text,
-                preserved_revision_ids=preserved_revision_ids,
-                placeholder_sdts=placeholder_sdts,
-                use_transaction=use_transaction,
-            )
-        for sdt in placeholder_sdts:
-            _clear_placeholder_state(sdt)
-        return result
+        return self._plain_replace(
+            new_text,
+            preserved_revision_ids=preserved_revision_ids,
+            placeholder_sdts=placeholder_sdts,
+            use_transaction=use_transaction,
+        )
 
     def _plain_replace(
         self,
@@ -1484,7 +1521,7 @@ class Span:
         placeholder_sdts: "Sequence[_Element]" = (),
         use_transaction: bool,
     ) -> ReplaceResult:
-        assignments = _regional_text_assignments(self, new_text)
+        assignments, preserved_formatting_regions = _regional_text_assignments(self, new_text)
         result = ReplaceResult(
             story=self.story,
             deleted_text=self.text,
@@ -1492,7 +1529,7 @@ class Span:
             tracked=False,
             revision_ids=(),
             preserved_revision_ids=preserved_revision_ids,
-            preserved_formatting_regions=True,
+            preserved_formatting_regions=preserved_formatting_regions,
         )
         if not assignments:
             return result
@@ -1550,12 +1587,9 @@ class Span:
         first, last = self._atoms[0], self._atoms[-1]
         old_mid = self.text[outcome.changed_start : outcome.changed_end]
         new_mid = outcome.replacement
-        changed_atoms = [
-            self._atoms[index] for index, _start, _end in outcome.segments
-        ]
+        changed_atoms = [self._atoms[index] for index, _start, _end in outcome.segments]
         _refuse_intervening_positional_nodes(changed_atoms)
-        if new_mid:
-            _validate_one_formatting_region(changed_atoms)
+        _validate_one_inline_ancestry(changed_atoms)
         stamp = date if date is not None else _clock.now()
         next_id = _next_revision_id(self._document)
         rpr = first.run.find(_RPR) if first.run is not None else None
@@ -1568,15 +1602,12 @@ class Span:
             start = self._start_offset if i == 0 else 0
             end = self._end_offset if i == len(self._atoms) - 1 else len(atom.text)
             span_pieces.append((atom.run, atom.text[start:end]))
-        deleted_pieces = _pieces_in_range(
-            span_pieces, prefix_len, len(self.text) - suffix_len
-        )
-        # Formatting/ancestry equality above proves that any changed source
-        # atom describes the same insertion destination.
+        deleted_pieces = _pieces_in_range(span_pieces, prefix_len, len(self.text) - suffix_len)
+        # The inserted text intentionally takes the direct formatting of the
+        # first consumed source run. Separate wrapper owners were refused
+        # above; later source runs may have different direct formatting.
         ins_source_run = changed_atoms[0].run if changed_atoms else first.run
-        ins_rpr = (
-            ins_source_run.find(_RPR) if ins_source_run is not None else None
-        )
+        ins_rpr = ins_source_run.find(_RPR) if ins_source_run is not None else None
 
         # -- everything validated; mutate ---------------------------------
         before = first.text[: self._start_offset]

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -412,25 +412,14 @@ class _TextAssignment:
     after_xml_space: "Optional[str]" = None
 
 
-@dataclass(frozen=True)
-class _FormattingRegionPlan:
-    """A complete ordinary-replacement plan plus its live-span boundaries."""
-
-    assignments: "Tuple[_TextAssignment, ...]"
-    before_prefix: str
-    after_suffix: str
-
-
 def _regional_text_assignments(
     span: "Span", new_text: str
-) -> _FormattingRegionPlan:
+) -> "Tuple[_TextAssignment, ...]":
     """Preflight one materially uniform ordinary replacement region."""
     old_text = span.text
     prefix_len, suffix_len = _common_affix_lengths(old_text, new_text)
-    before_prefix = span._atoms[0].text[: span._start_offset]
-    after_suffix = span._atoms[-1].text[span._end_offset :]
     if old_text == new_text:
-        return _FormattingRegionPlan((), before_prefix, after_suffix)
+        return ()
 
     changed_start = prefix_len
     changed_end = len(old_text) - suffix_len
@@ -520,7 +509,7 @@ def _regional_text_assignments(
         _hollowed_bookmarks_after(planned, span._atoms)
     )
     _refuse_intervening_positional_nodes(region_atoms)
-    return _FormattingRegionPlan(planned, before_prefix, after_suffix)
+    return planned
 
 
 def _validate_one_formatting_region(span: "Span", atoms: "Sequence[_Atom]") -> None:
@@ -656,7 +645,7 @@ class Span:
     _raw_start: int = field(repr=False)  # position in the story's raw visible text
     _match_start: int = field(repr=False)  # position in the selected policy space
     match_policy: "Optional[str]" = field(default=None, init=False)
-    _consumed: bool = field(default=False, repr=False)  # set by tracked replace
+    _consumed: bool = field(default=False, repr=False)
     _context_signatures: "Tuple[tuple, ...]" = field(init=False, repr=False)
     _atom_sequence: "Tuple[_Element, ...]" = field(init=False, repr=False)
     _sequence_view: "Optional[str]" = field(init=False, repr=False)
@@ -966,8 +955,7 @@ class Span:
     def _validate_fresh(self) -> None:
         if self._consumed:
             raise TargetNotFoundError(
-                "span was consumed by a tracked, structure-preserving, or"
-                " unrepresentable replacement; re-find the text"
+                "span was consumed by a successful replacement; re-find the text"
             )
         if self._current_slice() != self.text:
             raise TargetNotFoundError(
@@ -1154,9 +1142,10 @@ class Span:
 
         `preserved_formatting_regions`, `preserved_structure`, and
         `preserved_revision_ids` report independent guarantees; `revision_ids` remains reserved
-        for newly authored tracked revisions. A successful ordinary mutation refreshes the live
-        span when its result remains exactly representable, otherwise consumes it with re-find
-        guidance. Refuses a protected document, a stale or foreign span, and unsafe field,
+        for newly authored tracked revisions. Every successful text-changing replacement consumes
+        the supplied span; use the returned result and re-find the text before another operation.
+        A no-op, refusal, or rolled-back mutation leaves the span reusable. Refuses a protected
+        document, a stale or foreign span, and unsafe field,
         control, revision, bookmark, whitespace, or paragraph-boundary structures before
         mutation.
         """
@@ -1209,8 +1198,6 @@ class Span:
             narrowed = self._narrow_to_change(new_text)
             if narrowed is not None:
                 sub_span, sub_new = narrowed
-                before_prefix = self._atoms[0].text[: self._start_offset]
-                after_suffix = self._atoms[-1].text[self._end_offset :]
 
                 def apply_narrowed() -> ReplaceResult:
                     result = sub_span._replace(
@@ -1222,11 +1209,7 @@ class Span:
                         preserve_revision=preserve_revision,
                         use_transaction=False,
                     )
-                    if not tracked:
-                        self._refresh_after_ordinary_mutation(
-                            before_prefix=before_prefix,
-                            after_suffix=after_suffix,
-                        )
+                    self._consumed = True
                     return result
 
                 if use_transaction:
@@ -1318,7 +1301,6 @@ class Span:
             if use_transaction:
                 with rollback_on_error(self._document, self):
                     _apply_text_assignments(assignments)
-                    self.text = new_text
                     self._consumed = True
             else:
                 try:
@@ -1330,7 +1312,6 @@ class Span:
                     for assignment in assignments:
                         assignment.element.text = assignment.before
                     raise
-                self.text = new_text
                 self._consumed = True
             return result
         if preservation_noop:
@@ -1364,7 +1345,7 @@ class Span:
         placeholder_sdts: "Sequence[_Element]" = (),
         use_transaction: bool,
     ) -> ReplaceResult:
-        plan = _regional_text_assignments(self, new_text)
+        assignments = _regional_text_assignments(self, new_text)
         result = ReplaceResult(
             story=self.story,
             deleted_text=self.text,
@@ -1374,17 +1355,14 @@ class Span:
             preserved_revision_ids=preserved_revision_ids,
             preserved_formatting_regions=True,
         )
-        if not plan.assignments:
+        if not assignments:
             return result
 
         def apply() -> None:
-            _apply_text_assignments(plan.assignments)
+            _apply_text_assignments(assignments)
             for sdt in placeholder_sdts:
                 _clear_placeholder_state(sdt)
-            self._refresh_after_ordinary_mutation(
-                before_prefix=plan.before_prefix,
-                after_suffix=plan.after_suffix,
-            )
+            self._consumed = True
 
         if use_transaction:
             with rollback_on_error(self._document, self):
@@ -1393,120 +1371,9 @@ class Span:
             try:
                 apply()
             except BaseException:
-                _restore_text_assignments(plan.assignments)
+                _restore_text_assignments(assignments)
                 raise
         return result
-
-    def _refresh_after_ordinary_mutation(
-        self, *, before_prefix: str, after_suffix: str
-    ) -> None:
-        """Refresh this span to its exact live result, or consume it."""
-        story_root = next(
-            (
-                root
-                for story_name, root in _story_elements(self._document)
-                if story_name == self.story
-            ),
-            None,
-        )
-        if story_root is None:
-            self._consumed = True
-            return
-        all_atoms = (
-            tuple(_story_atoms(self._document, self.story, story_root))
-            if self._freshness_census is None
-            else tuple(
-                atom
-                for atom in self._freshness_census.atoms
-                if atom.text or atom.is_synthetic
-            )
-        )
-        current_by_element = {id(atom.element): atom for atom in all_atoms}
-        pieces: "List[Tuple[_Atom, int, int]]" = []
-        for index, captured in enumerate(self._atoms):
-            current = current_by_element.get(id(captured.element))
-            if current is None:
-                continue
-            start = len(before_prefix) if index == 0 else 0
-            end = (
-                len(current.text) - len(after_suffix)
-                if index == len(self._atoms) - 1
-                else len(current.text)
-            )
-            if start < 0 or end < start or end > len(current.text):
-                self._consumed = True
-                return
-            if end > start:
-                pieces.append((current, start, end))
-        if not pieces:
-            self.text = ""
-            self._consumed = True
-            return
-        visible_atoms = [atom for atom in all_atoms if _include_atom(atom, "current")]
-        visible_positions = {id(atom.element): index for index, atom in enumerate(visible_atoms)}
-        positions = [
-            visible_positions.get(id(atom.element))
-            for atom, _start, _end in pieces
-        ]
-        if any(position is None for position in positions):
-            self._consumed = True
-            return
-        first_position = positions[0]
-        assert first_position is not None
-        if positions != list(range(first_position, first_position + len(positions))):
-            self._consumed = True
-            return
-        text_parts: "List[str]" = []
-        previous: "Optional[_Atom]" = None
-        for atom, start, end in pieces:
-            if previous is not None and atom.paragraph is not previous.paragraph:
-                text_parts.append("\n")
-            text_parts.append(atom.text[start:end])
-            previous = atom
-        refreshed_text = "".join(text_parts)
-        selected_atoms = [atom for atom, _start, _end in pieces]
-        first_atom, first_start, _ = pieces[0]
-        last_atom, _, last_end = pieces[-1]
-        all_positions = {id(atom.element): index for index, atom in enumerate(all_atoms)}
-        sequence_start = all_positions[id(first_atom.element)]
-        sequence_end = all_positions[id(last_atom.element)]
-        raw_start = first_start
-        previous = None
-        for atom in visible_atoms[:first_position]:
-            if previous is not None and atom.paragraph is not previous.paragraph:
-                raw_start += 1
-            raw_start += len(atom.text)
-            previous = atom
-        if previous is not None and first_atom.paragraph is not previous.paragraph:
-            raw_start += 1
-        self.text = refreshed_text
-        self.anchor = Anchor(
-            story=self.story,
-            index=first_atom.block_index,
-            content_hash=content_hash(refreshed_text),
-        )
-        self.in_insert = any(atom.in_insert for atom in selected_atoms)
-        self.in_delete = any(atom.in_delete or atom.tag == _DEL_TEXT for atom in selected_atoms)
-        self.in_content_control = any(atom.sdt is not None for atom in selected_atoms)
-        self.in_text_box = any(atom.in_text_box for atom in selected_atoms)
-        self.in_field = any(atom.in_field for atom in selected_atoms)
-        self.crosses_paragraphs = any(
-            atom.paragraph is not first_atom.paragraph for atom in selected_atoms
-        )
-        self._atoms = selected_atoms
-        self._start_offset = first_start
-        self._end_offset = last_end
-        self._raw_start = raw_start
-        self._match_start = raw_start
-        self._context_signatures = tuple(
-            _atom_context_signature(atom) for atom in selected_atoms
-        )
-        self._atom_sequence = tuple(
-            atom.element for atom in all_atoms[sequence_start : sequence_end + 1]
-        )
-        self._sequence_view = None
-        self._view = "current"
-        self.match_policy = None
 
     def _tracked_replace(
         self, new_text: str, *, author: str, date: Optional[dt.datetime]
@@ -1668,8 +1535,7 @@ class Span:
             tracked=True,
             revision_ids=tuple(revision_ids),
         )
-        # span state after a tracked replace is complex; force a fresh find
-        self.text = new_text
+        # Successful text changes are one-shot; callers re-find for another edit.
         self._consumed = True
         return result
 

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -275,10 +275,10 @@ def update_cell(
     """Replace one cell's visible text and return a `ReplaceResult` (0-based `row`,
     layout-grid `column`).
 
-    Runs through `Span.replace`, so the first run's formatting carries the text. Guards are
-    cell-wise: a merged header elsewhere in the table does not block a plain target cell.
-    Refuses a protected document, an out-of-range address, and a merged, multi-paragraph or
-    nested target.
+    Runs through `Span.replace`, so a non-empty cell must be one materially uniform formatting
+    and structural region. Guards are cell-wise: a merged header elsewhere in the table does not
+    block a plain target cell. Refuses a protected document, an out-of-range address, and a
+    mixed-format, marker-divided, merged, multi-paragraph, or nested target.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")

--- a/src/docx/tableops.py
+++ b/src/docx/tableops.py
@@ -275,10 +275,11 @@ def update_cell(
     """Replace one cell's visible text and return a `ReplaceResult` (0-based `row`,
     layout-grid `column`).
 
-    Runs through `Span.replace`, so a non-empty cell must be one materially uniform formatting
-    and structural region. Guards are cell-wise: a merged header elsewhere in the table does not
-    block a plain target cell. Refuses a protected document, an out-of-range address, and a
-    mixed-format, marker-divided, merged, multi-paragraph, or nested target.
+    Runs through `Span.replace`, so a non-empty replacement inherits the target cell text's
+    starting run properties and reports whether later formatting regions were consumed. Guards
+    are cell-wise: a merged header elsewhere in the table does not block a plain target cell.
+    Refuses a protected document, an out-of-range address, and a marker-divided,
+    wrapper-divided, merged, multi-paragraph, or nested target.
     """
     if tracked and not author:
         raise ValueError("author is required when tracked=True")

--- a/tests/paper/test_audit_late_failure_atomicity.py
+++ b/tests/paper/test_audit_late_failure_atomicity.py
@@ -312,7 +312,7 @@ class DescribeRevisionRollback:
 
 
 class DescribeExactReplacementRollback:
-    def it_rolls_back_a_narrowed_edit_when_original_span_refresh_fails(
+    def it_rolls_back_a_narrowed_edit_after_a_late_failure(
         self, monkeypatch
     ):
         document = docx.Document()
@@ -323,22 +323,13 @@ class DescribeExactReplacementRollback:
         span = find_one(
             document, "Section 3. Termination", match="normalized"
         )
-        original = search_module.Span._refresh_after_ordinary_mutation
+        original = search_module._apply_text_assignments  # pyright: ignore[reportPrivateUsage]
 
-        def refresh_or_refuse(candidate, *, before_prefix, after_suffix):
-            if candidate is span:
-                raise UnsupportedStructureError("forced outer refresh refusal")
-            return original(
-                candidate,
-                before_prefix=before_prefix,
-                after_suffix=after_suffix,
-            )
+        def apply_then_refuse(assignments):  # pyright: ignore[reportMissingParameterType, reportUnknownParameterType]
+            original(assignments)  # pyright: ignore[reportUnknownArgumentType]
+            raise UnsupportedStructureError("forced narrowed replacement refusal")
 
-        monkeypatch.setattr(
-            search_module.Span,
-            "_refresh_after_ordinary_mutation",
-            refresh_or_refuse,
-        )
+        monkeypatch.setattr(search_module, "_apply_text_assignments", apply_then_refuse)
         assert_refusal_atomic(
             document,
             lambda _document: span.replace("Section 4. Termination"),

--- a/tests/paper/test_audit_late_failure_atomicity.py
+++ b/tests/paper/test_audit_late_failure_atomicity.py
@@ -312,6 +312,77 @@ class DescribeRevisionRollback:
 
 
 class DescribeExactReplacementRollback:
+    def it_rolls_back_a_narrowed_edit_when_original_span_refresh_fails(
+        self, monkeypatch
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Section 3.")
+        paragraph.add_run().add_tab()
+        paragraph.add_run("Termination")
+        span = find_one(
+            document, "Section 3. Termination", match="normalized"
+        )
+        original = search_module.Span._refresh_after_ordinary_mutation
+
+        def refresh_or_refuse(candidate, *, before_prefix, after_suffix):
+            if candidate is span:
+                raise UnsupportedStructureError("forced outer refresh refusal")
+            return original(
+                candidate,
+                before_prefix=before_prefix,
+                after_suffix=after_suffix,
+            )
+
+        monkeypatch.setattr(
+            search_module.Span,
+            "_refresh_after_ordinary_mutation",
+            refresh_or_refuse,
+        )
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("Section 4. Termination"),
+            UnsupportedStructureError,
+        )
+        assert paragraph.text == "Section 3.\tTermination"
+        assert span.text == "Section 3.\tTermination"
+        assert span.match_policy == "normalized"
+        span._validate_fresh()
+
+    def it_restores_ordinary_assignments_and_the_live_span_after_a_late_failure(
+        self, monkeypatch
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("alpha").bold = True
+        paragraph.add_run("beta").bold = True
+        span = find_one(document, "alphabeta")
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        original_atoms = tuple(span._atoms)
+        original_offsets = (span._start_offset, span._end_offset)
+        original_policy = span.match_policy
+
+        def apply_then_refuse(assignments):
+            assignments[0].element.text = assignments[0].after
+            assignments[0].element.set(qn("xml:space"), "preserve")
+            raise UnsupportedStructureError("forced late ordinary refusal")
+
+        monkeypatch.setattr(
+            search_module, "_apply_text_assignments", apply_then_refuse
+        )
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed"),
+            UnsupportedStructureError,
+        )
+        assert [element.text for element in elements] == ["alpha", "beta"]
+        assert all(element.get(qn("xml:space")) is None for element in elements)
+        assert tuple(span._atoms) == original_atoms
+        assert (span._start_offset, span._end_offset) == original_offsets
+        assert span.match_policy == original_policy
+        assert span.text == "alphabeta"
+        span._validate_fresh()
+
     def it_restores_text_nodes_and_the_live_span_after_a_late_failure(
         self, monkeypatch
     ):

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -304,6 +304,35 @@ class DescribeReplaceAll:
         assert "exact affix alignment is ambiguous" in result.refused[0]["message"]  # pyright: ignore[reportUnknownMemberType]
         assert document.element.xml == before
 
+    def it_records_tracked_formatting_refusals_and_continues_safe_matches(self):
+        document = _doc()
+        document.add_paragraph("token")
+        mixed = document.add_paragraph()
+        mixed.add_run("to").bold = True
+        mixed.add_run("ken").italic = True
+
+        result = replace_all(
+            document,
+            "token",
+            "value",
+            tracked=True,
+            author="Carol QA",
+            date=FROZEN,
+        )
+
+        assert result.replaced_count == 1
+        assert result.results[0].deleted_text == "token"
+        assert result.results[0].inserted_text == "value"
+        assert len(result.refused) == 1  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        assert result.refused[0]["error"] == "UnsupportedStructureError"  # pyright: ignore[reportUnknownMemberType]
+        assert "formatting or structural regions" in result.refused[0]["message"]  # pyright: ignore[reportUnknownMemberType]
+        assert "token" in mixed.text
+        document.revisions.accept_all()
+        assert [block.text for block in iter_blocks(document)][-2:] == [
+            "value",
+            "token",
+        ]
+
     def it_preserves_revision_identity_only_where_needed(self):
         document = _doc()
         document.add_paragraph("base term")

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -427,25 +427,17 @@ class DescribeReplaceAll:
             paragraph.add_run().add_tab()
             paragraph.add_run("Termination")
             paragraphs.append(paragraph)
-        original = search_module.Span._refresh_after_ordinary_mutation
+        original = search_module._apply_text_assignments  # pyright: ignore[reportPrivateUsage]
         refused = False
 
-        def refresh_then_refuse(candidate, *, before_prefix, after_suffix):
+        def apply_then_refuse(assignments):  # pyright: ignore[reportMissingParameterType, reportUnknownParameterType]
             nonlocal refused
-            original(
-                candidate,
-                before_prefix=before_prefix,
-                after_suffix=after_suffix,
-            )
-            if not refused and any(atom.is_synthetic for atom in candidate._atoms):
+            original(assignments)  # pyright: ignore[reportUnknownArgumentType]
+            if not refused:
                 refused = True
-                raise UnsupportedStructureError("forced outer refresh refusal")
+                raise UnsupportedStructureError("forced narrowed replacement refusal")
 
-        monkeypatch.setattr(
-            search_module.Span,
-            "_refresh_after_ordinary_mutation",
-            refresh_then_refuse,
-        )
+        monkeypatch.setattr(search_module, "_apply_text_assignments", apply_then_refuse)
         result = replace_all(
             document,
             "Section 3. Termination",

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -131,6 +131,21 @@ class DescribeBreakTolerantReplace:
         with pytest.raises(UnsupportedStructureError, match="tab or line break"):
             span.replace("Section3Termination")  # no whitespace for the tab
 
+    def it_refuses_ambiguous_synthetic_affix_narrowing_atomically(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A")
+        paragraph.add_run().add_tab()
+        paragraph.add_run("A")
+        span = find_one(document, "A A", match="normalized")
+
+        with pytest.raises(
+            UnsupportedStructureError, match="exact affix alignment is ambiguous"
+        ):
+            span.replace("A")
+
+        assert find_one(document, "A A", match="normalized").text == "A\tA"
+
 
 class DescribeHyperlinkInteriorEdits:
     """Text inside one hyperlink is redlinable; crossing its boundary is not."""
@@ -273,6 +288,21 @@ class DescribeReplaceAll:
             "value",
             "token",
         ]
+
+    def it_records_ambiguous_affix_refusals_without_mutation(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Term").bold = True
+        paragraph.add_run("Term")
+        before = document.element.xml
+
+        result = replace_all(document, "TermTerm", "Term")
+
+        assert result.replaced_count == 0
+        assert len(result.refused) == 1  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        assert result.refused[0]["error"] == "UnsupportedStructureError"  # pyright: ignore[reportUnknownMemberType]
+        assert "exact affix alignment is ambiguous" in result.refused[0]["message"]  # pyright: ignore[reportUnknownMemberType]
+        assert document.element.xml == before
 
     def it_preserves_revision_identity_only_where_needed(self):
         document = _doc()

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -271,7 +271,7 @@ class DescribeReplaceAll:
         assert payload["results"][0]["preserved_revision_ids"] == []
         assert payload["results"][0]["preserved_formatting_regions"] is True
 
-    def it_records_mixed_region_refusals_and_continues_safe_matches(self):
+    def it_records_when_a_batch_inherits_start_run_formatting(self):
         document = _doc()
         document.add_paragraph("token")
         mixed = document.add_paragraph()
@@ -280,13 +280,15 @@ class DescribeReplaceAll:
 
         result = replace_all(document, "token", "value")
 
-        assert result.replaced_count == 1
-        assert result.results[0].preserved_formatting_regions
-        assert len(result.refused) == 1
-        assert result.refused[0]["error"] == "UnsupportedStructureError"
+        assert result.replaced_count == 2
+        assert sorted(item.preserved_formatting_regions for item in result.results) == [
+            False,
+            True,
+        ]
+        assert result.refused == ()
         assert [paragraph.text for paragraph in document.paragraphs[-2:]] == [
             "value",
-            "token",
+            "value",
         ]
 
     def it_records_ambiguous_affix_refusals_without_mutation(self):
@@ -304,7 +306,7 @@ class DescribeReplaceAll:
         assert "exact affix alignment is ambiguous" in result.refused[0]["message"]  # pyright: ignore[reportUnknownMemberType]
         assert document.element.xml == before
 
-    def it_records_tracked_formatting_refusals_and_continues_safe_matches(self):
+    def it_tracks_all_mixed_format_matches_with_start_run_inheritance(self):
         document = _doc()
         document.add_paragraph("token")
         mixed = document.add_paragraph()
@@ -320,17 +322,14 @@ class DescribeReplaceAll:
             date=FROZEN,
         )
 
-        assert result.replaced_count == 1
-        assert result.results[0].deleted_text == "token"
-        assert result.results[0].inserted_text == "value"
-        assert len(result.refused) == 1  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
-        assert result.refused[0]["error"] == "UnsupportedStructureError"  # pyright: ignore[reportUnknownMemberType]
-        assert "formatting or structural regions" in result.refused[0]["message"]  # pyright: ignore[reportUnknownMemberType]
-        assert "token" in mixed.text
+        assert result.replaced_count == 2
+        assert all(item.deleted_text == "token" for item in result.results)
+        assert all(item.inserted_text == "value" for item in result.results)
+        assert result.refused == ()
         document.revisions.accept_all()
         assert [block.text for block in iter_blocks(document)][-2:] == [
             "value",
-            "token",
+            "value",
         ]
 
     def it_preserves_revision_identity_only_where_needed(self):
@@ -363,9 +362,12 @@ class DescribeReplaceAll:
         assert all(item.preserved_structure for item in result.results)
         assert "value value" in [block.text for block in iter_blocks(document)]
 
-    @pytest.mark.parametrize("preserve_structure", [False, True])
+    @pytest.mark.parametrize(
+        ("tracked", "preserve_structure"),
+        [(False, False), (True, False), (False, True)],
+    )
     def it_uses_only_the_outer_batch_transaction(
-        self, monkeypatch, preserve_structure: bool
+        self, monkeypatch, tracked: bool, preserve_structure: bool
     ):
         document = _doc()
         document.add_paragraph("token token")
@@ -379,13 +381,14 @@ class DescribeReplaceAll:
             with original(*args, **kwargs):
                 yield
 
-        monkeypatch.setattr(
-            search_module, "rollback_on_error", counted_transaction
-        )
+        monkeypatch.setattr(search_module, "rollback_on_error", counted_transaction)
         replace_all(
             document,
             "token",
             "value",
+            tracked=tracked,
+            author="Carol QA" if tracked else None,
+            date=FROZEN if tracked else None,
             preserve_structure=preserve_structure,
         )
         assert transaction_count == 1

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -248,13 +248,31 @@ class DescribeReplaceAll:
         document.add_paragraph("{{y}}")
         payload = replace_all(document, "{{y}}", "z").to_dict()
         assert payload["schema"] == "paper_replace_all"
-        assert payload["version"] == 1
+        assert payload["version"] == 2
         assert payload["replaced_count"] == 1
-        nested = payload["results"][0]
-        assert nested["schema"] == "paper_replace"
-        assert nested["version"] == 1
-        assert nested["preserved_structure"] is False
-        assert nested["preserved_revision_ids"] == []
+        assert payload["results"][0]["schema"] == "paper_replace"
+        assert payload["results"][0]["version"] == 2
+        assert payload["results"][0]["preserved_structure"] is False
+        assert payload["results"][0]["preserved_revision_ids"] == []
+        assert payload["results"][0]["preserved_formatting_regions"] is True
+
+    def it_records_mixed_region_refusals_and_continues_safe_matches(self):
+        document = _doc()
+        document.add_paragraph("token")
+        mixed = document.add_paragraph()
+        mixed.add_run("to")
+        mixed.add_run("ken").bold = True
+
+        result = replace_all(document, "token", "value")
+
+        assert result.replaced_count == 1
+        assert result.results[0].preserved_formatting_regions
+        assert len(result.refused) == 1
+        assert result.refused[0]["error"] == "UnsupportedStructureError"
+        assert [paragraph.text for paragraph in document.paragraphs[-2:]] == [
+            "value",
+            "token",
+        ]
 
     def it_preserves_revision_identity_only_where_needed(self):
         document = _doc()
@@ -273,6 +291,7 @@ class DescribeReplaceAll:
             (),
             (801,),
         ]
+        assert all(item.preserved_formatting_regions for item in result.results)
         assert document.element.body.xpath('//w:ins[@w:id="801"]')
 
     def it_reports_exact_structure_evidence_for_each_successful_match(self):
@@ -374,6 +393,93 @@ class DescribeReplaceAll:
         assert result.replaced_count == 1
         assert len(result.refused) == 1
         assert "token value" in [block.text for block in iter_blocks(document)]
+
+    def it_locally_restores_a_late_ordinary_match_refusal(self, monkeypatch):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("to")
+        paragraph.add_run("ken")
+        paragraph.add_run(" token")
+        original = search_module._apply_text_assignments
+        calls = 0
+
+        def refuse_second(assignments):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                assignments[0].element.text = "corrupt"
+                raise UnsupportedStructureError("forced late refusal")
+            original(assignments)
+
+        monkeypatch.setattr(search_module, "_apply_text_assignments", refuse_second)
+        result = replace_all(document, "token", "value")
+
+        assert result.replaced_count == 1
+        assert len(result.refused) == 1
+        assert paragraph.text == "token value"
+
+    def it_locally_restores_a_late_narrowed_match_refusal(self, monkeypatch):
+        document = _doc()
+        paragraphs = []
+        for _ in range(2):
+            paragraph = document.add_paragraph()
+            paragraph.add_run("Section 3.")
+            paragraph.add_run().add_tab()
+            paragraph.add_run("Termination")
+            paragraphs.append(paragraph)
+        original = search_module.Span._refresh_after_ordinary_mutation
+        refused = False
+
+        def refresh_then_refuse(candidate, *, before_prefix, after_suffix):
+            nonlocal refused
+            original(
+                candidate,
+                before_prefix=before_prefix,
+                after_suffix=after_suffix,
+            )
+            if not refused and any(atom.is_synthetic for atom in candidate._atoms):
+                refused = True
+                raise UnsupportedStructureError("forced outer refresh refusal")
+
+        monkeypatch.setattr(
+            search_module.Span,
+            "_refresh_after_ordinary_mutation",
+            refresh_then_refuse,
+        )
+        result = replace_all(
+            document,
+            "Section 3. Termination",
+            "Section 4. Termination",
+            match="normalized",
+        )
+
+        assert result.replaced_count == 1
+        assert len(result.refused) == 1
+        assert [paragraph.text for paragraph in paragraphs] == [
+            "Section 4.\tTermination",
+            "Section 3.\tTermination",
+        ]
+
+    def it_rolls_back_the_batch_after_an_unexpected_ordinary_failure(
+        self, monkeypatch
+    ):
+        document = _doc()
+        paragraph = document.add_paragraph("token token")
+        original = search_module._apply_text_assignments
+        calls = 0
+
+        def fail_second(assignments):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                assignments[0].element.text = "corrupt"
+                raise RuntimeError("forced unexpected ordinary failure")
+            original(assignments)
+
+        monkeypatch.setattr(search_module, "_apply_text_assignments", fail_second)
+        with pytest.raises(RuntimeError, match="forced unexpected ordinary"):
+            replace_all(document, "token", "value")
+        assert paragraph.text == "token token"
 
     def it_rolls_back_the_batch_after_an_unexpected_exact_failure(self, monkeypatch):
         document = _doc()

--- a/tests/paper/test_honesty_guards.py
+++ b/tests/paper/test_honesty_guards.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import docx
+from docx.bookmarks import list_bookmarks
 from docx.errors import TargetNotFoundError, UnsupportedStructureError
 from docx.package import diagnose
 from docx.search import find_one
@@ -121,11 +122,15 @@ class DescribeUntrackedEditInsideInsertions:
 class DescribeBookmarkHollowing:
     """Replaces must not silently empty cross-reference targets."""
 
-    def it_refuses_a_replace_that_hollows_a_named_bookmark(self):
+    def it_preserves_a_named_bookmark_around_exact_unchanged_affixes(self):
         document = _doc(BOOKMARKS)
         span = find_one(document, "See the Master Agreement for definitions.")
-        with pytest.raises(UnsupportedStructureError, match="DefinedTerm"):
-            span.replace("See the Purchase Agreement for definitions.")
+        span.replace("See the Purchase Agreement for definitions.")
+
+        bookmark = next(
+            item for item in list_bookmarks(document) if item.name == "DefinedTerm"
+        )
+        assert bookmark.text == "the Purchase Agreement"
 
     def it_allows_replacing_text_inside_the_bookmark(self):
         """Markers outside the span: the new text stays bookmarked."""

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -115,6 +115,21 @@ class DescribeTabAndBreakMatching:
         find_one(document, "beta").replace("gamma")
         assert paragraph.text == "alpha\tgamma"
 
+    def it_refreshes_the_original_span_after_break_adjacent_narrowing(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Section 3.")
+        paragraph.add_run().add_tab()
+        paragraph.add_run("Termination")
+        span = find_one(document, "Section 3. Termination", match="normalized")
+
+        result = span.replace("Section 4. Termination")
+
+        assert result.preserved_formatting_regions
+        assert span.text == "Section 4.\tTermination"
+        assert span.match_policy is None
+        span._validate_fresh()
+
 
 class DescribeOriginalViewNestedDeletions:
     def it_excludes_deletions_nested_inside_pending_insertions(self):
@@ -162,6 +177,28 @@ class DescribeConsumedAndDetachedSpans:
         with pytest.raises(TargetNotFoundError, match="structure-preserving"):
             span.replace("again")
         assert find_one(document, "thoroughly mundane").text == "thoroughly mundane"
+
+    def it_refreshes_a_partial_ordinary_span_for_reuse(self):
+        document = docx.Document()
+        document.add_paragraph("prefix target suffix")
+        span = find_one(document, "target")
+
+        span.replace("changed")
+        span.replace("renewed")
+
+        assert document.paragraphs[0].text == "prefix renewed suffix"
+        span._validate_fresh()
+
+    def it_refreshes_raw_position_across_a_paragraph_boundary(self):
+        document = docx.Document()
+        document.add_paragraph("before")
+        document.add_paragraph("target")
+        span = find_one(document, "target")
+
+        span.replace("changed")
+
+        assert span._raw_start == len("before\n")  # noqa: SLF001
+        assert span._raw_start == find_one(document, "changed")._raw_start  # noqa: SLF001
 
 
 class DescribePreservedRevisionAncestry:

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -115,7 +115,7 @@ class DescribeTabAndBreakMatching:
         find_one(document, "beta").replace("gamma")
         assert paragraph.text == "alpha\tgamma"
 
-    def it_refreshes_the_original_span_after_break_adjacent_narrowing(self):
+    def it_consumes_the_original_span_after_break_adjacent_narrowing(self):
         document = _doc()
         paragraph = document.add_paragraph()
         paragraph.add_run("Section 3.")
@@ -126,9 +126,27 @@ class DescribeTabAndBreakMatching:
         result = span.replace("Section 4. Termination")
 
         assert result.preserved_formatting_regions
-        assert span.text == "Section 4.\tTermination"
-        assert span.match_policy is None
-        span._validate_fresh()
+        assert paragraph.text == "Section 4.\tTermination"
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("Section 5. Termination")
+        fresh = find_one(document, "Section 4. Termination", match="normalized")
+        fresh.replace("Section 5. Termination")
+        assert paragraph.text == "Section 5.\tTermination"
+
+    def it_consumes_the_outer_span_after_narrowed_tracked_replacement(self):
+        document = _doc()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Section 3.")
+        paragraph.add_run().add_tab()
+        paragraph.add_run("Termination")
+        span = find_one(document, "Section 3. Termination", match="normalized")
+
+        span.replace(
+            "Section 4. Termination", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("again", tracked=True, author="Carol QA", date=FROZEN)
 
 
 class DescribeOriginalViewNestedDeletions:
@@ -174,22 +192,26 @@ class DescribeConsumedAndDetachedSpans:
         document = _doc()
         span = find_one(document, "perfectly ordinary")
         span.replace("thoroughly mundane", preserve_structure=True)
-        with pytest.raises(TargetNotFoundError, match="structure-preserving"):
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
             span.replace("again")
         assert find_one(document, "thoroughly mundane").text == "thoroughly mundane"
 
-    def it_refreshes_a_partial_ordinary_span_for_reuse(self):
+    def it_consumes_a_partial_ordinary_span_and_supports_refinding(self):
         document = docx.Document()
         document.add_paragraph("prefix target suffix")
         span = find_one(document, "target")
 
         span.replace("changed")
-        span.replace("renewed")
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("renewed")
+        fresh = find_one(document, "changed")
+        fresh.replace("renewed")
 
         assert document.paragraphs[0].text == "prefix renewed suffix"
-        span._validate_fresh()
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            fresh._validate_fresh()
 
-    def it_refreshes_raw_position_across_a_paragraph_boundary(self):
+    def it_preserves_refind_position_across_a_paragraph_boundary(self):
         document = docx.Document()
         document.add_paragraph("before")
         document.add_paragraph("target")
@@ -198,7 +220,10 @@ class DescribeConsumedAndDetachedSpans:
         span.replace("changed")
 
         assert span._raw_start == len("before\n")  # noqa: SLF001
-        assert span._raw_start == find_one(document, "changed")._raw_start  # noqa: SLF001
+        fresh = find_one(document, "changed")
+        assert span._raw_start == fresh._raw_start  # noqa: SLF001
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span._validate_fresh()
 
 
 class DescribePreservedRevisionAncestry:

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -490,6 +490,48 @@ class DescribePlainReplace:
         assert paragraph.text == "AXB"
         assert "".join(run.text for run in paragraph.runs if run.bold) == "AXB"
 
+    def it_refuses_an_insertion_across_a_proofing_marker_atomically(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("A")
+        first.bold = True
+        first._r.addnext(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        )
+        paragraph.add_run("B").bold = True
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("AXB"),
+            UnsupportedStructureError,
+        )
+
+        assert "positional marker" in str(refusal)
+
+    def it_refuses_an_insertion_across_a_bookmark_boundary_atomically(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("A")
+        first.bold = True
+        first._r.addnext(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:bookmarkStart {W} w:id="42" w:name="target"/>')
+        )
+        last = paragraph.add_run("B")
+        last.bold = True
+        last._r.addnext(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:bookmarkEnd {W} w:id="42"/>')
+        )
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("AXB"),
+            UnsupportedStructureError,
+        )
+
+        assert "bookmark 'target'" in str(refusal)
+
     def it_allows_equivalent_distinct_inline_wrappers(self):
         document = docx.Document()
         paragraph = document.add_paragraph()

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -16,6 +16,7 @@ from lxml import etree
 
 import docx
 import docx._clock
+from docx.enum.style import WD_STYLE_TYPE
 from docx.errors import (
     AmbiguousTargetError,
     BoundaryViolationError,
@@ -364,9 +365,12 @@ class DescribePlainReplace:
 
     def it_survives_a_bold_to_italic_formatting_transition(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
-        find_one(document, "100/hr on a “full-").replace("90/hr on any “full-")
-        reopened = save_and_reopen(document, tmp_path / "out.docx")
-        assert "90/hr on any “full-service”" in reopened.paragraphs[0].text
+        span = find_one(document, "100/hr on a “full-")
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("90/hr on any “full-"),
+            UnsupportedStructureError,
+        )
 
     def it_restores_text_and_formatting_when_inverting_a_uniform_span(
         self, tmp_path: Path
@@ -389,27 +393,163 @@ class DescribePlainReplace:
         bold_text = "".join(r.text for r in paragraph.runs if r.bold)
         assert bold_text == "$75–100/hr"
 
-    def it_restores_text_and_outside_formatting_for_mixed_spans(
+    def it_refuses_mixed_spans_instead_of_adopting_the_start_run(self):
+        document = _doc(FRAGMENTED)
+        span = find_one(document, RATE_TEXT)
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("something else entirely"),
+            UnsupportedStructureError,
+        )
+
+    def it_preserves_exact_affixes_in_their_own_formatting_regions(
         self, tmp_path: Path
     ):
-        """A span covering a formatting transition collapses ITS OWN interior
-        formatting into the start run when replaced — that information is
-        destroyed by any replacement. The
-        inverse still restores the visible text exactly and never disturbs
-        formatting outside the span."""
-        document = _doc(FRAGMENTED)
-        find_one(document, RATE_TEXT).replace("something else entirely")
-        find_one(document, "something else entirely").replace(RATE_TEXT)
-        reopened = save_and_reopen(document, tmp_path / "out.docx")
-        paragraph = reopened.paragraphs[0]
-        assert paragraph.text == (
-            "Consulting rate: $75–100/hr on a “full-service” basis"
-            " — travel time billed at $37.50/hr."
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("prefix ").bold = True
+        paragraph.add_run("middle").italic = True
+        paragraph.add_run(" suffix").underline = True
+
+        result = find_one(document, "prefix middle suffix").replace(
+            "prefix changed suffix"
         )
-        # outside the span, formatting is untouched
-        plain_runs = [r.text for r in paragraph.runs if not r.bold and not r.italic]
-        assert "Consulting rate: " in plain_runs[0]
-        assert any("travel time billed" in text for text in plain_runs)
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "affixes.docx")
+        runs = reopened.paragraphs[0].runs
+        assert [(run.text, run.bold, run.italic, run.underline) for run in runs] == [
+            ("prefix ", True, None, None),
+            ("changed", None, True, None),
+            (" suffix", None, None, True),
+        ]
+
+    def it_replaces_equivalent_fragmented_runs_and_refreshes_the_span(
+        self, tmp_path: Path
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("frag").bold = True
+        paragraph.add_run("mented").bold = True
+        span = find_one(document, "fragmented")
+
+        first = span.replace("unified")
+        second = span.replace("renewed")
+
+        assert first.preserved_formatting_regions
+        assert second.preserved_formatting_regions
+        assert span.match_policy is None
+        reopened = save_and_reopen(document, tmp_path / "fragmented.docx")
+        assert reopened.paragraphs[0].text == "renewed"
+        assert "".join(run.text for run in reopened.paragraphs[0].runs if run.bold) == "renewed"
+
+    def it_keeps_a_plain_noop_reusable_and_consumes_complete_deletion(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        span = find_one(document, "target")
+
+        result = span.replace("target")
+        assert result.preserved_formatting_regions
+        span.replace("target")
+        span.replace("")
+
+        with pytest.raises(TargetNotFoundError, match="re-find"):
+            span.replace("again")
+
+    def it_updates_xml_space_for_an_ordinary_replacement(self, tmp_path: Path):
+        document = docx.Document()
+        document.add_paragraph("plain")
+
+        result = find_one(document, "plain").replace(" edged ")
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "space.docx")
+        element = reopened.paragraphs[0]._p.find(".//" + qn("w:t"))
+        assert element is not None
+        assert element.text == " edged "
+        assert element.get(qn("xml:space")) == "preserve"
+
+    def it_refuses_different_complete_run_properties_even_when_values_agree(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("alpha")
+        second = paragraph.add_run("beta")
+        first.bold = True
+        second.bold = True
+        second._r.get_or_add_rPr().find(qn("w:b")).set(qn("w:val"), "1")
+        span = find_one(document, "alphabeta")
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_present_unresolved_run_formatting(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph("target")
+        rpr = paragraph.runs[0]._r.get_or_add_rPr()
+        rpr.append(parse_xml(f'<w:shd {W} w:fill="FFFF00"/>'))
+        span = find_one(document, "target")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed"),
+            UnsupportedStructureError,
+        )
+        assert "cannot compare" in str(refusal)
+
+    def it_refuses_distinct_effective_character_styles(self):
+        document = docx.Document()
+        first_style = document.styles.add_style(
+            "Replacement First", WD_STYLE_TYPE.CHARACTER
+        )
+        first_style.font.bold = True
+        second_style = document.styles.add_style(
+            "Replacement Second", WD_STYLE_TYPE.CHARACTER
+        )
+        second_style.font.italic = True
+        paragraph = document.add_paragraph()
+        paragraph.add_run("alpha", style=first_style)
+        paragraph.add_run("beta", style=second_style)
+        span = find_one(document, "alphabeta")
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_a_positional_marker_inside_the_changed_interval(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("alpha")
+        paragraph.add_run("beta")
+        first._r.addnext(parse_xml(f'<w:proofErr {W} w:type="spellStart"/>'))
+        span = find_one(document, "alphabeta")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("changed"),
+            UnsupportedStructureError,
+        )
+        assert "positional marker" in str(refusal)
+
+    def it_preserves_a_marker_wholly_inside_an_unchanged_affix(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        first = paragraph.add_run("prefix")
+        marker = parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        first._r.addnext(marker)
+        paragraph.add_run(" target")
+
+        find_one(document, "prefix target").replace("prefix changed")
+
+        reopened = save_and_reopen(document, tmp_path / "marker-affix.docx")
+        children = list(reopened.paragraphs[0]._p)
+        assert [child.tag for child in children] == [
+            qn("w:r"), qn("w:proofErr"), qn("w:r")
+        ]
 
     def it_keeps_the_changed_part_budget_to_the_document_part(self, tmp_path: Path):
         source = fixture_path(FRAGMENTED)
@@ -420,6 +560,35 @@ class DescribePlainReplace:
         out = tmp_path / "out.docx"
         docx.package.patch_save(working, document, out)
         assert_changed_parts(working, out, {"word/document.xml"})
+
+    def it_keeps_a_header_edit_to_its_own_story_part(self, tmp_path: Path):
+        source = fixture_path(GAUNTLET)
+        working = tmp_path / "header-work.docx"
+        shutil.copyfile(source, working)
+        document = docx.Document(str(working))
+        result = find_one(document, "Gauntlet header, section one").replace(
+            "Reviewed header, section one"
+        )
+        out = tmp_path / "header-out.docx"
+        docx.package.patch_save(working, document, out)
+        assert result.story == "word/header1.xml"
+        assert result.preserved_formatting_regions
+        assert_changed_parts(working, out, {"word/header1.xml"})
+
+    @pytest.mark.lo_smoke
+    def it_writes_a_safe_fragmented_replacement_libreoffice_can_open(
+        self, tmp_path: Path
+    ):
+        from .harness.lo import assert_libreoffice_opens
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("frag").bold = True
+        paragraph.add_run("mented").bold = True
+        find_one(document, "fragmented").replace("unified")
+        out = tmp_path / "safe-fragmented.docx"
+        document.save(out)
+        assert_libreoffice_opens(out)
 
 
 class DescribePreservationPolicies:
@@ -441,6 +610,7 @@ class DescribePreservationPolicies:
             "revised", preserve_revision=True
         )
         assert result.preserved_revision_ids == (41,)
+        assert result.preserved_formatting_regions
         assert not result.preserved_structure
         assert dict(insertion.attrib) == attributes
         assert [b.text for b in iter_blocks(document, view="original")] == original
@@ -625,10 +795,14 @@ class DescribePreservationPolicies:
         result = span.replace("outsideinside", preserve_revision=True)
 
         assert result.preserved_revision_ids == (42,)
+        assert result.preserved_formatting_regions
         assert document.element.xml == before
         span.replace("outsideinside", preserve_revision=True)
 
-    def it_does_not_apply_the_revision_noop_policy_to_base_text(self):
+    @pytest.mark.parametrize("preserve_revision", [False, True])
+    def it_keeps_a_base_text_noop_reusable_across_a_bookmark(
+        self, preserve_revision: bool
+    ):
         document = docx.Document()
         paragraph = document.add_paragraph()
         first = paragraph.add_run("outside")
@@ -638,13 +812,16 @@ class DescribePreservationPolicies:
         inside = paragraph.add_run("inside")
         inside._r.addnext(parse_xml(f'<w:bookmarkEnd {W} w:id="11"/>'))
         before = document.element.xml
+        span = find_one(document, "outsideinside")
 
-        with pytest.raises(UnsupportedStructureError, match="hollow"):
-            find_one(document, "outsideinside").replace(
-                "outsideinside", preserve_revision=True
-            )
+        result = span.replace(
+            "outsideinside", preserve_revision=preserve_revision
+        )
 
+        assert result.preserved_revision_ids == ()
+        assert result.preserved_formatting_regions
         assert document.element.xml == before
+        span.replace("outsideinside", preserve_revision=preserve_revision)
 
     def it_leaves_an_exact_noop_reusable(self):
         document = docx.Document()
@@ -652,6 +829,9 @@ class DescribePreservationPolicies:
         span = find_one(document, "same")
         before = document.element.xml
         assert span.replace("same", preserve_structure=True).preserved_structure
+        assert not span.replace(
+            "same", preserve_structure=True
+        ).preserved_formatting_regions
         assert document.element.xml == before
         span.replace("same", preserve_structure=True)
 
@@ -755,6 +935,7 @@ class DescribeTrackedReplace:
         )
         assert result.deleted_text == "75–10"
         assert result.inserted_text == "85–11"
+        assert not result.preserved_formatting_regions
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         blocks = list(iter_blocks(reopened))
         assert "$85–110/hr" in blocks[0].text  # current view: change applied

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -1259,6 +1259,94 @@ class DescribeTrackedReplace:
         uniform.revisions.accept_all()
         assert uniform_paragraph.text == "AXB"
 
+    def it_keeps_multirun_affixes_untouched_around_a_tracked_insertion(
+        self, tmp_path: Path
+    ):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A").bold = True
+        paragraph.add_run("A")
+        paragraph.add_run("B")
+
+        result = find_one(document, "AAB").replace(
+            "AAXB", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        assert result.deleted_text == ""
+        assert result.inserted_text == "X"
+        path = tmp_path / "tracked-insertion-affixes.docx"
+        reopened = save_and_reopen(document, path)
+        assert [block.text for block in iter_blocks(reopened)] == ["AAXB"]
+        assert [block.text for block in iter_blocks(reopened, view="original")] == [
+            "AAB"
+        ]
+        assert [(run.text, run.bold) for run in reopened.paragraphs[0].runs] == [
+            ("A", True),
+            ("A", None),
+            ("B", None),
+        ]
+
+        accepted = docx.Document(str(path))
+        accepted.revisions.accept_all()
+        assert [(run.text, run.bold) for run in accepted.paragraphs[0].runs] == [
+            ("A", True),
+            ("A", None),
+            ("X", None),
+            ("B", None),
+        ]
+        rejected = docx.Document(str(path))
+        rejected.revisions.reject_all()
+        assert [(run.text, run.bold) for run in rejected.paragraphs[0].runs] == [
+            ("A", True),
+            ("A", None),
+            ("B", None),
+        ]
+
+    @pytest.mark.parametrize(
+        ("retained_xml", "refusal_type", "message"),
+        [
+            (
+                '<w:fldSimple w:instr=" DATE "><w:r><w:t>B</w:t></w:r></w:fldSimple>',
+                UnsupportedStructureError,
+                "field result",
+            ),
+            (
+                '<w:hyperlink w:anchor="target"><w:r><w:t>B</w:t></w:r></w:hyperlink>',
+                BoundaryViolationError,
+                "hyperlink boundary",
+            ),
+            (
+                "<w:sdt><w:sdtPr><w:tag w:val=\"target\"/></w:sdtPr>"
+                "<w:sdtContent><w:r><w:t>B</w:t></w:r></w:sdtContent></w:sdt>",
+                BoundaryViolationError,
+                "content-control boundary",
+            ),
+        ],
+    )
+    def it_refuses_narrowing_across_retained_mutation_scopes(
+        self,
+        retained_xml: str,
+        refusal_type: type[BaseException],
+        message: str,
+    ):
+        document = docx.Document()
+        paragraph = parse_xml(
+            f'<w:p {W}><w:r><w:t>A</w:t><w:tab/></w:r>{retained_xml}</w:p>'
+        )
+        document.element.body.insert(0, paragraph)  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+        span = find_one(document, "A B", match="normalized")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "X B", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            refusal_type,
+        )
+
+        assert message in str(refusal)
+        assert not paragraph.xpath(".//w:ins | .//w:del")
+
     def it_proves_complete_tracked_destination_evidence(self):
         compatible = docx.Document()
         compatible_paragraph = parse_xml(

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -459,7 +459,7 @@ class DescribePlainReplace:
             UnsupportedStructureError,
         )
 
-        assert "exact affix alignment is ambiguous" in str(refusal)
+        assert "insertion point has competing" in str(refusal)
         assert span.replace("AB").preserved_formatting_regions
 
     def it_refuses_an_insertion_at_an_unlisted_wrapper_boundary_atomically(self):
@@ -477,7 +477,7 @@ class DescribePlainReplace:
             UnsupportedStructureError,
         )
 
-        assert "exact affix alignment is ambiguous" in str(refusal)
+        assert "insertion point has competing" in str(refusal)
 
     def it_allows_an_insertion_between_equivalent_destinations(self):
         document = docx.Document()
@@ -1081,21 +1081,294 @@ class DescribeReplaceRefusals:
 
 
 class DescribeTrackedReplace:
-    def it_keeps_its_existing_greedy_repeated_affix_behavior(self):
+    def it_refuses_repeated_affix_ambiguity_atomically(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
-        paragraph.add_run("Term").bold = True
         paragraph.add_run("Term")
+        paragraph.add_run("Term")
+        span = find_one(document, "TermTerm")
 
-        result = find_one(document, "TermTerm").replace(
-            "Term", tracked=True, author="Carol QA", date=FROZEN
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "Term", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
         )
 
-        assert result.deleted_text == "Term"
+        assert "exact affix alignment is ambiguous" in str(refusal)
+        assert "exact substring" in str(refusal)
+        assert not paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            ".//w:ins | .//w:del"
+        )
+        assert span.replace("TermTerm!").tracked is False
+
+    def it_refuses_competing_tracked_formatting_atomically(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Al").bold = True
+        paragraph.add_run("pha").italic = True
+        span = find_one(document, "Alpha")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "Omega", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "formatting or structural regions" in str(refusal)
+        assert "smaller span" in str(refusal)
+        assert "explicitly" in str(refusal)
+        assert not paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            ".//w:ins | .//w:del"
+        )
+        assert span.replace("Alpha!").tracked is False
+
+    def it_tracks_a_uniform_fragmented_change_and_round_trips(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Al").bold = True
+        paragraph.add_run("pha").bold = True
+
+        result = find_one(document, "Alpha").replace(
+            "Omega", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        assert result.deleted_text == "Alph"
+        assert result.inserted_text == "Omeg"
+        path = tmp_path / "uniform-fragmented.docx"
+        reopened = save_and_reopen(document, path)
+        assert [block.text for block in iter_blocks(reopened)] == ["Omega"]
+        assert [block.text for block in iter_blocks(reopened, view="original")] == [
+            "Alpha"
+        ]
+        (inserted_rpr,) = reopened.element.body.xpath(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue, reportUnknownVariableType]
+            "//w:ins/w:r/w:rPr"
+        )
+        assert inserted_rpr.find(qn("w:b")) is not None  # pyright: ignore[reportUnknownMemberType]
+
+        accepted = docx.Document(str(path))
+        accepted.revisions.accept_all()
+        assert [block.text for block in iter_blocks(accepted)] == ["Omega"]
+        assert accepted.paragraphs[0].runs[0].bold
+        rejected = docx.Document(str(path))
+        rejected.revisions.reject_all()
+        assert [block.text for block in iter_blocks(rejected)] == ["Alpha"]
+        assert all(run.bold for run in rejected.paragraphs[0].runs if run.text)
+
+    def it_keeps_differently_formatted_exact_affixes_in_place(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("pre-").bold = True
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        )
+        paragraph.add_run("old")
+        paragraph.add_run("-post").italic = True
+
+        result = find_one(document, "pre-old-post").replace(
+            "pre-new-post", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        assert result.deleted_text == "old"
+        assert result.inserted_text == "new"
+        reopened = save_and_reopen(document, tmp_path / "tracked-affixes.docx")
+        assert "".join(
+            reopened.element.body.xpath("//w:del//w:delText/text()")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue, reportUnknownArgumentType]
+        ) == "old"
+        assert "".join(
+            reopened.element.body.xpath("//w:ins//w:t/text()")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue, reportUnknownArgumentType]
+        ) == "new"
+        assert reopened.paragraphs[0].runs[0].text == "pre-"
+        assert reopened.paragraphs[0].runs[0].bold
+        assert reopened.paragraphs[0].runs[-1].text == "-post"
+        assert reopened.paragraphs[0].runs[-1].italic
+
+    def it_deletes_mixed_formatting_with_each_source_property(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("xAl").bold = True
+        paragraph.add_run("phay").italic = True
+
+        result = find_one(document, "Alpha").replace(
+            "", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        assert result.deleted_text == "Alpha"
         assert result.inserted_text == ""
-        document.revisions.accept_all()
-        assert paragraph.text == "Term"
-        assert paragraph.runs[0].bold
+        path = tmp_path / "mixed-delete.docx"
+        reopened = save_and_reopen(document, path)
+        assert not reopened.element.body.xpath("//w:ins")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+        deleted_runs = reopened.element.body.xpath("//w:del/w:r")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue, reportUnknownVariableType]
+        assert "".join(deleted_runs[0].xpath(".//w:delText/text()")) == "Al"  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        assert deleted_runs[0].find("w:rPr/w:b", deleted_runs[0].nsmap) is not None  # pyright: ignore[reportUnknownMemberType]
+        assert "".join(deleted_runs[1].xpath(".//w:delText/text()")) == "pha"  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        assert deleted_runs[1].find("w:rPr/w:i", deleted_runs[1].nsmap) is not None  # pyright: ignore[reportUnknownMemberType]
+        assert [block.text for block in iter_blocks(reopened)] == ["xy"]
+        assert [block.text for block in iter_blocks(reopened, view="original")] == [
+            "xAlphay"
+        ]
+
+        accepted = docx.Document(str(path))
+        accepted.revisions.accept_all()
+        assert accepted.paragraphs[0].text == "xy"
+        rejected = docx.Document(str(path))
+        rejected.revisions.reject_all()
+        assert rejected.paragraphs[0].text == "xAlphay"
+        assert any(run.bold and "Al" in run.text for run in rejected.paragraphs[0].runs)
+        assert any(run.italic and "pha" in run.text for run in rejected.paragraphs[0].runs)
+
+    def it_inserts_only_at_a_proved_tracked_destination(self):
+        inside = docx.Document()
+        inside_paragraph = inside.add_paragraph()
+        inside_paragraph.add_run("AB").bold = True
+        find_one(inside, "AB").replace(
+            "AXB", tracked=True, author="Carol QA", date=FROZEN
+        )
+        inside.revisions.accept_all()
+        assert inside_paragraph.text == "AXB"
+        assert all(run.bold for run in inside_paragraph.runs if run.text)
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A").bold = True
+        paragraph.add_run("B")
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "AXB", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "insertion point has competing" in str(refusal)
+        assert "explicitly" in str(refusal)
+        assert span.replace("AB!").tracked is False
+
+        uniform = docx.Document()
+        uniform_paragraph = uniform.add_paragraph()
+        uniform_paragraph.add_run("A").bold = True
+        uniform_paragraph.add_run("B").bold = True
+        find_one(uniform, "AB").replace(
+            "AXB", tracked=True, author="Carol QA", date=FROZEN
+        )
+        uniform.revisions.accept_all()
+        assert uniform_paragraph.text == "AXB"
+
+    def it_proves_complete_tracked_destination_evidence(self):
+        compatible = docx.Document()
+        compatible_paragraph = parse_xml(
+            f'<w:p {W}>'
+            '<w:customXml w:uri="urn:paper" w:element="same">'
+            '<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>A</w:t></w:r>'
+            '</w:customXml>'
+            '<w:customXml w:uri="urn:paper" w:element="same">'
+            '<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>B</w:t></w:r>'
+            '</w:customXml>'
+            '</w:p>'
+        )
+        compatible.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+            0, compatible_paragraph
+        )
+        find_one(compatible, "AB").replace(
+            "AXB", tracked=True, author="Carol QA", date=FROZEN
+        )
+        compatible.revisions.accept_all()
+        assert [block.text for block in iter_blocks(compatible)] == ["AXB"]
+
+        different_ancestry = docx.Document()
+        different_ancestry.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+            0,
+            parse_xml(
+                f'<w:p {W}>'
+                '<w:customXml w:uri="urn:paper" w:element="left">'
+                '<w:r><w:t>A</w:t></w:r></w:customXml>'
+                '<w:customXml w:uri="urn:paper" w:element="right">'
+                '<w:r><w:t>B</w:t></w:r></w:customXml>'
+                '</w:p>'
+            ),
+        )
+        ancestry_span = find_one(different_ancestry, "AB")
+        ancestry_refusal = assert_refusal_atomic(
+            different_ancestry,
+            lambda _document: ancestry_span.replace(
+                "AXB", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+        assert "competing formatting or structural destinations" in str(
+            ancestry_refusal
+        )
+
+        lexical_rpr = docx.Document()
+        lexical_rpr.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+            0,
+            parse_xml(
+                f'<w:p {W}>'
+                '<w:r><w:rPr><w:b/></w:rPr><w:t>A</w:t></w:r>'
+                '<w:r><w:rPr><w:b w:val="true"/></w:rPr><w:t>B</w:t></w:r>'
+                '</w:p>'
+            ),
+        )
+        rpr_span = find_one(lexical_rpr, "AB")
+        rpr_refusal = assert_refusal_atomic(
+            lexical_rpr,
+            lambda _document: rpr_span.replace(
+                "AXB", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+        assert "competing formatting or structural destinations" in str(rpr_refusal)
+
+    def it_refuses_a_tracked_insertion_across_a_positional_marker(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A")
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        )
+        paragraph.add_run("B")
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "AXB", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "positional marker" in str(refusal)
+        assert not paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            ".//w:ins | .//w:del"
+        )
+
+    def it_refuses_a_tracked_deletion_across_a_positional_marker(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Al")
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
+        )
+        paragraph.add_run("pha")
+        span = find_one(document, "Alpha")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace(
+                "", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+
+        assert "positional marker" in str(refusal)
+        assert not paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            ".//w:ins | .//w:del"
+        )
 
     def it_marks_only_the_minimal_changed_span(self, tmp_path: Path):
         """The redline marks `75-10 -> 85-11`, not the sentence (pinned)."""
@@ -1125,10 +1398,10 @@ class DescribeTrackedReplace:
     def it_allocates_unique_increasing_revision_ids(self):
         document = _doc(TRACKED)  # fixture already holds ids 11, 12, 21
         first = find_one(document, "Paragraph before").replace(
-            "Paragraph just before", tracked=True, author="Carol QA", date=FROZEN
+            "Clause before", tracked=True, author="Carol QA", date=FROZEN
         )
         second = find_one(document, "Paragraph after").replace(
-            "Paragraph right after", tracked=True, author="Carol QA", date=FROZEN
+            "Sentence after", tracked=True, author="Carol QA", date=FROZEN
         )
         all_ids = [int(v) for v in document.element.body.xpath(
             "//w:ins/@w:id | //w:del/@w:id"

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime as dt
 import shutil
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from lxml import etree
@@ -363,14 +364,17 @@ class DescribePlainReplace:
         bold_text = "".join(r.text for r in paragraph.runs if r.bold)
         assert bold_text.startswith("$85")
 
-    def it_survives_a_bold_to_italic_formatting_transition(self, tmp_path: Path):
+    def it_inherits_the_start_run_across_a_bold_to_italic_transition(self, tmp_path: Path):
         document = _doc(FRAGMENTED)
         span = find_one(document, "100/hr on a “full-")
-        assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("90/hr on any “full-"),
-            UnsupportedStructureError,
+        result = span.replace("90/hr on any “full-")
+
+        assert not result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "start-run-inheritance.docx")
+        assert any(
+            run.bold and "90/hr on any " in run.text for run in reopened.paragraphs[0].runs
         )
+        assert any(run.italic and "“full-" in run.text for run in reopened.paragraphs[0].runs)
 
     def it_restores_text_and_formatting_when_inverting_a_uniform_span(
         self, tmp_path: Path
@@ -393,14 +397,58 @@ class DescribePlainReplace:
         bold_text = "".join(r.text for r in paragraph.runs if r.bold)
         assert bold_text == "$75–100/hr"
 
-    def it_refuses_mixed_spans_instead_of_adopting_the_start_run(self):
+    def it_replaces_a_mixed_span_using_the_start_run_formatting(self):
         document = _doc(FRAGMENTED)
         span = find_one(document, RATE_TEXT)
-        assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("something else entirely"),
-            UnsupportedStructureError,
+        result = span.replace("something else entirely")
+
+        assert not result.preserved_formatting_regions
+        assert any(
+            run.bold and run.text == "something else entirely"
+            for run in document.paragraphs[0].runs
         )
+
+    def it_inherits_italic_when_the_changed_interval_starts_in_italics(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Al").italic = True
+        paragraph.add_run("pha").bold = True
+
+        result = find_one(document, "Alpha").replace("Omega")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "Omega"
+        assert any(run.italic and run.text == "Omega" for run in paragraph.runs)
+        assert not any(run.bold and run.text for run in paragraph.runs)
+
+    def it_preserves_an_unchanged_prefix_before_start_run_inheritance(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("PRE").underline = True
+        paragraph.add_run("Al").bold = True
+        paragraph.add_run("pha").italic = True
+
+        result = find_one(document, "PREAlpha").replace("PREOmega")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "PREOmega"
+        assert any(run.underline and run.text == "PRE" for run in paragraph.runs)
+        assert any(run.bold and run.text == "Omega" for run in paragraph.runs)
+        assert not any(run.italic and run.text for run in paragraph.runs)
+
+    def it_leaves_later_suffix_runs_untouched_when_inheriting_from_the_start_run(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Al").bold = True
+        paragraph.add_run("pha").italic = True
+        paragraph.add_run(" END").underline = True
+
+        result = find_one(document, "Alpha END").replace("Omega END")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "Omega END"
+        assert any(run.bold and run.text == "Omega" for run in paragraph.runs)
+        assert any(run.underline and run.text == " END" for run in paragraph.runs)
 
     def it_preserves_exact_affixes_in_their_own_formatting_regions(
         self, tmp_path: Path
@@ -532,25 +580,31 @@ class DescribePlainReplace:
 
         assert "bookmark 'target'" in str(refusal)
 
-    def it_allows_equivalent_distinct_inline_wrappers(self):
+    def it_refuses_replacement_across_equivalent_but_distinct_inline_wrappers(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
         paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
             parse_xml(
                 f'<w:smartTag {W} w:uri="urn:test" w:element="same">'
-                '<w:r><w:t>A</w:t></w:r></w:smartTag>'
+                "<w:r><w:t>A</w:t></w:r></w:smartTag>"
             )
         )
         paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
             parse_xml(
                 f'<w:smartTag {W} w:uri="urn:test" w:element="same">'
-                '<w:r><w:t>B</w:t></w:r></w:smartTag>'
+                "<w:r><w:t>B</w:t></w:r></w:smartTag>"
             )
         )
 
-        find_one(document, "AB").replace("AXB")
+        span = find_one(document, "AB")
 
-        assert find_one(document, "AXB").text == "AXB"
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("XY"),
+            UnsupportedStructureError,
+        )
+
+        assert "separate inline wrapper owners" in str(refusal)
 
     def it_replaces_equivalent_fragmented_runs_and_consumes_the_span(
         self, tmp_path: Path
@@ -601,7 +655,28 @@ class DescribePlainReplace:
         assert element.text == " edged "
         assert element.get(qn("xml:space")) == "preserve"
 
-    def it_refuses_different_complete_run_properties_even_when_values_agree(self):
+    def it_clears_placeholder_state_after_an_ordinary_replacement(self):
+        document = docx.Document()
+        body = cast(Any, document.element).body
+        body.insert(
+            0,
+            parse_xml(
+                f'<w:p {W}><w:sdt><w:sdtPr><w:showingPlcHdr/></w:sdtPr>'
+                '<w:sdtContent><w:r><w:rPr>'
+                '<w:rStyle w:val="PlaceholderText"/></w:rPr>'
+                '<w:t>Click or tap here to enter text.</w:t>'
+                '</w:r></w:sdtContent></w:sdt></w:p>'
+            ),
+        )
+
+        find_one(document, "Click or tap here to enter text.").replace("Filled")
+
+        assert not body.xpath("//w:sdtPr/w:showingPlcHdr")
+        assert not body.xpath('//w:rStyle[@w:val="PlaceholderText"]')
+
+    def it_reports_start_run_inheritance_for_lexically_different_run_properties(
+        self,
+    ):
         document = docx.Document()
         paragraph = document.add_paragraph()
         first = paragraph.add_run("alpha")
@@ -611,11 +686,11 @@ class DescribePlainReplace:
         second._r.get_or_add_rPr().find(qn("w:b")).set(qn("w:val"), "1")
         span = find_one(document, "alphabeta")
 
-        assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("changed"),
-            UnsupportedStructureError,
-        )
+        result = span.replace("changed")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "changed"
+        assert paragraph.runs[0].bold
 
     def it_accepts_single_node_complete_run_formatting(self, tmp_path: Path):
         document = docx.Document()
@@ -650,26 +725,22 @@ class DescribePlainReplace:
             'w:r/w:rPr/w:shd[@w:fill="FFFF00"]'
         )
 
-    def it_refuses_distinct_effective_character_styles(self):
+    def it_inherits_the_starting_character_style(self):
         document = docx.Document()
-        first_style = document.styles.add_style(
-            "Replacement First", WD_STYLE_TYPE.CHARACTER
-        )
+        first_style = document.styles.add_style("Replacement First", WD_STYLE_TYPE.CHARACTER)
         first_style.font.bold = True
-        second_style = document.styles.add_style(
-            "Replacement Second", WD_STYLE_TYPE.CHARACTER
-        )
+        second_style = document.styles.add_style("Replacement Second", WD_STYLE_TYPE.CHARACTER)
         second_style.font.italic = True
         paragraph = document.add_paragraph()
         paragraph.add_run("alpha", style=first_style)
         paragraph.add_run("beta", style=second_style)
         span = find_one(document, "alphabeta")
 
-        assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("changed"),
-            UnsupportedStructureError,
-        )
+        result = span.replace("changed")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "changed"
+        assert paragraph.runs[0].style.name == "Replacement First"
 
     def it_refuses_a_positional_marker_inside_the_changed_interval(self):
         document = docx.Document()
@@ -1081,6 +1152,31 @@ class DescribeReplaceRefusals:
 
 
 class DescribeTrackedReplace:
+    def it_rolls_back_a_late_direct_tracked_failure_and_keeps_the_span_reusable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from docx.oxml.revision import CT_RunTrackChange
+
+        document = docx.Document()
+        paragraph = document.add_paragraph("Alpha")
+        span = find_one(document, "Alpha")
+        before = document.element.xml  # pyright: ignore[reportUnknownMemberType]
+
+        def fail_revision_creation(*_args, **_kwargs):
+            raise RuntimeError("injected revision creation failure")
+
+        monkeypatch.setattr(
+            CT_RunTrackChange,
+            "new",
+            staticmethod(fail_revision_creation),
+        )
+        with pytest.raises(RuntimeError, match="injected revision"):
+            span.replace("Zulu", tracked=True, author="Carol QA", date=FROZEN)
+
+        assert document.element.xml == before  # pyright: ignore[reportUnknownMemberType]
+        assert paragraph.text == "Alpha"
+        assert span.replace("Zulu").inserted_text == "Zulu"
+
     def it_refuses_repeated_affix_ambiguity_atomically(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
@@ -1103,28 +1199,51 @@ class DescribeTrackedReplace:
         )
         assert span.replace("TermTerm!").tracked is False
 
-    def it_refuses_competing_tracked_formatting_atomically(self):
+    def it_tracks_mixed_formatting_with_the_start_run_properties(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
         paragraph.add_run("Al").bold = True
         paragraph.add_run("pha").italic = True
         span = find_one(document, "Alpha")
 
-        refusal = assert_refusal_atomic(
-            document,
-            lambda _document: span.replace(
-                "Omega", tracked=True, author="Carol QA", date=FROZEN
-            ),
-            UnsupportedStructureError,
+        result = span.replace("Omega", tracked=True, author="Carol QA", date=FROZEN)
+
+        assert result.deleted_text == "Alpha"
+        assert result.inserted_text == "Omega"
+        (inserted_rpr,) = paragraph._p.xpath("w:ins/w:r/w:rPr")  # pyright: ignore[reportPrivateUsage]
+        assert inserted_rpr.find(qn("w:b")) is not None
+        assert inserted_rpr.find(qn("w:i")) is None
+        document.revisions.accept_all()
+        assert paragraph.text == "Omega"
+
+    def it_tracks_mixed_formatting_without_collapsing_prefix_or_suffix_runs(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("KEEP").underline = True
+        paragraph.add_run(" PRE").underline = True
+        paragraph.add_run("Al").bold = True
+        paragraph.add_run("pha").italic = True
+        paragraph.add_run(" END").font.small_caps = True
+
+        result = find_one(document, "KEEP PREAlpha END").replace(
+            "KEEP PREOmega END",
+            tracked=True,
+            author="Carol QA",
+            date=FROZEN,
         )
 
-        assert "formatting or structural regions" in str(refusal)
-        assert "smaller span" in str(refusal)
-        assert "explicitly" in str(refusal)
-        assert not paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
-            ".//w:ins | .//w:del"
-        )
-        assert span.replace("Alpha!").tracked is False
+        assert result.deleted_text == "Alpha"
+        assert result.inserted_text == "Omega"
+        assert paragraph.runs[0].text == "KEEP"
+        assert paragraph.runs[0].underline
+        assert paragraph.runs[1].text == " PRE"
+        assert paragraph.runs[1].underline
+        assert paragraph.runs[-1].text == " END"
+        assert paragraph.runs[-1].font.small_caps
+        document.revisions.accept_all()
+        assert paragraph.text == "KEEP PREOmega END"
+        assert any(run.bold and run.text == "Omega" for run in paragraph.runs)
+        assert paragraph.runs[-1].font.small_caps
 
     def it_tracks_a_uniform_fragmented_change_and_round_trips(self, tmp_path: Path):
         document = docx.Document()
@@ -1219,6 +1338,52 @@ class DescribeTrackedReplace:
         assert rejected.paragraphs[0].text == "xAlphay"
         assert any(run.bold and "Al" in run.text for run in rejected.paragraphs[0].runs)
         assert any(run.italic and "pha" in run.text for run in rejected.paragraphs[0].runs)
+
+    def it_deletes_mixed_formatting_inside_one_wrapper_without_moving_ownership(
+        self, tmp_path: Path
+    ):
+        document = docx.Document()
+        paragraph = parse_xml(
+            f'<w:p {W}><w:customXml w:uri="urn:paper" w:element="owner">'
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>Al</w:t></w:r>"
+            "<w:r><w:rPr><w:i/></w:rPr><w:t>pha</w:t></w:r>"
+            "</w:customXml></w:p>"
+        )
+        document.element.body.insert(0, paragraph)  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+
+        find_one(document, "Alpha").replace("", tracked=True, author="Carol QA", date=FROZEN)
+        path = tmp_path / "same-wrapper-delete.docx"
+        document.save(path)
+        rejected = docx.Document(path)
+        rejected.revisions.reject_all()
+
+        (wrapper,) = rejected.element.body.xpath("//w:customXml")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+        assert "".join(element.text or "" for element in wrapper.iter(qn("w:t"))) == "Alpha"
+        assert not rejected.element.body.xpath("//w:customXml[not(@w:element='owner')]//w:t")  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+
+    def it_refuses_a_tracked_deletion_across_separate_identical_wrappers(self):
+        document = docx.Document()
+        paragraph = parse_xml(
+            f"<w:p {W}>"
+            '<w:customXml w:uri="urn:paper" w:element="same">'
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>Al</w:t></w:r>"
+            "</w:customXml>"
+            '<w:customXml w:uri="urn:paper" w:element="same">'
+            "<w:r><w:rPr><w:i/></w:rPr><w:t>pha</w:t></w:r>"
+            "</w:customXml>"
+            "</w:p>"
+        )
+        document.element.body.insert(0, paragraph)  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+        span = find_one(document, "Alpha")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("", tracked=True, author="Carol QA", date=FROZEN),
+            UnsupportedStructureError,
+        )
+
+        assert "separate inline wrapper owners" in str(refusal)
+        assert span.replace("Alpha!").inserted_text == "Alpha!"
 
     def it_inserts_only_at_a_proved_tracked_destination(self):
         inside = docx.Document()
@@ -1350,34 +1515,54 @@ class DescribeTrackedReplace:
     def it_proves_complete_tracked_destination_evidence(self):
         compatible = docx.Document()
         compatible_paragraph = parse_xml(
-            f'<w:p {W}>'
+            f"<w:p {W}>"
             '<w:customXml w:uri="urn:paper" w:element="same">'
-            '<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>A</w:t></w:r>'
-            '</w:customXml>'
-            '<w:customXml w:uri="urn:paper" w:element="same">'
-            '<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>B</w:t></w:r>'
-            '</w:customXml>'
-            '</w:p>'
+            "<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>A</w:t></w:r>"
+            "<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>B</w:t></w:r>"
+            "</w:customXml>"
+            "</w:p>"
         )
         compatible.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
             0, compatible_paragraph
         )
-        find_one(compatible, "AB").replace(
-            "AXB", tracked=True, author="Carol QA", date=FROZEN
-        )
+        find_one(compatible, "AB").replace("AXB", tracked=True, author="Carol QA", date=FROZEN)
         compatible.revisions.accept_all()
         assert [block.text for block in iter_blocks(compatible)] == ["AXB"]
+
+        identical_separate_ancestry = docx.Document()
+        identical_separate_ancestry.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+            0,
+            parse_xml(
+                f"<w:p {W}>"
+                '<w:customXml w:uri="urn:paper" w:element="same">'
+                "<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>A</w:t></w:r>"
+                "</w:customXml>"
+                '<w:customXml w:uri="urn:paper" w:element="same">'
+                "<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>B</w:t></w:r>"
+                "</w:customXml>"
+                "</w:p>"
+            ),
+        )
+        identical_span = find_one(identical_separate_ancestry, "AB")
+        identical_refusal = assert_refusal_atomic(
+            identical_separate_ancestry,
+            lambda _document: identical_span.replace(
+                "AXB", tracked=True, author="Carol QA", date=FROZEN
+            ),
+            UnsupportedStructureError,
+        )
+        assert "competing formatting or structural destinations" in str(identical_refusal)
 
         different_ancestry = docx.Document()
         different_ancestry.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
             0,
             parse_xml(
-                f'<w:p {W}>'
+                f"<w:p {W}>"
                 '<w:customXml w:uri="urn:paper" w:element="left">'
-                '<w:r><w:t>A</w:t></w:r></w:customXml>'
+                "<w:r><w:t>A</w:t></w:r></w:customXml>"
                 '<w:customXml w:uri="urn:paper" w:element="right">'
-                '<w:r><w:t>B</w:t></w:r></w:customXml>'
-                '</w:p>'
+                "<w:r><w:t>B</w:t></w:r></w:customXml>"
+                "</w:p>"
             ),
         )
         ancestry_span = find_one(different_ancestry, "AB")
@@ -1388,26 +1573,22 @@ class DescribeTrackedReplace:
             ),
             UnsupportedStructureError,
         )
-        assert "competing formatting or structural destinations" in str(
-            ancestry_refusal
-        )
+        assert "competing formatting or structural destinations" in str(ancestry_refusal)
 
         lexical_rpr = docx.Document()
         lexical_rpr.element.body.insert(  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
             0,
             parse_xml(
-                f'<w:p {W}>'
-                '<w:r><w:rPr><w:b/></w:rPr><w:t>A</w:t></w:r>'
+                f"<w:p {W}>"
+                "<w:r><w:rPr><w:b/></w:rPr><w:t>A</w:t></w:r>"
                 '<w:r><w:rPr><w:b w:val="true"/></w:rPr><w:t>B</w:t></w:r>'
-                '</w:p>'
+                "</w:p>"
             ),
         )
         rpr_span = find_one(lexical_rpr, "AB")
         rpr_refusal = assert_refusal_atomic(
             lexical_rpr,
-            lambda _document: rpr_span.replace(
-                "AXB", tracked=True, author="Carol QA", date=FROZEN
-            ),
+            lambda _document: rpr_span.replace("AXB", tracked=True, author="Carol QA", date=FROZEN),
             UnsupportedStructureError,
         )
         assert "competing formatting or structural destinations" in str(rpr_refusal)

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -424,7 +424,7 @@ class DescribePlainReplace:
             (" suffix", None, None, True),
         ]
 
-    def it_replaces_equivalent_fragmented_runs_and_refreshes_the_span(
+    def it_replaces_equivalent_fragmented_runs_and_consumes_the_span(
         self, tmp_path: Path
     ):
         document = docx.Document()
@@ -434,11 +434,15 @@ class DescribePlainReplace:
         span = find_one(document, "fragmented")
 
         first = span.replace("unified")
-        second = span.replace("renewed")
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("renewed")
+        replacement_span = find_one(document, "unified")
+        second = replacement_span.replace("renewed")
 
         assert first.preserved_formatting_regions
         assert second.preserved_formatting_regions
-        assert span.match_policy is None
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            replacement_span.replace("again")
         reopened = save_and_reopen(document, tmp_path / "fragmented.docx")
         assert reopened.paragraphs[0].text == "renewed"
         assert "".join(run.text for run in reopened.paragraphs[0].runs if run.bold) == "renewed"
@@ -606,7 +610,8 @@ class DescribePreservationPolicies:
         document, insertion = self._insertion_document()
         attributes = dict(insertion.attrib)
         original = [b.text for b in iter_blocks(document, view="original")]
-        result = find_one(document, "pending").replace(
+        span = find_one(document, "pending")
+        result = span.replace(
             "revised", preserve_revision=True
         )
         assert result.preserved_revision_ids == (41,)
@@ -614,6 +619,8 @@ class DescribePreservationPolicies:
         assert not result.preserved_structure
         assert dict(insertion.attrib) == attributes
         assert [b.text for b in iter_blocks(document, view="original")] == original
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("again", preserve_revision=True)
         path = tmp_path / "preserved-insertion.docx"
         document.save(path)
         accepted = docx.Document(path)
@@ -731,7 +738,7 @@ class DescribePreservationPolicies:
         span = find_one(document, "abcdef")
         span.replace("x", preserve_structure=True)
         assert [e.text for e in elements] == ["x", "", ""]
-        with pytest.raises(TargetNotFoundError, match="structure-preserving"):
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
             span.replace("again")
         assert find_one(document, "x").text == "x"
 
@@ -1000,11 +1007,13 @@ class DescribeTrackedReplace:
         with pytest.raises(ValueError, match="author"):
             span.replace("x", tracked=True)
 
-    def it_refuses_a_replacement_equal_to_the_existing_text(self):
+    def it_refuses_a_replacement_equal_to_the_existing_text_without_consuming(self):
         document = _doc(MINIMAL)
         span = find_one(document, "perfectly ordinary")
         with pytest.raises(TargetNotFoundError, match="nothing to change"):
             span.replace("perfectly ordinary", tracked=True, author="Carol QA")
+        result = span.replace("quite ordinary")
+        assert result.inserted_text == "quite ordinary"
 
     def it_refuses_cross_paragraph_tracked_targets(self):
         document = _doc(MINIMAL)

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -424,6 +424,92 @@ class DescribePlainReplace:
             (" suffix", None, None, True),
         ]
 
+    @pytest.mark.parametrize("same_format", [False, True])
+    def it_refuses_ambiguous_repeated_affixes_atomically(self, same_format: bool):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Term").bold = True
+        second = paragraph.add_run("Term")
+        if same_format:
+            second.bold = True
+        span = find_one(document, "TermTerm")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("Term"),
+            UnsupportedStructureError,
+        )
+
+        assert "exact affix alignment is ambiguous" in str(refusal)
+        assert "re-find" in str(refusal)
+        assert "'payment'" in str(refusal)
+        assert "'settlement'" in str(refusal)
+        assert span.replace("TermTerm").preserved_formatting_regions
+
+    def it_refuses_an_insertion_at_a_formatting_boundary_atomically(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A").bold = True
+        paragraph.add_run("B")
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("AXB"),
+            UnsupportedStructureError,
+        )
+
+        assert "exact affix alignment is ambiguous" in str(refusal)
+        assert span.replace("AB").preserved_formatting_regions
+
+    def it_refuses_an_insertion_at_an_unlisted_wrapper_boundary_atomically(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A")
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(f'<w:customXml {W}><w:r><w:t>B</w:t></w:r></w:customXml>')
+        )
+        span = find_one(document, "AB")
+
+        refusal = assert_refusal_atomic(
+            document,
+            lambda _document: span.replace("AXB"),
+            UnsupportedStructureError,
+        )
+
+        assert "exact affix alignment is ambiguous" in str(refusal)
+
+    def it_allows_an_insertion_between_equivalent_destinations(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("A").bold = True
+        paragraph.add_run("B").bold = True
+
+        find_one(document, "AB").replace("AXB")
+
+        assert paragraph.text == "AXB"
+        assert "".join(run.text for run in paragraph.runs if run.bold) == "AXB"
+
+    def it_allows_equivalent_distinct_inline_wrappers(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(
+                f'<w:smartTag {W} w:uri="urn:test" w:element="same">'
+                '<w:r><w:t>A</w:t></w:r></w:smartTag>'
+            )
+        )
+        paragraph._p.append(  # pyright: ignore[reportPrivateUsage]
+            parse_xml(
+                f'<w:smartTag {W} w:uri="urn:test" w:element="same">'
+                '<w:r><w:t>B</w:t></w:r></w:smartTag>'
+            )
+        )
+
+        find_one(document, "AB").replace("AXB")
+
+        assert find_one(document, "AXB").text == "AXB"
+
     def it_replaces_equivalent_fragmented_runs_and_consumes_the_span(
         self, tmp_path: Path
     ):
@@ -489,19 +575,38 @@ class DescribePlainReplace:
             UnsupportedStructureError,
         )
 
-    def it_refuses_present_unresolved_run_formatting(self):
+    def it_accepts_single_node_complete_run_formatting(self, tmp_path: Path):
         document = docx.Document()
         paragraph = document.add_paragraph("target")
-        rpr = paragraph.runs[0]._r.get_or_add_rPr()
+        rpr = paragraph.runs[0]._r.get_or_add_rPr()  # pyright: ignore[reportPrivateUsage]
         rpr.append(parse_xml(f'<w:shd {W} w:fill="FFFF00"/>'))
-        span = find_one(document, "target")
 
-        refusal = assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("changed"),
-            UnsupportedStructureError,
+        result = find_one(document, "target").replace("changed")
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "single-node-shading.docx")
+        assert reopened.paragraphs[0].text == "changed"
+        assert reopened.paragraphs[0]._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            'w:r/w:rPr/w:shd[@w:fill="FFFF00"]'
         )
-        assert "cannot compare" in str(refusal)
+
+    def it_accepts_fragmented_identical_complete_run_properties(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        for text in ("alpha", "beta"):
+            run = paragraph.add_run(text)
+            run._r.get_or_add_rPr().append(  # pyright: ignore[reportPrivateUsage]
+                parse_xml(f'<w:shd {W} w:fill="FFFF00"/>')
+            )
+
+        result = find_one(document, "alphabeta").replace("changed")
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "fragmented-shading.docx")
+        assert reopened.paragraphs[0].text == "changed"
+        assert reopened.paragraphs[0]._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            'w:r/w:rPr/w:shd[@w:fill="FFFF00"]'
+        )
 
     def it_refuses_distinct_effective_character_styles(self):
         document = docx.Document()
@@ -934,6 +1039,22 @@ class DescribeReplaceRefusals:
 
 
 class DescribeTrackedReplace:
+    def it_keeps_its_existing_greedy_repeated_affix_behavior(self):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("Term").bold = True
+        paragraph.add_run("Term")
+
+        result = find_one(document, "TermTerm").replace(
+            "Term", tracked=True, author="Carol QA", date=FROZEN
+        )
+
+        assert result.deleted_text == "Term"
+        assert result.inserted_text == ""
+        document.revisions.accept_all()
+        assert paragraph.text == "Term"
+        assert paragraph.runs[0].bold
+
     def it_marks_only_the_minimal_changed_span(self, tmp_path: Path):
         """The redline marks `75-10 -> 85-11`, not the sentence (pinned)."""
         document = _doc(FRAGMENTED)

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -10,9 +10,11 @@ import pytest
 from lxml import etree
 
 import docx
+from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.errors import (
     AmbiguousTargetError,
+    BoundaryViolationError,
     TargetNotFoundError,
     UnsupportedStructureError,
 )
@@ -22,8 +24,8 @@ from docx.numbering import (
     ensure_bullet_definition,
     list_numbering,
 )
-from docx.oxml.ns import qn
-from docx.oxml.parser import OxmlElement
+from docx.oxml.ns import nsdecls, qn
+from docx.oxml.parser import OxmlElement, parse_xml
 from docx.shared import Inches
 from docx.tableops import delete_row, find_table, insert_row_after, update_cell
 
@@ -40,6 +42,7 @@ NUMBERING = "generated/feature-isolated/numbering-custom.docx"
 NUMBERING_LO = "libreoffice/feature-isolated/numbering-custom.docx"
 
 FROZEN = dt.datetime(2026, 7, 7, 12, 0, 0, tzinfo=dt.timezone.utc)
+W = nsdecls("w")
 
 
 def _doc(relpath: str):
@@ -170,13 +173,15 @@ class DescribeUpdateCell:
         document, table = _doc_with_simple_table()
         result = update_cell(table, 0, 1, "updated value")
         assert result.deleted_text == "cell 01"
+        assert result.preserved_formatting_regions
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert reopened.tables[0].cell(0, 1).text == "updated value"
 
     def it_fills_an_empty_cell(self, tmp_path: Path):
         document, table = _doc_with_simple_table()
         table.cell(1, 1).paragraphs[0].clear()
-        update_cell(table, 1, 1, "was empty")
+        result = update_cell(table, 1, 1, "was empty")
+        assert not result.preserved_formatting_regions
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert reopened.tables[0].cell(1, 1).text == "was empty"
 
@@ -185,6 +190,7 @@ class DescribeUpdateCell:
         result = update_cell(table, 0, 0, "cell 99", tracked=True, author="Carol QA", date=FROZEN)
         assert result.tracked
         assert result.revision_ids
+        assert not result.preserved_formatting_regions
         reopened = save_and_reopen(document, tmp_path / "out.docx")
         assert reopened.tables[0].cell(0, 0).text.startswith("cell")
         revisions = reopened.revisions
@@ -228,6 +234,100 @@ class DescribeUpdateCell:
         _, table = _doc_with_simple_table()
         with pytest.raises(ValueError, match="author"):
             update_cell(table, 0, 0, "x", tracked=True)
+
+    def it_replaces_a_uniformly_formatted_fragmented_cell(self, tmp_path: Path):
+        document, table = _doc_with_simple_table()
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        paragraph.add_run("cell ").bold = True
+        paragraph.add_run("value").bold = True
+
+        result = update_cell(table, 0, 0, "updated")
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "uniform-cell.docx")
+        runs = reopened.tables[0].cell(0, 0).paragraphs[0].runs
+        assert "".join(run.text for run in runs if run.bold) == "updated"
+
+    def it_refuses_a_mixed_format_cell_atomically(self):
+        document, table = _doc_with_simple_table()
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        paragraph.add_run("Label: ").bold = True
+        paragraph.add_run("value")
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: update_cell(table, 0, 0, "updated"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_a_marker_divided_cell_atomically(self):
+        document, table = _doc_with_simple_table()
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        first = paragraph.add_run("cell ")
+        first._r.addnext(parse_xml(f'<w:proofErr {W} w:type="spellStart"/>'))
+        paragraph.add_run("value")
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: update_cell(table, 0, 0, "updated"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_unresolved_cell_formatting_atomically(self):
+        document, table = _doc_with_simple_table()
+        run = table.cell(0, 0).paragraphs[0].runs[0]
+        run._r.get_or_add_rPr().append(
+            parse_xml(f'<w:shd {W} w:fill="FFFF00"/>')
+        )
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: update_cell(table, 0, 0, "updated"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_a_character_style_divided_cell_atomically(self):
+        document, table = _doc_with_simple_table()
+        first_style = document.styles.add_style(
+            "Cell First", WD_STYLE_TYPE.CHARACTER
+        )
+        first_style.font.bold = True
+        second_style = document.styles.add_style(
+            "Cell Second", WD_STYLE_TYPE.CHARACTER
+        )
+        second_style.font.italic = True
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        paragraph.add_run("cell ", style=first_style)
+        paragraph.add_run("value", style=second_style)
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: update_cell(table, 0, 0, "updated"),
+            UnsupportedStructureError,
+        )
+
+    def it_refuses_a_hyperlink_scope_divided_cell_atomically(self):
+        document, table = _doc_with_simple_table()
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        paragraph._p.append(
+            parse_xml(
+                f'<w:hyperlink {W} w:anchor="target">'
+                "<w:r><w:t>cell </w:t></w:r>"
+                "</w:hyperlink>"
+            )
+        )
+        paragraph.add_run("value")
+
+        assert_refusal_atomic(
+            document,
+            lambda _document: update_cell(table, 0, 0, "updated"),
+            BoundaryViolationError,
+        )
 
 
 class DescribeRowOperations:

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -276,18 +276,37 @@ class DescribeUpdateCell:
             UnsupportedStructureError,
         )
 
-    def it_refuses_unresolved_cell_formatting_atomically(self):
+    def it_accepts_single_node_complete_cell_formatting(self, tmp_path: Path):
         document, table = _doc_with_simple_table()
         run = table.cell(0, 0).paragraphs[0].runs[0]
-        run._r.get_or_add_rPr().append(
+        run._r.get_or_add_rPr().append(  # pyright: ignore[reportPrivateUsage]
             parse_xml(f'<w:shd {W} w:fill="FFFF00"/>')
         )
 
-        assert_refusal_atomic(
+        result = update_cell(table, 0, 0, "updated")
+
+        assert result.preserved_formatting_regions
+        reopened = save_and_reopen(document, tmp_path / "shaded-cell.docx")
+        paragraph = reopened.tables[0].cell(0, 0).paragraphs[0]
+        assert paragraph.text == "updated"
+        assert paragraph._p.xpath(  # pyright: ignore[reportPrivateUsage]
+            'w:r/w:rPr/w:shd[@w:fill="FFFF00"]'
+        )
+
+    def it_refuses_ambiguous_repeated_cell_affixes_atomically(self):
+        document, table = _doc_with_simple_table()
+        paragraph = table.cell(0, 0).paragraphs[0]
+        paragraph.clear()
+        paragraph.add_run("Term").bold = True
+        paragraph.add_run("Term")
+
+        refusal = assert_refusal_atomic(
             document,
-            lambda _document: update_cell(table, 0, 0, "updated"),
+            lambda _document: update_cell(table, 0, 0, "Term"),
             UnsupportedStructureError,
         )
+
+        assert "exact affix alignment is ambiguous" in str(refusal)
 
     def it_refuses_a_character_style_divided_cell_atomically(self):
         document, table = _doc_with_simple_table()

--- a/tests/paper/test_tableops_numbering.py
+++ b/tests/paper/test_tableops_numbering.py
@@ -249,18 +249,18 @@ class DescribeUpdateCell:
         runs = reopened.tables[0].cell(0, 0).paragraphs[0].runs
         assert "".join(run.text for run in runs if run.bold) == "updated"
 
-    def it_refuses_a_mixed_format_cell_atomically(self):
+    def it_updates_a_mixed_format_cell_using_the_start_run(self):
         document, table = _doc_with_simple_table()
         paragraph = table.cell(0, 0).paragraphs[0]
         paragraph.clear()
         paragraph.add_run("Label: ").bold = True
         paragraph.add_run("value")
 
-        assert_refusal_atomic(
-            document,
-            lambda _document: update_cell(table, 0, 0, "updated"),
-            UnsupportedStructureError,
-        )
+        result = update_cell(table, 0, 0, "updated")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "updated"
+        assert paragraph.runs[0].bold
 
     def it_refuses_a_marker_divided_cell_atomically(self):
         document, table = _doc_with_simple_table()
@@ -308,26 +308,22 @@ class DescribeUpdateCell:
 
         assert "exact affix alignment is ambiguous" in str(refusal)
 
-    def it_refuses_a_character_style_divided_cell_atomically(self):
+    def it_updates_a_character_style_divided_cell_using_the_start_style(self):
         document, table = _doc_with_simple_table()
-        first_style = document.styles.add_style(
-            "Cell First", WD_STYLE_TYPE.CHARACTER
-        )
+        first_style = document.styles.add_style("Cell First", WD_STYLE_TYPE.CHARACTER)
         first_style.font.bold = True
-        second_style = document.styles.add_style(
-            "Cell Second", WD_STYLE_TYPE.CHARACTER
-        )
+        second_style = document.styles.add_style("Cell Second", WD_STYLE_TYPE.CHARACTER)
         second_style.font.italic = True
         paragraph = table.cell(0, 0).paragraphs[0]
         paragraph.clear()
         paragraph.add_run("cell ", style=first_style)
         paragraph.add_run("value", style=second_style)
 
-        assert_refusal_atomic(
-            document,
-            lambda _document: update_cell(table, 0, 0, "updated"),
-            UnsupportedStructureError,
-        )
+        result = update_cell(table, 0, 0, "updated")
+
+        assert not result.preserved_formatting_regions
+        assert paragraph.text == "updated"
+        assert paragraph.runs[0].style.name == "Cell First"
 
     def it_refuses_a_hyperlink_scope_divided_cell_atomically(self):
         document, table = _doc_with_simple_table()


### PR DESCRIPTION
## Why

The fm02 eval exposed formatting loss: whole-phrase replacement flattened independently formatted interior text. A regional planner fixes that only when the changed interval and formatting destination are provable.

## Final behavior

- Enumerate maximal exact prefix/suffix alignments.
- Proceed only when they identify one changed interval and one compatible formatting/inline-ancestry outcome.
- Preserve retained affixes, deletion pieces, markers, bookmarks, `xml:space`, and placeholder cleanup.
- Mixed or competing formatting destinations, repeated-affix ambiguity, unsupported structures, and unsafe insertion boundaries refuse atomically with guidance to re-find a smaller exact substring.
- Successful non-no-op direct replacement consumes its span; callers re-find for another edit.
- Tracked replacement follows the same ambiguity-first posture.

## Verification

Focused final matrix: 354 passed. fm02/fm06/fm13 graders: 1.000. Word for Mac 16.112.1 opened all 15 final-hash artifacts without repair. Full pytest currently reports 3,019 passed, 7 skipped, and 10 compare-related failures: compare widens zero-width insertions to a one-character replacement, after which this planner correctly refuses the resulting equal affix alignments. PR #44 was intentionally left unchanged; no heuristic tie-break was added.

## Stack

Parent: #47. Child: #49. Published head: `a9314ab1f1d3f9ae62849f0559655beb99d69e6e`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core `Span.replace` semantics and result schema change how Word XML is mutated and when spans remain valid; behavior is heavily tested but callers relying on old span reuse or run-length redistribution will see different outcomes.
> 
> **Overview**
> **Ordinary and tracked `Span.replace()` now use a shared maximal-affix planner** instead of collapsing or redistributing text across runs by old node lengths. Edits proceed only when every maximal prefix/suffix alignment agrees on one changed interval inside a single inline wrapper chain; ambiguous affixes, competing insertion destinations, separate wrapper owners, and positional markers in the changed region refuse atomically.
> 
> **Replacement formatting** keeps exact unchanged affixes in their original runs; non-empty new text inherits the **starting run’s complete direct `w:rPr`**, which may intentionally collapse later differently formatted runs in that interval. Tracked deletes still keep per-source run properties; inserts follow the same start-run rule.
> 
> **`ReplaceResult` / `replace_all` JSON bumps to schema version 2** with **`preserved_formatting_regions`** (whether the edit avoided collapsing multiple formatting regions). Successful text-changing direct replaces **consume the supplied span** (re-find before another edit); no-ops, refusals, and rollbacks leave it reusable. Ordinary edits also preflight **`xml:space`**, bookmark hollowing, and placeholder cleanup through the regional assignment path.
> 
> Docs (`paper-search`, user guide, `update_cell` docstring) describe the new contracts; tests cover rollback, batch behavior, table cells, and bookmark/affix cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c97287e68827d239ab49e93a0d423d8771bbf1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->