### PR TITLE
refactor: remove exact replacement mode and capacity allocation

### DIFF
--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -104,23 +104,14 @@ changed interval.
      - For a current-view span wholly owned by one ``w:ins``, keeps that
        insertion's id, author, date, and accept/reject projections. Outside
        revision markup, behaves like an ordinary untracked edit.
-   * - Preserve exact text topology
-     - ``span.replace(text, preserve_structure=True)``
-     - Changes only existing ``w:t`` values; preserves their attributes,
-       ancestor runs, and intervening transparent markers.
-   * - Correct an insertion and preserve topology
-     - ``span.replace(text, preserve_revision=True,
-       preserve_structure=True)``
-     - Applies both contracts to one existing insertion.
 
-``tracked=True`` cannot be combined with either preservation option. Revision
+``tracked=True`` cannot be combined with revision preservation. Revision
 preservation does not reauthor or restamp the existing insertion and does not
 support deletions, tracked moves, mixed base/insertion text, or multiple or
 nested revision wrappers. The corrected text remains attributed to the
 existing insertion's recorded author and date. Its outside-revision behavior
 lets ``replace_all`` apply one policy to both base text and insertion-owned
-matches. ``preserve_structure=True`` alone does not authorize an edit inside
-an insertion; request both guarantees for that case.
+matches.
 
 Ordinary and tracked replacement consider every non-overlapping exact prefix/suffix split
 that preserves the maximal number of characters. It narrows only when all
@@ -144,28 +135,16 @@ when their serialized XML is identical. Pure insertions at a boundary also
 refuse unless both sides prove the same complete formatting and concrete
 wrapper destination.
 
-Exact topology means structural preservation, not preservation of inferred
-formatting intent. Replacement text fills each selected text-node slice from
-left to right up to that slice's original capacity; the final selected node
-receives the remainder. Empty nodes remain present. Existing field,
-content-control, hyperlink, revision, protection, and paragraph-boundary guards
-still apply. The operation also refuses when the result would need an
-``xml:space`` attribute change, hollow a bookmark, or require placeholder
-cleanup. A successful mutation consumes the span because its captured offsets
-no longer describe the same text. A no-op still runs the full preflight and
-reports preservation evidence, but changes nothing and leaves the span
-reusable.
-
-For example, if ``Alpha`` consists of bold ``Al`` followed by italic ``pha``,
-replacing the whole word with ``Omega`` produces bold ``Omega`` because the
-changed interval starts in the bold run. Starting the same match in the italic
-run instead produces italic replacement text.
-
 Ordinary replacement never distributes new text according to prior text-node
 lengths. Existing field,
 content-control, hyperlink, revision, protection, bookmark, and paragraph-
 boundary guards still apply. Required ``xml:space`` updates and placeholder
 cleanup are part of a successful ordinary edit.
+
+For example, if ``Alpha`` consists of bold ``Al`` followed by italic ``pha``,
+replacing the whole word with ``Omega`` produces bold ``Omega`` because the
+changed interval starts in the bold run. Starting the same match in the italic
+run instead produces italic replacement text.
 
 |ReplaceResult| sets ``preserved_formatting_regions`` only when a successful
 ordinary untracked replacement did not collapse differently formatted changed
@@ -174,7 +153,8 @@ a no-op is not a formatting probe and leaves the span reusable. Tracked edits
 and empty-cell creation report false. The flag is
 orthogonal to ``preserved_revision_ids``: an authorized correction inside one
 existing insertion reports both the preserved insertion ID and formatting-
-region evidence. ``preserved_structure`` remains separate, and
+region evidence. The guarantee does not infer a semantic mapping from new words
+to styles; after a typed refusal, target a smaller uniform span.
 ``revision_ids`` continues to identify only newly authored revisions.
 ``replace_all`` accepts the same replacement options plus the same exact-by-
 default ``match`` policy, records each per-match
@@ -194,8 +174,9 @@ or a marker, target a smaller span wholly inside one structural region. Markers
 and differently formatted text wholly contained in exact unchanged affixes
 remain in their original elements and order.
 
-The direct and batch ``to_dict()`` payloads use schema version 2 and retain
-their earlier keys while adding ``preserved_formatting_regions``.
+The direct and batch ``to_dict()`` payloads use schema version 3 and retain
+``preserved_formatting_regions`` and revision evidence. They do not include a
+separate structure-preservation mode or result field.
 
 These contracts describe the edited XML structure. They do not promise raw
 byte identity inside a changed package part; use :func:`docx.package.patch_save`

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -179,6 +179,7 @@ Choose the option that matches the edit's preservation contract:
   and accept/reject behavior. The correction remains attributed to the
   recorded author and date. Base text encountered by ``replace_all`` still
   uses the ordinary untracked behavior.
+
 Ordinary replacement changes the proved regional interval without allocating
 text according to old text-node lengths. If structural ownership is ambiguous,
 target a smaller span inside one wrapper owner.

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -179,12 +179,6 @@ Choose the option that matches the edit's preservation contract:
   and accept/reject behavior. The correction remains attributed to the
   recorded author and date. Base text encountered by ``replace_all`` still
   uses the ordinary untracked behavior.
-- Use ``preserve_structure=True`` when the existing text-node and run topology
-  must remain exact. This mode changes only text values and may refuse text
-  whose whitespace cannot be represented without changing ``xml:space``.
-- Combine the two preservation options when both contracts apply. Neither can
-  be combined with ``tracked=True``.
-
 Ordinary replacement changes the proved regional interval without allocating
 text according to old text-node lengths. If structural ownership is ambiguous,
 target a smaller span inside one wrapper owner.

--- a/src/docx/search.py
+++ b/src/docx/search.py
@@ -375,7 +375,7 @@ class ReplaceResult:
     wrong for tracked edits. `preserved_formatting_regions` reports whether an ordinary
     replacement kept every changed formatting region rather than intentionally inheriting the
     changed interval's starting run properties; for a no-op, it records that no formatting
-    changed. It is independent of revision and topology evidence.
+    changed. It is independent of revision evidence.
     """
 
     story: str
@@ -383,20 +383,18 @@ class ReplaceResult:
     inserted_text: str
     tracked: bool
     revision_ids: Tuple[int, ...]
-    preserved_structure: bool = False
     preserved_revision_ids: Tuple[int, ...] = ()
     preserved_formatting_regions: bool = False
 
     def to_dict(self) -> dict:
         return {
             "schema": "paper_replace",
-            "version": 2,
+            "version": 3,
             "story": self.story,
             "deleted_text": self.deleted_text,
             "inserted_text": self.inserted_text,
             "tracked": self.tracked,
             "revision_ids": list(self.revision_ids),
-            "preserved_structure": self.preserved_structure,
             "preserved_revision_ids": list(self.preserved_revision_ids),
             "preserved_formatting_regions": self.preserved_formatting_regions,
         }
@@ -658,7 +656,7 @@ def _regional_text_assignments(
                 after_xml_space=(
                     "preserve"
                     if after[:1].isspace() or after[-1:].isspace()
-                    else None
+                    else atom.element.get(_XML_SPACE)
                 ),
             )
         )
@@ -1265,7 +1263,6 @@ class Span:
         tracked: bool = False,
         author: Optional[str] = None,
         date: Optional[dt.datetime] = None,
-        preserve_structure: bool = False,
         preserve_revision: bool = False,
     ) -> ReplaceResult:
         """Replace this span's text and return machine-readable change evidence.
@@ -1284,17 +1281,9 @@ class Span:
         existing `w:ins` to be corrected without changing that insertion's id, author, date,
         or accept/reject meaning; outside revision markup it behaves like an ordinary untracked
         edit. The corrected text remains attributed to the existing insertion's author and date.
-        `preserve_structure=True` changes only the selected `w:t` values: each node receives up
-        to its selected original capacity from left to right, and the final node receives the
-        remainder. Text elements, attributes, runs, intervening markers, and empty nodes are
-        retained. A mutating exact-structure edit consumes the span and refuses text that would
-        require changing `xml:space`. A fully preflighted no-op reports preservation evidence
-        but does not consume the span. The two preservation options can be combined, but neither
-        can be combined with `tracked=True`.
-
-        `preserved_formatting_regions`, `preserved_structure`, and
-        `preserved_revision_ids` report independent guarantees; `revision_ids` remains reserved
-        for newly authored tracked revisions. Every successful text-changing replacement consumes
+        `preserved_formatting_regions` and `preserved_revision_ids` report independent
+        guarantees; `revision_ids` remains reserved for newly authored tracked revisions. Every
+        successful text-changing replacement consumes
         the supplied span; use the returned result and re-find the text before another operation.
         A no-op, refusal, or rolled-back mutation leaves the span reusable. Refuses a protected
         document, a stale or foreign span, and unsafe field,
@@ -1306,7 +1295,6 @@ class Span:
             tracked=tracked,
             author=author,
             date=date,
-            preserve_structure=preserve_structure,
             preserve_revision=preserve_revision,
             use_transaction=self._freshness_census is None,
         )
@@ -1318,7 +1306,6 @@ class Span:
         tracked: bool,
         author: Optional[str],
         date: Optional[dt.datetime],
-        preserve_structure: bool,
         preserve_revision: bool,
         use_transaction: bool,
         tracked_context: "Optional[Tuple[Tuple[Optional[_Element], ...], bool]]" = None,
@@ -1326,7 +1313,6 @@ class Span:
         """Implementation shared with the already-transactional batch path."""
         _validate_replacement_options(
             tracked=tracked,
-            preserve_structure=preserve_structure,
             preserve_revision=preserve_revision,
         )
         if tracked:
@@ -1345,8 +1331,10 @@ class Span:
             if tracked_context is None:
                 tracked_context = _tracked_layering_context(self, author)
             if self.text == new_text:
-                raise TargetNotFoundError("replacement equals the existing text; nothing to change")
-        if not preserve_structure and (
+                raise TargetNotFoundError(
+                    "replacement equals the existing text; nothing to change"
+                )
+        if (
             tracked
             or any(atom.is_synthetic for atom in self._atoms)
             or self.crosses_paragraphs
@@ -1372,7 +1360,6 @@ class Span:
                         tracked=tracked,
                         author=author,
                         date=date,
-                        preserve_structure=False,
                         preserve_revision=preserve_revision,
                         use_transaction=False,
                         tracked_context=tracked_context,
@@ -1405,9 +1392,7 @@ class Span:
                     raise
         preserved_revision_ids = _preserved_insertion_ids(self, authorize=preserve_revision)
         preservation_noop = bool(preserved_revision_ids) and new_text == self.text
-        self._validate_replaceable(
-            validate_bookmarks=tracked and not preserve_structure
-        )
+        self._validate_replaceable(validate_bookmarks=tracked)
         if not tracked:
             for atom in self._atoms:
                 if atom.in_insert and not preserve_revision:
@@ -1419,11 +1404,6 @@ class Span:
                     )
         placeholder_sdts = _placeholder_controls_of(self._atoms)
         if placeholder_sdts:
-            if preserve_structure and new_text != self.text:
-                raise UnsupportedStructureError(
-                    "span lies in placeholder prompt text whose successful fill"
-                    " requires structural cleanup; exact structure cannot be preserved"
-                )
             if tracked:
                 raise UnsupportedStructureError(
                     "span lies in a form control still showing PLACEHOLDER"
@@ -1440,46 +1420,6 @@ class Span:
                         " to real content — replace the whole prompt"
                         f" ({prompt!r}) or use docx.controls.set_control_value"
                     )
-        if preserve_structure:
-            assignments = _exact_text_assignments(self, new_text)
-            _refuse_hollowed_bookmarks(
-                _hollowed_bookmarks_after(
-                    assignments,
-                    self._atoms,
-                    census=(
-                        self._freshness_census.bookmarks
-                        if self._freshness_census is not None
-                        else None
-                    ),
-                )
-            )
-            result = ReplaceResult(
-                story=self.story,
-                deleted_text=self.text,
-                inserted_text=new_text,
-                tracked=False,
-                revision_ids=(),
-                preserved_structure=True,
-                preserved_revision_ids=preserved_revision_ids,
-            )
-            if new_text == self.text:
-                return result
-            if use_transaction:
-                with rollback_on_error(self._document, self):
-                    _apply_text_assignments(assignments)
-                    self._consumed = True
-            else:
-                try:
-                    _apply_text_assignments(assignments)
-                except BaseException:
-                    # The batch owns the package transaction. Restore this
-                    # text-only attempt locally so a late PaperRefusal can be
-                    # recorded and an unexpected error can roll back the batch.
-                    for assignment in assignments:
-                        assignment.element.text = assignment.before
-                    raise
-                self._consumed = True
-            return result
         if preservation_noop:
             return ReplaceResult(
                 story=self.story,
@@ -2011,42 +1951,6 @@ def _hollowed_bookmarks(atoms: "Sequence[_Atom]", end_offset: int) -> "List[str]
     return hollowed
 
 
-def _exact_text_assignments(span: Span, new_text: str) -> "Tuple[_TextAssignment, ...]":
-    """Plan deterministic text-only assignments without changing the tree."""
-    assignments: "List[_TextAssignment]" = []
-    cursor = 0
-    atoms = span._atoms  # pyright: ignore[reportPrivateUsage]
-    last_index = len(atoms) - 1
-    for index, atom in enumerate(atoms):
-        start = span._start_offset if index == 0 else 0  # pyright: ignore[reportPrivateUsage]
-        end = (
-            span._end_offset  # pyright: ignore[reportPrivateUsage]
-            if index == last_index
-            else len(atom.text)
-        )
-        capacity = end - start
-        if index == last_index:
-            replacement_piece = new_text[cursor:]
-        else:
-            piece_length = min(capacity, len(new_text) - cursor)
-            replacement_piece = new_text[cursor : cursor + piece_length]
-            cursor += piece_length
-        after = atom.text[:start] + replacement_piece + atom.text[end:]
-        if (
-            after != atom.text
-            and (after[:1].isspace() or after[-1:].isspace())
-            and atom.element.get(_XML_SPACE) != "preserve"
-        ):
-            raise UnsupportedStructureError(
-                "exact structure would leave significant edge whitespace in a"
-                " w:t without its existing xml:space='preserve' attribute"
-            )
-        assignments.append(
-            _TextAssignment(element=atom.element, before=atom.text, after=after)
-        )
-    return tuple(assignments)
-
-
 def _apply_text_assignments(assignments: "Sequence[_TextAssignment]") -> None:
     """Apply a fully validated text-assignment collection."""
     for assignment in assignments:
@@ -2142,13 +2046,7 @@ def _refuse_hollowed_bookmarks(hollowed: "Sequence[str]") -> None:
         )
 
 
-def _validate_replacement_options(
-    *, tracked: bool, preserve_structure: bool, preserve_revision: bool
-) -> None:
-    if tracked and preserve_structure:
-        raise ValueError(
-            "tracked=True cannot be combined with preserve_structure=True"
-        )
+def _validate_replacement_options(*, tracked: bool, preserve_revision: bool) -> None:
     if tracked and preserve_revision:
         raise ValueError(
             "tracked=True cannot be combined with preserve_revision=True"
@@ -2376,7 +2274,7 @@ class ReplaceAllResult:
     def to_dict(self) -> dict:
         return {
             "schema": "paper_replace_all",
-            "version": 2,
+            "version": 3,
             "replaced_count": self.replaced_count,
             "results": [result.to_dict() for result in self.results],
             "refused": list(self.refused),
@@ -2394,7 +2292,6 @@ def replace_all(
     tracked: bool = False,
     author: Optional[str] = None,
     date: Optional[dt.datetime] = None,
-    preserve_structure: bool = False,
     preserve_revision: bool = False,
 ) -> ReplaceAllResult:
     """Replace every match of `needle` in one pass, and return a `ReplaceAllResult`.
@@ -2405,16 +2302,14 @@ def replace_all(
     shifts. A refusal on one match is recorded in `refused` and the rest
     proceed; a stale span aborts the batch instead, rolling back every
     replacement already applied. Matches already equal to `new_text` are
-    skipped. `preserve_structure` and `preserve_revision` have the same
-    contracts as |Span| ``.replace`` and are forwarded to every match without
-    adding a transaction per match.
+    skipped. `preserve_revision` has the same contract as |Span| ``.replace``
+    and is forwarded to every match without adding a transaction per match.
     """
     from docx.errors import PaperRefusal
 
     _validate_match_policy(match)
     _validate_replacement_options(
         tracked=tracked,
-        preserve_structure=preserve_structure,
         preserve_revision=preserve_revision,
     )
     if tracked and not author:
@@ -2445,7 +2340,7 @@ def replace_all(
             positions={
                 id(atom.element): index for index, atom in enumerate(atoms)
             },
-            bookmarks=_bookmark_census(root) if preserve_structure else None,
+            bookmarks=_bookmark_census(root),
         )
         for span in story_spans:
             span._freshness_census = census
@@ -2463,7 +2358,6 @@ def replace_all(
                                 tracked=tracked,
                                 author=author,
                                 date=date,
-                                preserve_structure=preserve_structure,
                                 preserve_revision=preserve_revision,
                             )
                         )

--- a/tests/paper/test_api_surface.py
+++ b/tests/paper/test_api_surface.py
@@ -92,7 +92,7 @@ APPROVED_SIGNATURES = [
         "docx.search",
         "Span.replace",
         "(self, new_text, *, tracked=False, author=None, date=None,"
-        " preserve_structure=False, preserve_revision=False)",
+        " preserve_revision=False)",
     ),
     # -- block operations ----------------------------------------------------
     (
@@ -143,8 +143,7 @@ APPROVED_SIGNATURES = [
         "docx.search",
         "replace_all",
         "(document, needle, new_text, *, story=None, view='current', match='exact',"
-        " tracked=False, author=None, date=None, preserve_structure=False,"
-        " preserve_revision=False)",
+        " tracked=False, author=None, date=None, preserve_revision=False)",
     ),
     (
         "docx.search",

--- a/tests/paper/test_audit_late_failure_atomicity.py
+++ b/tests/paper/test_audit_late_failure_atomicity.py
@@ -311,7 +311,7 @@ class DescribeRevisionRollback:
         assert deleted_text.getparent() is not None
 
 
-class DescribeExactReplacementRollback:
+class DescribeReplacementRollback:
     def it_rolls_back_a_narrowed_edit_after_a_late_failure(
         self, monkeypatch
     ):
@@ -373,37 +373,6 @@ class DescribeExactReplacementRollback:
         assert span.match_policy == original_policy
         assert span.text == "alphabeta"
         span._validate_fresh()
-
-    def it_restores_text_nodes_and_the_live_span_after_a_late_failure(
-        self, monkeypatch
-    ):
-        document = docx.Document()
-        paragraph = document.add_paragraph()
-        paragraph.add_run("alpha")
-        paragraph.add_run("beta")
-        span = find_one(document, "alphabeta")
-        elements = tuple(paragraph._p.iter(qn("w:t")))
-        original = search_module._apply_text_assignments
-
-        def apply_then_refuse(assignments):
-            assignments[0].element.text = assignments[0].after
-            raise UnsupportedStructureError("forced late refusal")
-
-        monkeypatch.setattr(
-            search_module, "_apply_text_assignments", apply_then_refuse
-        )
-        assert_refusal_atomic(
-            document,
-            lambda _document: span.replace("changed", preserve_structure=True),
-            UnsupportedStructureError,
-        )
-        assert [element.text for element in elements] == ["alpha", "beta"]
-        assert span.text == "alphabeta"
-        span._validate_fresh()
-
-        monkeypatch.setattr(search_module, "_apply_text_assignments", original)
-        span.replace("changed", preserve_structure=True)
-
 
 class DescribeCommentAuthoringRollback:
     def it_refuses_comment_ranges_from_another_document(self):

--- a/tests/paper/test_everyday_shapes.py
+++ b/tests/paper/test_everyday_shapes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import datetime as dt
 from contextlib import contextmanager
+from typing import Any, cast
 
 import pytest
 
@@ -263,13 +264,25 @@ class DescribeReplaceAll:
         document.add_paragraph("{{y}}")
         payload = replace_all(document, "{{y}}", "z").to_dict()
         assert payload["schema"] == "paper_replace_all"
-        assert payload["version"] == 2
+        assert payload["version"] == 3
         assert payload["replaced_count"] == 1
         assert payload["results"][0]["schema"] == "paper_replace"
-        assert payload["results"][0]["version"] == 2
-        assert payload["results"][0]["preserved_structure"] is False
+        assert payload["results"][0]["version"] == 3
+        assert "preserved_" + "structure" not in payload["results"][0]
         assert payload["results"][0]["preserved_revision_ids"] == []
         assert payload["results"][0]["preserved_formatting_regions"] is True
+
+    def it_rejects_the_removed_structure_keyword_before_batch_mutation(self):
+        document = _doc()
+        paragraph = document.add_paragraph("token token")
+        removed_keyword = "preserve_" + "structure"
+
+        with pytest.raises(TypeError, match=removed_keyword):
+            cast(Any, replace_all)(
+                document, "token", "value", **{removed_keyword: True}
+            )
+
+        assert paragraph.text == "token token"
 
     def it_records_when_a_batch_inherits_start_run_formatting(self):
         document = _doc()
@@ -352,23 +365,8 @@ class DescribeReplaceAll:
         assert all(item.preserved_formatting_regions for item in result.results)
         assert document.element.body.xpath('//w:ins[@w:id="801"]')
 
-    def it_reports_exact_structure_evidence_for_each_successful_match(self):
-        document = _doc()
-        document.add_paragraph("token token")
-        result = replace_all(
-            document, "token", "value", preserve_structure=True
-        )
-        assert result.replaced_count == 2
-        assert all(item.preserved_structure for item in result.results)
-        assert "value value" in [block.text for block in iter_blocks(document)]
-
-    @pytest.mark.parametrize(
-        ("tracked", "preserve_structure"),
-        [(False, False), (True, False), (False, True)],
-    )
-    def it_uses_only_the_outer_batch_transaction(
-        self, monkeypatch, tracked: bool, preserve_structure: bool
-    ):
+    @pytest.mark.parametrize("tracked", [False, True])
+    def it_uses_only_the_outer_batch_transaction(self, monkeypatch, tracked: bool):
         document = _doc()
         document.add_paragraph("token token")
         transaction_count = 0
@@ -389,11 +387,10 @@ class DescribeReplaceAll:
             tracked=tracked,
             author="Carol QA" if tracked else None,
             date=FROZEN if tracked else None,
-            preserve_structure=preserve_structure,
         )
         assert transaction_count == 1
 
-    def it_reuses_one_bookmark_census_for_an_exact_batch(self, monkeypatch):
+    def it_reuses_one_bookmark_census_for_an_ordinary_batch(self, monkeypatch):
         document = _doc()
         document.add_paragraph("token token token")
         census_count = 0
@@ -405,14 +402,12 @@ class DescribeReplaceAll:
             return original(*args, **kwargs)
 
         monkeypatch.setattr(search_module, "_bookmark_census", counted_census)
-        result = replace_all(
-            document, "token", "value", preserve_structure=True
-        )
+        result = replace_all(document, "token", "value")
 
         assert result.replaced_count == 3
         assert census_count == 1
 
-    def it_keeps_bookmark_hollowing_checks_per_match_in_an_exact_batch(self):
+    def it_keeps_bookmark_hollowing_checks_per_match(self):
         document = _doc()
         paragraph = document.add_paragraph()
         start = parse_xml(
@@ -423,38 +418,12 @@ class DescribeReplaceAll:
         paragraph._p.append(parse_xml(f'<w:bookmarkEnd {W} w:id="91"/>'))
         document.add_paragraph("token")
 
-        result = replace_all(
-            document, "token", "", preserve_structure=True
-        )
+        result = replace_all(document, "token", "")
 
         assert result.replaced_count == 1
         assert len(result.refused) == 1
         assert result.refused[0]["error"] == "UnsupportedStructureError"
         assert "token" in [block.text for block in iter_blocks(document)]
-
-    def it_locally_restores_a_late_per_match_refusal(self, monkeypatch):
-        document = _doc()
-        document.add_paragraph("token token")
-        original = search_module._apply_text_assignments
-        calls = 0
-
-        def refuse_second(assignments):
-            nonlocal calls
-            calls += 1
-            if calls == 2:
-                assignments[0].element.text = "corrupt"
-                raise UnsupportedStructureError("forced late refusal")
-            original(assignments)
-
-        monkeypatch.setattr(
-            search_module, "_apply_text_assignments", refuse_second
-        )
-        result = replace_all(
-            document, "token", "value", preserve_structure=True
-        )
-        assert result.replaced_count == 1
-        assert len(result.refused) == 1
-        assert "token value" in [block.text for block in iter_blocks(document)]
 
     def it_locally_restores_a_late_ordinary_match_refusal(self, monkeypatch):
         document = _doc()
@@ -533,23 +502,4 @@ class DescribeReplaceAll:
         monkeypatch.setattr(search_module, "_apply_text_assignments", fail_second)
         with pytest.raises(RuntimeError, match="forced unexpected ordinary"):
             replace_all(document, "token", "value")
-        assert paragraph.text == "token token"
-
-    def it_rolls_back_the_batch_after_an_unexpected_exact_failure(self, monkeypatch):
-        document = _doc()
-        paragraph = document.add_paragraph("token token")
-        original = search_module._apply_text_assignments
-        calls = 0
-
-        def fail_second(assignments):
-            nonlocal calls
-            calls += 1
-            if calls == 2:
-                assignments[0].element.text = "corrupt"
-                raise RuntimeError("forced unexpected failure")
-            original(assignments)
-
-        monkeypatch.setattr(search_module, "_apply_text_assignments", fail_second)
-        with pytest.raises(RuntimeError, match="forced unexpected"):
-            replace_all(document, "token", "value", preserve_structure=True)
         assert paragraph.text == "token token"

--- a/tests/paper/test_regressions_core.py
+++ b/tests/paper/test_regressions_core.py
@@ -188,14 +188,6 @@ class DescribeConsumedAndDetachedSpans:
         with pytest.raises(TargetNotFoundError, match="removed"):
             span.replace("lost edit")
 
-    def it_consumes_a_span_after_exact_structure_replacement(self):
-        document = _doc()
-        span = find_one(document, "perfectly ordinary")
-        span.replace("thoroughly mundane", preserve_structure=True)
-        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
-            span.replace("again")
-        assert find_one(document, "thoroughly mundane").text == "thoroughly mundane"
-
     def it_consumes_a_partial_ordinary_span_and_supports_refinding(self):
         document = docx.Document()
         document.add_paragraph("prefix target suffix")
@@ -284,20 +276,6 @@ class DescribePreservedRevisionAncestry:
             find_one(inserted, "inserted text", view="all").replace(
                 "updated", preserve_revision=True
             )
-
-    def it_keeps_structure_preservation_orthogonal_to_revision_authorization(self):
-        document = _doc()
-        document.add_paragraph()._p.append(
-            parse_xml(
-                f'<w:ins {W} w:id="730" w:author="Alice">'
-                "<w:r><w:t>inserted text</w:t></w:r></w:ins>"
-            )
-        )
-        with pytest.raises(UnsupportedStructureError, match="pending tracked insertion"):
-            find_one(document, "inserted text").replace(
-                "updated", preserve_structure=True
-            )
-
 
 class DescribeLayeredTrackedEdits:
     def it_refuses_spans_straddling_a_pending_insertion(self):

--- a/tests/paper/test_search_replace.py
+++ b/tests/paper/test_search_replace.py
@@ -642,6 +642,19 @@ class DescribePlainReplace:
         with pytest.raises(TargetNotFoundError, match="re-find"):
             span.replace("again")
 
+    def it_rejects_the_removed_structure_keyword_without_consuming_the_span(self):
+        document = docx.Document()
+        document.add_paragraph("target")
+        span = find_one(document, "target")
+        before = document.element.xml
+        removed_keyword = "preserve_" + "structure"
+
+        with pytest.raises(TypeError, match=removed_keyword):
+            cast(Any, span.replace)("changed", **{removed_keyword: True})
+
+        assert document.element.xml == before
+        span.replace("changed")
+
     def it_updates_xml_space_for_an_ordinary_replacement(self, tmp_path: Path):
         document = docx.Document()
         document.add_paragraph("plain")
@@ -765,7 +778,8 @@ class DescribePlainReplace:
         first._r.addnext(marker)
         paragraph.add_run(" target")
 
-        find_one(document, "prefix target").replace("prefix changed")
+        result = find_one(document, "prefix target").replace("prefix changed")
+        assert result.preserved_formatting_regions
 
         reopened = save_and_reopen(document, tmp_path / "marker-affix.docx")
         children = list(reopened.paragraphs[0]._p)
@@ -834,7 +848,6 @@ class DescribePreservationPolicies:
         )
         assert result.preserved_revision_ids == (41,)
         assert result.preserved_formatting_regions
-        assert not result.preserved_structure
         assert dict(insertion.attrib) == attributes
         assert [b.text for b in iter_blocks(document, view="original")] == original
         with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
@@ -915,14 +928,13 @@ class DescribePreservationPolicies:
         with pytest.raises(UnsupportedStructureError, match="view='current'"):
             span.replace("revised", preserve_revision=True)
 
-    def it_preserves_the_exact_text_element_graph_and_distribution(self, tmp_path: Path):
+    def it_assigns_the_changed_region_without_character_capacities(
+        self, tmp_path: Path
+    ):
         document = docx.Document()
         paragraph = document.add_paragraph()
-        for text in ("alpha", " pay", "ment", " terms"):
+        for text in ("ab", "c", "def"):
             paragraph.add_run(text)
-        paragraph.runs[1].bold = True
-        proofing_marker = parse_xml(f'<w:proofErr {W} w:type="spellStart"/>')
-        paragraph.runs[1]._r.addnext(proofing_marker)
         elements = tuple(paragraph._p.iter(qn("w:t")))
         runs = tuple(paragraph._p.iter(qn("w:r")))
         graph = tuple((e, e.tag, tuple(e.attrib.items()), tuple(e)) for e in elements)
@@ -931,47 +943,102 @@ class DescribePreservationPolicies:
             if run.find(qn("w:rPr")) is not None else None
             for run in runs
         )
-        result = find_one(document, "alpha payment terms").replace(
-            "alpha settlement terms", preserve_structure=True
-        )
-        assert result.preserved_structure
-        assert [e.text for e in elements] == ["alpha", " set", "tlem", "ent terms"]
+        replacement = "a whole new phrase"
+        result = find_one(document, "abcdef").replace(replacement)
+        assert result.preserved_formatting_regions
+        assert [e.text for e in elements] == [replacement, "", ""]
         assert tuple((e, e.tag, tuple(e.attrib.items()), tuple(e)) for e in elements) == graph
         assert tuple(paragraph._p.iter(qn("w:r"))) == runs
-        assert proofing_marker.getparent() is paragraph._p
         assert tuple(
             etree.tostring(run.find(qn("w:rPr")))
             if run.find(qn("w:rPr")) is not None else None
             for run in runs
         ) == run_properties
-        reopened = save_and_reopen(document, tmp_path / "exact.docx")
-        assert reopened.paragraphs[-1].text == "alpha settlement terms"
+        reopened = save_and_reopen(document, tmp_path / "regional.docx")
+        assert reopened.paragraphs[-1].text == replacement
 
-    def it_keeps_empty_nodes_and_consumes_a_mutated_exact_span(self):
+    def it_keeps_empty_nodes_and_consumes_a_mutated_span(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
         for text in ("ab", "cd", "ef"):
             paragraph.add_run(text)
         elements = tuple(paragraph._p.iter(qn("w:t")))
         span = find_one(document, "abcdef")
-        span.replace("x", preserve_structure=True)
+        span.replace("x")
         assert [e.text for e in elements] == ["x", "", ""]
         with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
             span.replace("again")
         assert find_one(document, "x").text == "x"
 
-    def it_refuses_exact_edge_whitespace_without_changing_xml_space(self):
+    def it_retains_all_text_nodes_after_complete_deletion(self, tmp_path: Path):
         document = docx.Document()
-        paragraph = document.add_paragraph("plain")
-        element = paragraph._p.find(".//" + qn("w:t"))
-        assert element is not None
-        assert element.get(qn("xml:space")) is None
-        before = etree.tostring(paragraph._p)
-        with pytest.raises(UnsupportedStructureError, match="edge whitespace"):
-            find_one(document, "plain").replace(" plain", preserve_structure=True)
-        assert etree.tostring(paragraph._p) == before
+        paragraph = document.add_paragraph()
+        paragraph.add_run("alpha")
+        paragraph.add_run("beta")
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        span = find_one(document, "alphabeta")
 
-    def it_refuses_an_exact_plan_that_would_hollow_a_bookmark(self):
+        result = span.replace("")
+
+        assert result.preserved_formatting_regions
+        assert [element.text for element in elements] == ["", ""]
+        with pytest.raises(TargetNotFoundError, match="consumed.*re-find"):
+            span.replace("again")
+        reopened = save_and_reopen(document, tmp_path / "regional-deletion.docx")
+        assert reopened.paragraphs[0].text == ""
+
+    def it_preserves_partial_first_and_last_text_nodes(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+        paragraph.add_run("prefix-alpha")
+        paragraph.add_run("beta-suffix")
+        elements = tuple(paragraph._p.iter(qn("w:t")))
+        attributes = tuple(tuple(element.attrib.items()) for element in elements)
+
+        result = find_one(document, "alphabeta").replace("replacement")
+
+        assert result.preserved_formatting_regions
+        assert [element.text for element in elements] == [
+            "prefix-replacement",
+            "-suffix",
+        ]
+        assert tuple(tuple(element.attrib.items()) for element in elements) == attributes
+        reopened = save_and_reopen(document, tmp_path / "regional-partial.docx")
+        assert reopened.paragraphs[0].text == "prefix-replacement-suffix"
+
+    def it_retains_an_existing_xml_space_attribute(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            parse_xml(f'<w:r {W}><w:t xml:space="preserve"> edged </w:t></w:r>')
+        )
+        element = next(paragraph.iter(qn("w:t")))
+
+        find_one(document, " edged ").replace("plain")
+
+        assert element.text == "plain"
+        assert element.get(qn("xml:space")) == "preserve"
+        reopened = save_and_reopen(document, tmp_path / "existing-space.docx")
+        reopened_element = next(reopened.paragraphs[0]._p.iter(qn("w:t")))
+        assert reopened_element.get(qn("xml:space")) == "preserve"
+
+    def it_retains_an_existing_xml_space_default(self, tmp_path: Path):
+        document = docx.Document()
+        paragraph = document.add_paragraph()._p
+        paragraph.append(
+            parse_xml(f'<w:r {W}><w:t xml:space="default">plain</w:t></w:r>')
+        )
+        element = next(paragraph.iter(qn("w:t")))
+
+        result = find_one(document, "plain").replace("changed")
+
+        assert result.preserved_formatting_regions
+        assert element.get(qn("xml:space")) == "default"
+        reopened = save_and_reopen(document, tmp_path / "existing-default.docx")
+        reopened_element = next(reopened.paragraphs[0]._p.iter(qn("w:t")))
+        assert reopened_element.get(qn("xml:space")) == "default"
+
+    def it_refuses_a_plan_that_would_hollow_a_bookmark(self):
         document = docx.Document()
         paragraph = document.add_paragraph()
         first = paragraph.add_run("outside")
@@ -982,9 +1049,7 @@ class DescribePreservationPolicies:
         inside._r.addnext(end)
         before = etree.tostring(paragraph._p)
         with pytest.raises(UnsupportedStructureError, match="hollow"):
-            find_one(document, "outsideinside").replace(
-                "x", preserve_structure=True
-            )
+            find_one(document, "outsideinside").replace("x")
         assert etree.tostring(paragraph._p) == before
 
     def it_refuses_hollowing_a_bookmark_whose_markers_span_paragraphs(self):
@@ -999,7 +1064,7 @@ class DescribePreservationPolicies:
         before = document.element.xml
 
         with pytest.raises(UnsupportedStructureError, match="hollow"):
-            find_one(document, "inside").replace("", preserve_structure=True)
+            find_one(document, "inside").replace("")
 
         assert document.element.xml == before
 
@@ -1048,40 +1113,6 @@ class DescribePreservationPolicies:
         assert document.element.xml == before
         span.replace("outsideinside", preserve_revision=preserve_revision)
 
-    def it_leaves_an_exact_noop_reusable(self):
-        document = docx.Document()
-        document.add_paragraph("same")
-        span = find_one(document, "same")
-        before = document.element.xml
-        assert span.replace("same", preserve_structure=True).preserved_structure
-        assert not span.replace(
-            "same", preserve_structure=True
-        ).preserved_formatting_regions
-        assert document.element.xml == before
-        span.replace("same", preserve_structure=True)
-
-    def it_combines_revision_and_structure_preservation(self):
-        document, insertion = self._insertion_document()
-        text_element = next(insertion.iter(qn("w:t")))
-        result = find_one(document, "pending").replace(
-            "current", preserve_revision=True, preserve_structure=True
-        )
-        assert result.preserved_structure
-        assert result.preserved_revision_ids == (41,)
-        assert text_element.getparent() is not None
-
-    def it_keeps_an_exact_patch_save_to_the_changed_story(self, tmp_path: Path):
-        source = fixture_path(FRAGMENTED)
-        working = tmp_path / "work.docx"
-        shutil.copyfile(source, working)
-        document = docx.Document(str(working))
-        find_one(document, "$75–100/hr").replace(
-            "$85–110/hr", preserve_structure=True
-        )
-        out = tmp_path / "out.docx"
-        docx.package.patch_save(working, document, out)
-        assert_changed_parts(working, out, {"word/document.xml"})
-
     @pytest.mark.parametrize("revision_id", ["bad", ""])
     def it_refuses_unreportable_insertion_ids(self, revision_id: str):
         document, insertion = self._insertion_document(revision_id=revision_id)
@@ -1090,13 +1121,12 @@ class DescribePreservationPolicies:
         with pytest.raises(UnsupportedStructureError, match="w:id"):
             find_one(document, "pending").replace("current", preserve_revision=True)
 
-    @pytest.mark.parametrize("policy", ["preserve_structure", "preserve_revision"])
-    def it_refuses_tracked_preservation_combinations(self, policy: str):
+    def it_refuses_tracked_revision_preservation(self):
         document = docx.Document()
         document.add_paragraph("target")
-        with pytest.raises(ValueError, match=policy):
+        with pytest.raises(ValueError, match="preserve_revision"):
             find_one(document, "target").replace(
-                "changed", tracked=True, author="Editor", **{policy: True}
+                "changed", tracked=True, author="Editor", preserve_revision=True
             )
 
 


### PR DESCRIPTION
## Why

The draft `preserve_structure` mode distributed new text by old text-node character capacity. Capacity reflects editing history, not formatting intent, and could split words across unrelated regions while appearing authoritative.

## Final behavior

- Remove `preserve_structure`, `preserved_structure`, its option matrix, and the inherited capacity allocator.
- Add no replacement mode or substitute allocator.
- Safe topology-aware assignment lives only in #48 ordinary replacement; edits that cannot be proved safe refuse.
- Existing marker, bookmark, whitespace, placeholder, cell, rollback, and consumed-span contracts remain.

## Verification

The final stack has 3,019 passing tests, 7 skips, and the same 10 known compare zero-width insertion failures documented in #48 and #50.

## Stack

Parent: #48. Child: #50. Published head: `2374cdba982e1c32094dbbda9e841e1a7fd6ebdc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public API mode and bumps serialized result schema version 2→3, which can break callers relying on preserve_structure or old to_dict fields; core replace semantics shift toward regional assignment rather than per-node capacity filling.
> 
> **Overview**
> Removes the **`preserve_structure`** replacement mode and its capacity-based text distribution across existing `w:t` nodes. **`Span.replace`** and **`replace_all`** no longer accept that option; **`ReplaceResult`** drops **`preserved_structure`**, and serialized replace payloads bump to **schema version 3**.
> 
> Ordinary regional replacement from the parent stack remains the only untracked path: maximal affix localization, start-run formatting inheritance, and the same structural guards (bookmarks, wrappers, revisions via **`preserve_revision`**). **`replace_all`** always builds a bookmark census for batch matches, not only in the removed exact mode.
> 
> **`xml:space`** handling on ordinary edits now **retains** an existing attribute when replacement text has no leading/trailing whitespace, instead of clearing it. Docs and API-surface tests align with the slimmer contract; callers passing the old keyword get **`TypeError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c9ef1d2d5bcc5cedf634aabea65e357014ffeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->