### PR TITLE
docs: simplify selection guidance and retain one audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,15 @@ cross-paragraph targets. See the
 [block](docs/api/paper-blocks.rst) references for the complete contracts.
 
 Ordinary untracked replacement considers every maximal exact prefix/suffix
-alignment. It preserves unchanged affixes and edits one proved formatting and
-structural region only when those alignments agree on the changed interval and
-writable destination; ambiguous repeated affixes or insertion boundaries refuse
-with guidance to re-find the intended substring. It also refuses rather than
-infer how a mixed region should be restyled or a marker should move. Every
+alignment. It preserves unchanged affixes and edits one proved structural
+region only when those alignments agree on the changed interval and writable
+destination; ambiguous repeated affixes or insertion boundaries refuse with
+guidance to re-find the intended substring. Mixed formatting across the
+consumed text is not itself a refusal: nonempty replacement text takes the
+complete direct `w:rPr` of the run holding the first consumed character, and
+the differently formatted runs it consumes collapse into that format.
+Untouched affixes and boundary fragments keep their own runs. Crossing
+distinct inline wrapper owners, or moving a marker, still refuses. Every
 successful text-changing direct `Span.replace()` consumes that span; re-find
 before another operation. Direct no-ops and atomically refused or rolled-back
 operations leave the supplied span reusable. There is no separate
@@ -101,11 +105,13 @@ the [replacement](docs/api/paper-search.rst),
 [formatting](docs/api/paper-formatting.rst), and
 [revision](docs/api/paper-revisions.rst) references for details.
 
-Tracked replacement uses the same unique localization rule. Inserted revision
-text is authored only when the changed region proves one complete run-property
-and inline-ancestry outcome; deletion-only redlines retain each source run's
-formatting. If a replacement such as mixed bold/italic `Alpha` to `Omega` would
-require choosing a format, it refuses and leaves the document unchanged.
+Tracked replacement uses the same unique localization and the same start-run
+rule: inserted revision text takes the direct formatting of the run holding the
+first consumed character, while deletion markup retains each source run's own
+formatting. Replacing bold/italic `Alpha` with `Omega` authors a bold `Omega`,
+because the changed interval starts in the bold run. A changed interval that
+would cross distinct inline wrapper owners still refuses and leaves the
+document unchanged.
 
 Live blocks and spans captured from historical revision views remain useful for
 inspection, but mutation destinations must be reacquired from the current view.

--- a/README.md
+++ b/README.md
@@ -64,13 +64,35 @@ result.document.paragraphs[0].text
 
 - **`docx.story`** traverses the body, headers, footers, footnotes, endnotes, comments, tracked insertions, content controls, and text boxes. Callers can view the document as it stands, before pending revisions, or all at once.
 - **`docx.search`** finds exact text by default across Word's run fragmentation, with explicit normalized matching when wanted. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
-- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to a text anchor, as plain edits or as a tracked change.
+- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to an exact string, live target, or fail-closed portable block locator, as plain edits or as a tracked change.
 - **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that refuse on unsafe structures such as merged cells, nested tables, or undefined numbering.
 - **`docx.controls`** fills content controls with the correct value type and clears placeholder state so Word treats them as filled.
 - **`docx.bookmarks` / `docx.fields`** create bookmarks over a span and author page numbers, dates, cross-references, captions, and tables of contents as fields with placeholder results.
 - **`docx.notes` / `docx.links`** anchor real footnotes, endnotes, and hyperlinks to a matched span, so they compose with `docx.search` rather than needing their own targeting.
 - **`Drawing.replace_picture`** swaps the image behind a drawing in place, leaving its size, position, and identity alone.
 - **`docx.formatting`** resolves effective formatting through document defaults, styles, and direct formatting, with provenance for each value.
+
+### Selection and preservation
+
+Search is exact by default across Word's ordinary run fragmentation; normalized
+matching is an explicit policy. A live `Span` identifies selected characters and
+a live `Block` identifies one attached document element. A versioned
+`BlockLocator` can carry exact evidence between processes, but may refuse after
+the document changes; generic `Anchor` values are location evidence, not mutation
+authority. Contextual `near` selection is authoritative only when it has one
+unique nearest match and cannot be combined with `nth`. See the
+[search](docs/api/paper-search.rst), [story](docs/api/paper-story.rst), and
+[block](docs/api/paper-blocks.rst) references for the complete contracts.
+
+Ordinary untracked replacement preserves exact unchanged affixes and edits only
+one proved formatting and structural region. It refuses rather than infer how a
+mixed region should be restyled. `preserve_structure=True` adds an exact-topology
+contract: only already selected text-node values may change, without allocating
+new text according to old character counts. Formatting inspection follows the
+supplied span; a block or locator provides paragraph-level formatting only. See
+the [replacement](docs/api/paper-search.rst),
+[formatting](docs/api/paper-formatting.rst), and
+[revision](docs/api/paper-revisions.rst) references for details.
 
 ### Reviewing
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ result.document.paragraphs[0].text
 
 - **`docx.story`** traverses the body, headers, footers, footnotes, endnotes, comments, tracked insertions, content controls, and text boxes. Callers can view the document as it stands, before pending revisions, or all at once.
 - **`docx.search`** finds exact text by default across Word's run fragmentation, with explicit normalized matching when wanted. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
-- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to an exact string, live target, or fail-closed portable block locator, as plain edits or as a tracked change.
+- **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to an exact string, live span, or owner-bound live paragraph block, as plain edits or as a tracked change.
 - **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that refuse on unsafe structures such as merged cells, nested tables, or undefined numbering.
 - **`docx.controls`** fills content controls with the correct value type and clears placeholder state so Word treats them as filled.
 - **`docx.bookmarks` / `docx.fields`** create bookmarks over a span and author page numbers, dates, cross-references, captions, and tables of contents as fields with placeholder results.
@@ -75,21 +75,24 @@ result.document.paragraphs[0].text
 ### Selection and preservation
 
 Search is exact by default across Word's ordinary run fragmentation; normalized
-matching is an explicit policy. A live `Span` identifies selected characters and
-a live `Block` identifies one attached document element. A versioned
-`BlockLocator` can carry exact evidence between processes, but may refuse after
-the document changes; generic `Anchor` values are location evidence, not mutation
-authority. Contextual `near` selection is authoritative only when it has one
-unique nearest match and cannot be combined with `nth`. See the
+matching is an explicit policy. `find_text(..., near=...)` orders the complete
+candidate set for inspection; `find_one()` retains ordinary zero/one/many
+resolution and accepts no contextual-ranking keyword. A live `Span` identifies
+selected characters and a live `Block` identifies one attached document element.
+Serialized `Anchor` values are location evidence, not mutation authority; after a
+reload, reacquire a live target. Operations that require one paragraph refuse
+cross-paragraph targets. See the
 [search](docs/api/paper-search.rst), [story](docs/api/paper-story.rst), and
 [block](docs/api/paper-blocks.rst) references for the complete contracts.
 
 Ordinary untracked replacement preserves exact unchanged affixes and edits only
 one proved formatting and structural region. It refuses rather than infer how a
-mixed region should be restyled. `preserve_structure=True` adds an exact-topology
-contract: only already selected text-node values may change, without allocating
-new text according to old character counts. Formatting inspection follows the
-supplied span; a block or locator provides paragraph-level formatting only. See
+mixed region should be restyled or a marker should move. Every successful
+text-changing direct `Span.replace()` consumes that span; re-find before another
+operation. Direct no-ops and atomically refused or rolled-back operations leave
+the supplied span reusable. There is no separate topology-preservation mode or
+character-capacity allocator. Formatting inspection composes an explicit search
+with `format_of(span)`, or passes a run or paragraph directly. See
 the [replacement](docs/api/paper-search.rst),
 [formatting](docs/api/paper-formatting.rst), and
 [revision](docs/api/paper-revisions.rst) references for details.

--- a/README.md
+++ b/README.md
@@ -85,14 +85,18 @@ cross-paragraph targets. See the
 [search](docs/api/paper-search.rst), [story](docs/api/paper-story.rst), and
 [block](docs/api/paper-blocks.rst) references for the complete contracts.
 
-Ordinary untracked replacement preserves exact unchanged affixes and edits only
-one proved formatting and structural region. It refuses rather than infer how a
-mixed region should be restyled or a marker should move. Every successful
-text-changing direct `Span.replace()` consumes that span; re-find before another
-operation. Direct no-ops and atomically refused or rolled-back operations leave
-the supplied span reusable. There is no separate topology-preservation mode or
-character-capacity allocator. Formatting inspection composes an explicit search
-with `format_of(span)`, or passes a run or paragraph directly. See
+Ordinary untracked replacement considers every maximal exact prefix/suffix
+alignment. It preserves unchanged affixes and edits one proved formatting and
+structural region only when those alignments agree on the changed interval and
+writable destination; ambiguous repeated affixes or insertion boundaries refuse
+with guidance to re-find the intended substring. It also refuses rather than
+infer how a mixed region should be restyled or a marker should move. Every
+successful text-changing direct `Span.replace()` consumes that span; re-find
+before another operation. Direct no-ops and atomically refused or rolled-back
+operations leave the supplied span reusable. There is no separate
+topology-preservation mode or character-capacity allocator. Formatting inspection
+composes an explicit search with `format_of(span)`, or passes a run or paragraph
+directly. See
 the [replacement](docs/api/paper-search.rst),
 [formatting](docs/api/paper-formatting.rst), and
 [revision](docs/api/paper-revisions.rst) references for details.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ result.document.paragraphs[0].text
 - **`docx.story`** traverses the body, headers, footers, footnotes, endnotes, comments, tracked insertions, content controls, and text boxes. Callers can view the document as it stands, before pending revisions, or all at once.
 - **`docx.search`** finds exact text by default across Word's run fragmentation, with explicit normalized matching when wanted. A returned `Span` can replace the matched text while preserving unaffected runs, emit the replacement as a tracked change, or anchor a comment.
 - **`docx.blocks`** inserts, deletes, or replaces whole paragraphs relative to an exact string, live span, or owner-bound live paragraph block, as plain edits or as a tracked change.
-- **`docx.tableops` / `docx.numbering`** provide cell, row, and list edits that refuse on unsafe structures such as merged cells, nested tables, or undefined numbering.
+- **`docx.tableops` / `docx.numbering`** provide explicit exact-or-normalized top-level table lookup plus cell, row, and list edits. Table lookup never synthesizes a match across cells, and copied rows accept only simple uniform templates rather than flattening ambiguous or unsupported structures.
 - **`docx.controls`** fills content controls with the correct value type and clears placeholder state so Word treats them as filled.
 - **`docx.bookmarks` / `docx.fields`** create bookmarks over a span and author page numbers, dates, cross-references, captions, and tables of contents as fields with placeholder results.
 - **`docx.notes` / `docx.links`** anchor real footnotes, endnotes, and hyperlinks to a matched span, so they compose with `docx.search` rather than needing their own targeting.
@@ -100,6 +100,18 @@ directly. See
 the [replacement](docs/api/paper-search.rst),
 [formatting](docs/api/paper-formatting.rst), and
 [revision](docs/api/paper-revisions.rst) references for details.
+
+Tracked replacement uses the same unique localization rule. Inserted revision
+text is authored only when the changed region proves one complete run-property
+and inline-ancestry outcome; deletion-only redlines retain each source run's
+formatting. If a replacement such as mixed bold/italic `Alpha` to `Omega` would
+require choosing a format, it refuses and leaves the document unchanged.
+
+Live blocks and spans captured from historical revision views remain useful for
+inspection, but mutation destinations must be reacquired from the current view.
+Cross-document composition applies that rule to its destination and refuses
+before importing anything when insertion after a paragraph, table, or block
+content control would remain inside an open complex-field result.
 
 ### Reviewing
 

--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -11,9 +11,11 @@ that stamps paragraph marks so Word accepts or rejects them exactly.
 ``insert_blocks_after`` takes typed |RichParagraph|/|ListBlock|/|TableBlock|
 blocks.
 
-Targets may be an exact string, a live |Span|, or a live |Block|. Live blocks
-validate document ownership and exact element attachment. Tables remain
-blocks but are not paragraph anchors, so live table blocks raise
+Targets may be an exact string, a live |Span|, or an owner-bound live
+paragraph |Block|. Live blocks validate document ownership and exact element
+attachment, including story and containing-structure checks. They survive
+index shifts, but a detached, replaced, reparented, or foreign element refuses.
+Tables remain blocks but are not paragraph anchors, so live table blocks raise
 |UnsupportedStructureError|.
 
 Live block and span mutation targets must be captured from ``view="current"``.
@@ -30,8 +32,9 @@ pass an explicit live block endpoint.
 
 Legacy |Anchor| values are inert location evidence and are refused with
 migration guidance. Reacquire a live block with ``iter_blocks()``/``outline()``,
-or pass an exact string or live span. Do not use an old index/hash payload as a
-mutation target.
+or pass an exact string or live span after reloading a document. No serialized
+block locator or persistence scheme is part of this API; an old index/hash
+payload cannot authorize mutation.
 
 .. currentmodule:: docx.blocks
 

--- a/docs/api/paper-blocks.rst
+++ b/docs/api/paper-blocks.rst
@@ -4,7 +4,8 @@
 Block operations
 ================
 
-*paper-docx addition.* Make clause-level edits relative to a content anchor.
+*paper-docx addition.* Make clause-level edits relative to an exact or live
+paragraph target.
 Insert, delete, or replace whole paragraphs, plainly or as a tracked redline
 that stamps paragraph marks so Word accepts or rejects them exactly.
 ``insert_blocks_after`` takes typed |RichParagraph|/|ListBlock|/|TableBlock|

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -135,6 +135,12 @@ when their serialized XML is identical. Pure insertions at a boundary also
 refuse unless both sides prove the same complete formatting and concrete
 wrapper destination.
 
+For example, if ``Alpha`` consists of bold ``Al`` followed by italic ``pha``,
+replacing the whole word with ``Omega`` has no single evidenced formatting
+outcome and refuses atomically. The package does not choose bold or italic for
+the caller. Re-find a uniform subrange or construct the intended runs
+explicitly.
+
 Ordinary replacement never distributes new text according to prior text-node
 lengths. Existing field,
 content-control, hyperlink, revision, protection, bookmark, and paragraph-

--- a/docs/api/paper-search.rst
+++ b/docs/api/paper-search.rst
@@ -135,12 +135,6 @@ when their serialized XML is identical. Pure insertions at a boundary also
 refuse unless both sides prove the same complete formatting and concrete
 wrapper destination.
 
-For example, if ``Alpha`` consists of bold ``Al`` followed by italic ``pha``,
-replacing the whole word with ``Omega`` has no single evidenced formatting
-outcome and refuses atomically. The package does not choose bold or italic for
-the caller. Re-find a uniform subrange or construct the intended runs
-explicitly.
-
 Ordinary replacement never distributes new text according to prior text-node
 lengths. Existing field,
 content-control, hyperlink, revision, protection, bookmark, and paragraph-

--- a/docs/api/paper-tableops.rst
+++ b/docs/api/paper-tableops.rst
@@ -33,17 +33,6 @@ simpler uniform template. Complex templates are never repaired or flattened.
 Rows with ``gridBefore``/``gridAfter``, omitted grid columns, or horizontal
 merges are not positional templates and refuse before the table is mutated.
 
-``insert_row_after()`` copies row, cell, and paragraph properties, then fills
-each physical cell as one run. A copied cell is accepted only when it contains
-exactly one direct paragraph of plain direct text runs and all text-bearing
-runs have identical complete explicit run properties; an ordinary unformatted
-empty cell is also accepted. Every cell is checked while the copied row is
-detached, before any cell is populated or the row is attached. Conflicting run
-properties, extra paragraphs, fields, controls, revisions, hyperlinks,
-markers, drawings, nested content, and unknown wrappers raise
-|UnsupportedStructureError| with the template row/cell and guidance to use a
-simpler uniform template. Complex templates are never repaired or flattened.
-
 .. currentmodule:: docx.tableops
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,21 +24,25 @@ Selection and preservation
 --------------------------
 
 Search is exact by default across ordinary Word run fragmentation; normalized
-matching is an explicit caller choice. A live |Span| identifies selected text
-and a live |Block| identifies one attached document element. A versioned
-``BlockLocator`` carries portable exact evidence but may become stale or
-ambiguous after edits. Generic |Anchor| values remain location evidence rather
-than mutation authority. Authoritative ``near`` selection requires one unique
-nearest candidate and cannot be combined with ``nth``. See
+matching is an explicit caller choice. ``find_text(..., near=...)`` orders the
+complete candidate set for inspection; ``find_one()`` keeps ordinary
+zero/one/many resolution and has no contextual-ranking keyword. A live |Span|
+identifies selected text and a live |Block| identifies one attached document
+element. Serialized |Anchor| values remain inert location evidence; reacquire a
+live target after reload. One-paragraph operations refuse cross-paragraph
+targets. See
 :ref:`docx.search <paper_search_api>`, :ref:`docx.story <paper_story_api>`, and
 :ref:`docx.blocks <paper_blocks_api>`.
 
 Ordinary untracked replacement preserves exact unchanged affixes and edits only
 one proved formatting and structural region; otherwise it refuses before
-mutation. Exact-topology replacement changes only already selected text-node
-values and never allocates new text by previous character counts. Formatting
-inspection follows the selected span, while a block or locator provides only
-paragraph-level evidence. See :ref:`docx.search <paper_search_api>`,
+mutation. Every successful text-changing direct ``Span.replace()`` consumes
+that span; callers re-find before another operation. Direct no-ops and
+atomically refused or rolled-back operations leave the supplied span reusable.
+There is no separate topology-preservation mode or character-capacity
+allocator. Formatting inspection composes explicit search with
+``format_of(span)``, or accepts a run or paragraph directly. See
+:ref:`docx.search <paper_search_api>`,
 :ref:`docx.formatting <paper_formatting_api>`, and
 :ref:`docx.revision <paper_revisions_api>` for the detailed contracts.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,29 @@ The rest of this page is inherited from python-docx and covers the shared
 foundation for creating and updating Microsoft Word (.docx) files.
 
 
+Selection and preservation
+--------------------------
+
+Search is exact by default across ordinary Word run fragmentation; normalized
+matching is an explicit caller choice. A live |Span| identifies selected text
+and a live |Block| identifies one attached document element. A versioned
+``BlockLocator`` carries portable exact evidence but may become stale or
+ambiguous after edits. Generic |Anchor| values remain location evidence rather
+than mutation authority. Authoritative ``near`` selection requires one unique
+nearest candidate and cannot be combined with ``nth``. See
+:ref:`docx.search <paper_search_api>`, :ref:`docx.story <paper_story_api>`, and
+:ref:`docx.blocks <paper_blocks_api>`.
+
+Ordinary untracked replacement preserves exact unchanged affixes and edits only
+one proved formatting and structural region; otherwise it refuses before
+mutation. Exact-topology replacement changes only already selected text-node
+values and never allocates new text by previous character counts. Formatting
+inspection follows the selected span, while a block or locator provides only
+paragraph-level evidence. See :ref:`docx.search <paper_search_api>`,
+:ref:`docx.formatting <paper_formatting_api>`, and
+:ref:`docx.revision <paper_revisions_api>` for the detailed contracts.
+
+
 What it can do
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,11 +34,14 @@ targets. See
 :ref:`docx.search <paper_search_api>`, :ref:`docx.story <paper_story_api>`, and
 :ref:`docx.blocks <paper_blocks_api>`.
 
-Ordinary untracked replacement preserves exact unchanged affixes and edits only
-one proved formatting and structural region; otherwise it refuses before
-mutation. Every successful text-changing direct ``Span.replace()`` consumes
-that span; callers re-find before another operation. Direct no-ops and
-atomically refused or rolled-back operations leave the supplied span reusable.
+Ordinary untracked replacement considers every maximal exact prefix/suffix
+alignment. It preserves unchanged affixes and edits one proved formatting and
+structural region only when those alignments agree on the changed interval and
+writable destination. Ambiguous repeated affixes or insertion boundaries refuse
+with guidance to re-find the intended substring. Every successful text-changing
+direct ``Span.replace()`` consumes that span; callers re-find before another
+operation. Direct no-ops and atomically refused or rolled-back operations leave
+the supplied span reusable.
 There is no separate topology-preservation mode or character-capacity
 allocator. Formatting inspection composes explicit search with
 ``format_of(span)``, or accepts a run or paragraph directly. See

--- a/docs/proposals/lossy-selection-audit.md
+++ b/docs/proposals/lossy-selection-audit.md
@@ -8,8 +8,8 @@ replacement, table editing, and comparison behavior
 This is a historical design audit, not an API reference. It records where a
 Paper convenience layer discarded identity, boundary, formatting, or topology
 evidence and what the selection-integrity changes retained or removed. Current
-contracts live in the `docx.search`, `docx.blocks`, and `docx.formatting` API
-documentation.
+contracts live in the `docx.search`, `docx.blocks`, `docx.tableops`,
+`docx.composition`, and `docx.formatting` API documentation.
 
 ## Evidence and provenance
 
@@ -23,8 +23,9 @@ The measured evaluation evidence is narrower than the code audit. A 2026-08-22
 trace review covered 75 focused Harbor trajectories and 60 Knowledge48 DOCX
 trajectories. It distinguished three events: an API was called, the lossy input
 condition was present, and a harmful output or score effect was observed. Only
-LS-05 reached all three. The other entries remain real code-level risks or open
-design questions, but this corpus does not show that they cost points.
+LS-05 reached all three. The other entries were identified through code audit;
+this corpus neither demonstrated score loss nor resolved them. Their dispositions
+below come from follow-up code-audit reproductions and implementation checks.
 
 | ID | Evaluated condition | Observed result | Final disposition |
 | --- | --- | --- | --- |
@@ -35,10 +36,10 @@ design questions, but this corpus does not show that they cost points.
 | LS-05 | Heterogeneous fragmented replacement | **Structure loss and score loss** | Ordinary replacement proves one safe changed region or refuses |
 | LS-06 | Not present in evaluated build | Not executable | Capacity allocator and separate mode removed |
 | LS-07 | No calls | Not exercised | Convenience wrapper removed |
-| LS-08 | Row copy called; template cells were uniform | Lossy choice not activated | Open; outside this stack |
-| LS-09 | Table lookup called; queries stayed within one cell | Lossy choice not activated | Open; outside this stack |
+| LS-08 | Row copy called; template cells were uniform | Lossy choice not activated | Uniform simple templates copy; ambiguous or destructive templates refuse |
+| LS-09 | Table lookup called; queries stayed within one cell | Lossy choice not activated | Match policy is explicit; matches cannot cross physical cells |
 | LS-10 | Comparison pairing called | No observed mispair | Open; outside this stack |
-| LS-11 | Tracked replacement called on simple regions | No observed formatting loss | Open; outside this stack |
+| LS-11 | Tracked replacement called on simple regions | No observed formatting loss | Insertions require one proved formatting/ancestry outcome; otherwise refuse |
 
 ## Closed issues
 
@@ -213,38 +214,75 @@ text and pass the live span to `format_of()`, which resolves every touched run
 and reports mixed values and provenance; callers that already hold a run or
 paragraph pass that object directly.
 
-## Open issues outside this stack
+### LS-08 — copied table cells chose one representative run format
 
-These behaviors were also introduced by Paper bootstrap commit `a55be769`.
-They were not changed by the selection-integrity stack, and this audit does not
-present the absence of an eval loss as proof that they are safe.
-
-### LS-08 — copied table cells choose one representative run format
-
-**Lossy behavior and impact.** Row-copy population finds the first run with
-explicit run properties, clears the cell, and applies that one property set to
-the replacement. A template cell whose first styled run is red and whose later
-run is bold can become entirely red, losing the later region and any semantic
+**Lossy behavior and impact.** Row-copy population found the first run with
+explicit run properties, cleared the cell, and applied that one property set to
+the replacement. A template cell whose first styled run was red and whose later
+run was bold could become entirely red, losing the later region and any semantic
 relationship between text and style.
 
-**Evidence and status.** Row copying ran in three `fm13` trajectories, but each
-template cell had one ordinary unformatted run, so no competing formats were
-discarded. The observed score loss came from row order, not this heuristic.
-The issue remains open and is outside this stack.
+**Evidence.** Row copying ran in three `fm13` trajectories, but each template
+cell had one ordinary unformatted run, so no competing formats were discarded.
+The observed score loss came from row order, not this heuristic.
 
-### LS-09 — table search can synthesize text across cell boundaries
+**Disposition.** Copied-row population now preflights every physical template
+cell before attachment. It accepts one direct paragraph of plain text runs only
+when all text-bearing runs have identical complete explicit run properties;
+ordinary unformatted empty cells are also safe. Conflicting formatting, extra
+paragraphs, fields, controls, revisions, hyperlinks, markers, drawings, nested
+content, and unknown wrappers raise an actionable typed refusal. The operation
+does not choose a representative format, delete unsupported structure, or
+partially attach a row.
 
-**Lossy behavior and impact.** `find_table()` concatenates cell text with
-separators and normalizes the result before substring search. Because
-normalization collapses whitespace, a query can be formed from the end of one
-cell and the start of another even though no cell contains it. In a document
-with repeated tables, `Account` in one cell and `Balance` in the next can make
+### LS-09 — table search could synthesize text across cell boundaries
+
+**Lossy behavior and impact.** `find_table()` concatenated cell text with
+separators and normalized the result before substring search. Because
+normalization collapses whitespace, a query could be formed from the end of one
+cell and the start of another even though no cell contained it. In a document
+with repeated tables, `Account` in one cell and `Balance` in the next could make
 `Account Balance` appear to be a real within-cell marker and select the wrong
 table.
 
-**Evidence and status.** Public table lookup ran in four `fm13` trajectories,
-but every query was a unique marker wholly inside one cell. Cross-cell
-synthesis was not activated. The issue remains open and is outside this stack.
+**Evidence.** Public table lookup ran in four `fm13` trajectories, but every
+query was a unique marker wholly inside one cell. Cross-cell synthesis was not
+activated, so no score effect is attributed to this issue.
+
+**Disposition.** `find_table()` now uses exact matching by default and exposes
+normalized matching only through an explicit policy. It tests each deduplicated
+physical cell independently, preserving paragraph separators within a cell but
+never joining evidence across cells. Existing zero/one/many table resolution
+remains unchanged.
+
+### LS-11 — tracked replacement inferred revision formatting from one run
+
+**Lossy behavior and impact.** Tracked replacement narrowed a common textual
+prefix and suffix, then used run properties from the first changed region for
+inserted redline text. A replacement spanning differently formatted changed
+runs could therefore attribute all inserted text to one run's formatting and
+present a semantically misleading revision even when accept/reject text was
+correct.
+
+**Evidence.** The path ran in `fm06`, `fm02` experiments, and `fm21`, but those
+changed regions did not force a choice among competing run formats. Accept/reject
+algebra was correct and no grader reported this loss.
+
+**Disposition.** Tracked and ordinary replacement now share unique maximal
+exact-affix localization. Any tracked edit inserting text requires one complete
+run-property and inline-ancestry outcome: either one changed text node or
+identical canonical properties and compatible ancestry across all changed
+nodes. A mixed-format `Alpha` to `Omega` edit refuses before mutation rather
+than choosing bold or italic. Deletion-only tracked edits may cross differently
+formatted source runs because each deletion preserves its own source run
+properties. Repeated-affix or insertion-boundary ambiguity also refuses with
+guidance to re-find a smaller exact substring.
+
+## Open issue outside this stack
+
+LS-10 was also introduced by Paper bootstrap commit `a55be769`. It is not
+changed by this stack, and this audit does not present the absence of an eval
+loss as proof that it is safe.
 
 ### LS-10 — comparison pairs blocks above one global text threshold
 
@@ -259,20 +297,6 @@ pairing and produced correct accept/reject projections. Their `.250` scores
 came from an unstated exact author/date grader filter, not an observed mispair.
 That clean fixture does not validate the threshold for repeated or similarly
 worded paragraphs. The issue remains open and is outside this stack.
-
-### LS-11 — tracked replacement infers revision formatting from one run
-
-**Lossy behavior and impact.** Tracked replacement narrows a common textual
-prefix and suffix, then uses run properties from the first changed region for
-inserted redline text. A replacement spanning differently formatted changed
-runs can therefore attribute all inserted text to one run's formatting and
-present a semantically misleading revision even when accept/reject text is
-correct.
-
-**Evidence and status.** The path ran in `fm06`, `fm02` experiments, and
-`fm21`, but those changed regions did not force a choice among competing run
-formats. Accept/reject algebra was correct and no grader reported this loss.
-The issue remains open and is outside this stack.
 
 ## Resulting boundary
 

--- a/docs/proposals/lossy-selection-audit.md
+++ b/docs/proposals/lossy-selection-audit.md
@@ -157,15 +157,22 @@ first node and produced structure-check scores of `.962963`, `.925926`, and
 `.962963` in the skill-05 attempts. A manual topology-aware edit scored
 `1.000`. The trace and grader both identified the lost structure.
 
-**Disposition.** One ordinary planner now leaves exact common prefix and
-suffix text in place and changes only the residual interval when that interval
-is one proved uniform formatting and structural region. It preserves safe
-markers and required `xml:space`/placeholder behavior and refuses mixed,
-marker-crossing, or unresolved intent. Direct, batch, and cell-update paths
-share the planner. Every successful non-no-op direct replacement consumes its
-supplied span so stale live state cannot be reconstructed approximately;
-callers re-find before another operation. No-op and atomically refused or
-rolled-back direct operations leave the supplied span reusable.
+**Disposition.** PR #48 first introduced one ordinary planner that could leave
+exact common prefix and suffix text in place and change only a residual interval,
+fixing the observed formatting loss. A follow-up audit found that choosing one
+greedy affix split could still manufacture certainty for repeated affixes or
+insertion boundaries. The planner now considers every maximal exact alignment
+and proceeds only when they agree on both one changed interval and one writable
+formatting/inline-ancestry destination. Otherwise it refuses with guidance to
+re-find the intended substring. It preserves safe markers and required
+`xml:space`/placeholder behavior and refuses mixed, marker-crossing, or unresolved
+intent. Direct, batch, and cell-update paths share the planner. Every successful
+non-no-op direct replacement consumes its supplied span so stale live state
+cannot be reconstructed approximately; callers re-find before another operation.
+No-op and atomically refused or rolled-back direct operations leave the supplied
+span reusable. The original greedy planner was part of the selection-integrity
+repair, not the Paper bootstrap behavior that caused LS-05, and the follow-up is
+a code-level correctness correction rather than a new eval-attributed loss.
 
 ### LS-06 — old character counts were treated as formatting intent
 

--- a/docs/proposals/lossy-selection-audit.md
+++ b/docs/proposals/lossy-selection-audit.md
@@ -158,16 +158,16 @@ first node and produced structure-check scores of `.962963`, `.925926`, and
 `.962963` in the skill-05 attempts. A manual topology-aware edit scored
 `1.000`. The trace and grader both identified the lost structure.
 
-**Disposition.** PR #48 first introduced one ordinary planner that could leave
-exact common prefix and suffix text in place and change only a residual interval,
-fixing the observed formatting loss. A follow-up audit found that choosing one
-greedy affix split could still manufacture certainty for repeated affixes or
-insertion boundaries. The planner now considers every maximal exact alignment
-and proceeds only when they agree on both one changed interval and one writable
-formatting/inline-ancestry destination. Otherwise it refuses with guidance to
-re-find the intended substring. It preserves safe markers and required
-`xml:space`/placeholder behavior and refuses mixed, marker-crossing, or unresolved
-intent. Direct, batch, and cell-update paths share the planner. Every successful
+**Disposition.** PR #48 introduced one ordinary planner that can leave an exact
+common prefix and suffix in place and change only a residual interval, fixing
+the observed formatting loss. The planner considers every maximal exact
+alignment and refuses repeated-affix or pure-insertion ambiguity. Once a
+nonempty changed interval is unique, replacement text deterministically takes
+the complete direct `w:rPr` of its starting run; later consumed formatting
+regions may collapse into that run, and the receipt reports that collapse.
+Unchanged affixes and boundary fragments stay in their source runs. Distinct
+inline wrapper objects, markers, and unresolved structural intent still refuse.
+Direct, batch, tracked, and cell-update paths share the planner. Every successful
 non-no-op direct replacement consumes its supplied span so stale live state
 cannot be reconstructed approximately; callers re-find before another operation.
 No-op and atomically refused or rolled-back direct operations leave the supplied
@@ -234,6 +234,9 @@ paragraphs, fields, controls, revisions, hyperlinks, markers, drawings, nested
 content, and unknown wrappers raise an actionable typed refusal. The operation
 does not choose a representative format, delete unsupported structure, or
 partially attach a row.
+Rows with omitted leading/trailing grid columns (`gridBefore`/`gridAfter`) or
+other nonrectangular physical layouts are also refused before mutation because
+their cells are not an unambiguous positional template for supplied values.
 
 ### LS-09 — table search could synthesize text across cell boundaries
 
@@ -253,7 +256,8 @@ activated, so no score effect is attributed to this issue.
 normalized matching only through an explicit policy. It tests each deduplicated
 physical cell independently, preserving paragraph separators within a cell but
 never joining evidence across cells. Existing zero/one/many table resolution
-remains unchanged.
+remains unchanged. Empty and normalization-empty queries refuse rather than
+matching every table.
 
 ### LS-11 — tracked replacement inferred revision formatting from one run
 
@@ -269,20 +273,20 @@ changed regions did not force a choice among competing run formats. Accept/rejec
 algebra was correct and no grader reported this loss.
 
 **Disposition.** Tracked and ordinary replacement now share unique maximal
-exact-affix localization. Any tracked edit inserting text requires one complete
-run-property and inline-ancestry outcome: either one changed text node or
-identical canonical properties and compatible ancestry across all changed
-nodes. A mixed-format `Alpha` to `Omega` edit refuses before mutation rather
-than choosing bold or italic. Deletion-only tracked edits may cross differently
-formatted source runs because each deletion preserves its own source run
-properties. Repeated-affix or insertion-boundary ambiguity also refuses with
-guidance to re-find a smaller exact substring.
+exact-affix localization and deterministic start-run formatting. A mixed-format
+bold `Al` plus italic `pha` replacement from `Alpha` to `Omega` inserts bold
+`Omega`; every tracked deletion piece retains its source run properties.
+Separate inline wrapper objects still refuse even when their XML is identical,
+and repeated-affix or pure-insertion boundary ambiguity refuses with guidance
+to re-find a smaller exact substring. Standalone tracked replacement is wrapped
+in package-and-span rollback; the batch path retains its single outer
+transaction rather than nesting one per private span.
 
-## Open issue outside this stack
+## Resolved comparison follow-up
 
-LS-10 was also introduced by Paper bootstrap commit `a55be769`. It is not
-changed by this stack, and this audit does not present the absence of an eval
-loss as proof that it is safe.
+LS-10 was introduced by Paper bootstrap commit `a55be769`. The evaluated clean
+fixture was not proof that similarity pairing was generally safe, so the stack
+removes that authority conservatively.
 
 ### LS-10 — comparison pairs blocks above one global text threshold
 
@@ -292,11 +296,16 @@ repeated clauses can cross the threshold for the wrong counterpart, producing
 a plausible but misleading redline instead of an explicit deletion and
 insertion.
 
-**Evidence and status.** All five valid `fm21` trajectories exercised block
+**Evidence and disposition.** All five valid `fm21` trajectories exercised block
 pairing and produced correct accept/reject projections. Their `.250` scores
 came from an unstated exact author/date grader filter, not an observed mispair.
-That clean fixture does not validate the threshold for repeated or similarly
-worded paragraphs. The issue remains open and is outside this stack.
+That clean fixture did not validate the threshold for repeated or similarly
+worded paragraphs. Fine-grained compare now runs only for one unambiguous old
+block paired with one new block of the same kind. Larger changed regions emit
+coarse deletions and insertions in document order instead of guessing a pairing.
+Pure insertions retain their exact zero-width boundary so formatting or wrapper
+ambiguity is surfaced by the ordinary insertion guard rather than hidden by a
+borrowed neighboring character.
 
 ## Resulting boundary
 
@@ -305,5 +314,7 @@ position, missing context, a representative run, or old character capacity.
 They retain only evidence the package can validate directly: exact or
 explicitly normalized text policy, complete candidate inspection, live
 owner-bound objects, concrete paragraph boundaries, span-local formatting,
-and one proved uniform replacement region. When those facts do not determine a
-safe mutation, the public contract is refusal rather than a plausible guess.
+and one proved structural owner. Nonempty replacement formatting is the explicit
+start-run policy, not a claim that every consumed formatting region survived.
+When those facts do not determine a safe mutation, the public contract is
+refusal rather than a plausible guess.

--- a/docs/proposals/lossy-selection-audit.md
+++ b/docs/proposals/lossy-selection-audit.md
@@ -1,0 +1,278 @@
+# Lossy selection and replacement audit
+
+**Audit completed:** 2026-08-23
+
+**Scope:** Paper-added DOCX search, target resolution, formatting inspection,
+replacement, table editing, and comparison behavior
+
+This is a historical design audit, not an API reference. It records where a
+Paper convenience layer discarded identity, boundary, formatting, or topology
+evidence and what the selection-integrity changes retained or removed. Current
+contracts live in the `docx.search`, `docx.blocks`, and `docx.formatting` API
+documentation.
+
+## Evidence and provenance
+
+The code review compared the fork with upstream `python-docx` 1.2.0 and traced
+each Paper-added behavior to Git history. None of LS-01 through LS-11 came from
+upstream. LS-01 through LS-05 and LS-07 through LS-11 entered in the Paper
+bootstrap commit `a55be769`. LS-06 entered later in the unmerged draft PR #41
+patch identified by the audit as commit `4cb35aa`.
+
+The measured evaluation evidence is narrower than the code audit. A 2026-08-22
+trace review covered 75 focused Harbor trajectories and 60 Knowledge48 DOCX
+trajectories. It distinguished three events: an API was called, the lossy input
+condition was present, and a harmful output or score effect was observed. Only
+LS-05 reached all three. The other entries remain real code-level risks or open
+design questions, but this corpus does not show that they cost points.
+
+| ID | Evaluated condition | Observed result | Final disposition |
+| --- | --- | --- | --- |
+| LS-01 | Resolver called; no stale equivalent block | No adverse effect | Live block identity retained; serialized locator removed |
+| LS-02 | Span-to-block path called; no cross-paragraph target | No adverse effect | One-paragraph operations refuse cross-paragraph spans |
+| LS-03 | `near` called in four Harbor trajectories | One safe refusal; no final loss | Ranking remains inspection-only on `find_text()` |
+| LS-04 | Normalized case-folding observed | No wrong mutation | Exact is default; normalized matching is explicit |
+| LS-05 | Heterogeneous fragmented replacement | **Structure loss and score loss** | Ordinary replacement proves one safe changed region or refuses |
+| LS-06 | Not present in evaluated build | Not executable | Capacity allocator and separate mode removed |
+| LS-07 | No calls | Not exercised | Convenience wrapper removed |
+| LS-08 | Row copy called; template cells were uniform | Lossy choice not activated | Open; outside this stack |
+| LS-09 | Table lookup called; queries stayed within one cell | Lossy choice not activated | Open; outside this stack |
+| LS-10 | Comparison pairing called | No observed mispair | Open; outside this stack |
+| LS-11 | Tracked replacement called on simple regions | No observed formatting loss | Open; outside this stack |
+
+## Closed issues
+
+### LS-01 — serialized block aliases were treated as identity
+
+**Lossy behavior.** A serialized block anchor combined a story name, block
+index, and the first eight hexadecimal SHA-256 characters of normalized text.
+Re-resolution treated that tuple as the block. Normalization erased case,
+whitespace, and punctuation, while the 32-bit digest omitted element identity,
+structure, formatting, revisions, controls, and table topology.
+
+**Impact and failure shape.** If an edit moved a normalization-equivalent
+paragraph into the recorded index, an old anchor could authorize a mutation of
+the new paragraph. For example, an anchor captured for `Payment Terms` could
+later resolve to a different `payment  terms` paragraph at the same index and
+insert or delete content in the wrong clause while reporting success.
+
+**Evidence.** Fresh anchors were used successfully in several eval workflows,
+but no trace mutated the document between capture and reuse in a way that put
+an equivalent block at the old index. There was no measured adverse effect.
+
+**Disposition.** A live `Block` now retains its owning document and exact OOXML
+element and validates attachment, story, containing structure, and ownership.
+It survives index shifts but refuses detached, replaced, reparented, or foreign
+elements. `BlockLocator` was removed rather than replaced with another
+persistence heuristic. Legacy serialized `Anchor` data remains inert evidence
+and cannot authorize mutation; callers reacquire a live target after reload.
+
+### LS-02 — cross-paragraph spans collapsed to the first paragraph
+
+**Lossy behavior.** Search intentionally permits a span to cross a paragraph
+boundary, but the shared block resolver converted such a span to the paragraph
+of its first selected atom. It discarded the other endpoint without requiring
+the caller to choose one.
+
+**Impact and failure shape.** A caller selecting `end of clause A\nstart of
+clause B` and asking to insert after the selection could insert after clause A,
+even though the supplied range included clause B. Field, composition, and block
+operations could therefore act at an invented endpoint.
+
+**Evidence.** Span-to-block resolution ran in the evals, but all reported spans
+were confined to one paragraph. The risky condition and adverse effect were not
+observed.
+
+**Disposition.** Operations that require one paragraph revalidate both the
+span summary and its concrete selected atoms and raise a boundary refusal when
+they cross paragraphs. Cross-paragraph inspection remains valid. Ordinary
+replacement may narrow unchanged exact affixes only when its actual changed
+interval is proved to remain within one paragraph.
+
+### LS-03 — contextual distance looked like unique authority
+
+**Lossy behavior.** `near` ranked targets by absolute character distance to
+context. Missing context gave all candidates the same non-result, and tied
+distances fell back to document order. Combining the ranking with a positional
+selector could make that fallback look like a context-proved identity.
+
+**Impact and failure shape.** If `Renewal` is absent or exactly between two
+`Payment terms` occurrences, choosing the first ranked result can mutate the
+wrong clause even though the caller supplied context specifically to
+disambiguate it. Character distance is useful evidence, but it is not semantic
+document identity.
+
+**Evidence.** Four Harbor trajectories used `near`. Three reached the intended
+target and one multi-match exploration refused safely before recovery. The
+corpus contained no missing-or-tied context that caused a wrong final edit or
+score loss.
+
+**Disposition.** `find_text(..., near=...)` remains an inspection tool: it
+orders and returns every candidate, preserves stable document order for ties
+or missing context, and makes no unique-authority claim. `find_one()` has no
+`near` keyword and retains ordinary zero/one/many refusal semantics. A caller
+that wants one result must supply a uniquely identifying target or explicitly
+choose from inspected live spans.
+
+### LS-04 — normalized discovery was the mutation default
+
+**Lossy behavior.** The original search path always case-folded text, mapped
+smart quotes and dashes, collapsed whitespace, mapped exotic spaces, and
+removed soft hyphens. The resulting span was mutation-capable even when the
+document text was only normalization-equivalent to the requested string.
+
+**Impact and failure shape.** `Company` can select `company`; an en dash can be
+treated like a hyphen; and a non-breaking space can be treated like a normal
+space. Those distinctions may identify names, terms, typography, or protected
+labels. A successful mutation can therefore target text the caller never
+literally named.
+
+**Evidence.** One `fm02` exploration proved case-folding was active by finding
+lowercase occurrences from an uppercase query. The actual mutations used more
+specific targets, and a typography-only echo was preserved. No harmful
+overmatch was observed.
+
+**Disposition.** Exact codepoint matching is the default for search and
+replacement. Normalized matching remains available only through an explicit
+policy. Both policies use the same live span machinery and preserve the actual
+selected document text as evidence.
+
+### LS-05 — ordinary replacement adopted the first selected run
+
+**Lossy behavior.** Ordinary untracked replacement wrote all new text into the
+first selected text node and emptied later selected nodes. The first run's
+formatting and semantic scope silently became the formatting policy for the
+whole replacement.
+
+**Impact and failure shape.** Replacing text spanning regular, bold, italic, or
+underlined runs could flatten the entire replacement into the first style.
+Crossing a hyperlink, control, revision, or marker boundary could move text to
+the wrong scope or hollow a bookmark while leaving an openable but incorrect
+document.
+
+**Evidence.** This was the only issue with direct adverse eval evidence. The
+fragmented `fm02` target contained bold, italic, and underlined regions plus
+bookmark/proofing boundaries. Public replacement consolidated text into the
+first node and produced structure-check scores of `.962963`, `.925926`, and
+`.962963` in the skill-05 attempts. A manual topology-aware edit scored
+`1.000`. The trace and grader both identified the lost structure.
+
+**Disposition.** One ordinary planner now leaves exact common prefix and
+suffix text in place and changes only the residual interval when that interval
+is one proved uniform formatting and structural region. It preserves safe
+markers and required `xml:space`/placeholder behavior and refuses mixed,
+marker-crossing, or unresolved intent. Direct, batch, and cell-update paths
+share the planner. Every successful non-no-op direct replacement consumes its
+supplied span so stale live state cannot be reconstructed approximately;
+callers re-find before another operation. No-op and atomically refused or
+rolled-back direct operations leave the supplied span reusable.
+
+### LS-06 — old character counts were treated as formatting intent
+
+**Lossy behavior.** Draft PR #41 added `preserve_structure` and divided new
+text among existing text nodes according to their former character capacity.
+Node lengths often reflect arbitrary editing history, not boundaries between
+meaningful formatting regions.
+
+**Impact and failure shape.** Nodes that previously held 6, 4, and 8
+characters could split a replacement at those same counts, including through a
+new word. The call could report preserved structure while assigning the word's
+halves to unrelated run formats.
+
+**Evidence.** The evaluated build predated the draft allocator and no trace
+called the mode, so LS-06 cannot explain an eval outcome.
+
+**Disposition.** The public `preserve_structure` option, associated result
+field, option matrix, and inherited capacity allocator were deleted. Safe
+topology-aware text assignment belongs to the one ordinary planner described
+under LS-05; an edit that planner cannot prove safe refuses. There is no
+replacement mode for exact topology and no substitute allocator.
+
+### LS-07 — formatting inspection sampled an unrelated first run
+
+**Lossy behavior.** `surrounding_format(document, target)` resolved a target to
+a paragraph and sampled that paragraph's first run, even when the target was a
+live span over text later in the paragraph.
+
+**Impact and failure shape.** In a paragraph beginning bold and ending regular,
+asking about the regular clause could report bold. An agent could then use that
+incorrect evidence to format an insertion or replacement.
+
+**Evidence.** The skill material mentioned the wrapper, but none of the 135
+reviewed trajectories called it. No score can be attributed to LS-07.
+
+**Disposition.** The redundant wrapper was removed. Callers explicitly locate
+text and pass the live span to `format_of()`, which resolves every touched run
+and reports mixed values and provenance; callers that already hold a run or
+paragraph pass that object directly.
+
+## Open issues outside this stack
+
+These behaviors were also introduced by Paper bootstrap commit `a55be769`.
+They were not changed by the selection-integrity stack, and this audit does not
+present the absence of an eval loss as proof that they are safe.
+
+### LS-08 — copied table cells choose one representative run format
+
+**Lossy behavior and impact.** Row-copy population finds the first run with
+explicit run properties, clears the cell, and applies that one property set to
+the replacement. A template cell whose first styled run is red and whose later
+run is bold can become entirely red, losing the later region and any semantic
+relationship between text and style.
+
+**Evidence and status.** Row copying ran in three `fm13` trajectories, but each
+template cell had one ordinary unformatted run, so no competing formats were
+discarded. The observed score loss came from row order, not this heuristic.
+The issue remains open and is outside this stack.
+
+### LS-09 — table search can synthesize text across cell boundaries
+
+**Lossy behavior and impact.** `find_table()` concatenates cell text with
+separators and normalizes the result before substring search. Because
+normalization collapses whitespace, a query can be formed from the end of one
+cell and the start of another even though no cell contains it. In a document
+with repeated tables, `Account` in one cell and `Balance` in the next can make
+`Account Balance` appear to be a real within-cell marker and select the wrong
+table.
+
+**Evidence and status.** Public table lookup ran in four `fm13` trajectories,
+but every query was a unique marker wholly inside one cell. Cross-cell
+synthesis was not activated. The issue remains open and is outside this stack.
+
+### LS-10 — comparison pairs blocks above one global text threshold
+
+**Lossy behavior and impact.** Word-level comparison uses order-preserving
+text-similarity pairing and a global `0.5` threshold. Similar boilerplate or
+repeated clauses can cross the threshold for the wrong counterpart, producing
+a plausible but misleading redline instead of an explicit deletion and
+insertion.
+
+**Evidence and status.** All five valid `fm21` trajectories exercised block
+pairing and produced correct accept/reject projections. Their `.250` scores
+came from an unstated exact author/date grader filter, not an observed mispair.
+That clean fixture does not validate the threshold for repeated or similarly
+worded paragraphs. The issue remains open and is outside this stack.
+
+### LS-11 — tracked replacement infers revision formatting from one run
+
+**Lossy behavior and impact.** Tracked replacement narrows a common textual
+prefix and suffix, then uses run properties from the first changed region for
+inserted redline text. A replacement spanning differently formatted changed
+runs can therefore attribute all inserted text to one run's formatting and
+present a semantically misleading revision even when accept/reject text is
+correct.
+
+**Evidence and status.** The path ran in `fm06`, `fm02` experiments, and
+`fm21`, but those changed regions did not force a choice among competing run
+formats. Accept/reject algebra was correct and no grader reported this loss.
+The issue remains open and is outside this stack.
+
+## Resulting boundary
+
+The closed changes remove authority that was based on normalization,
+position, missing context, a representative run, or old character capacity.
+They retain only evidence the package can validate directly: exact or
+explicitly normalized text policy, complete candidate inspection, live
+owner-bound objects, concrete paragraph boundaries, span-local formatting,
+and one proved uniform replacement region. When those facts do not determine a
+safe mutation, the public contract is refusal rather than a plausible guess.


### PR DESCRIPTION
## Why

The public docs still described removed or misleading authority: portable locators, formatting convenience selection, refreshed mutated spans, and a separate topology mode.

## Final documentation

- Exact-by-default search and inspection-only `near`.
- Owner-bound live blocks and inert serialized anchors.
- One-paragraph mutation refusal.
- Explicit `find_*()` plus `format_of(span)`.
- One ambiguity-first ordinary replacement planner.
- Consumed live spans after successful mutation.
- One historical lossy-selection audit; phase/build prose and duplicate rule restatements are removed.

## Verification

Focused matrix: 354 passed. Behave: 650 scenarios / 1,856 steps passed. LibreOffice non-compare: 38 passed. Strict Sphinx, build/Twine, and install-collision checks passed. Ruff remained at the 69-diagnostic baseline; Pyright improved from 12,695 to 12,613. Word for Mac opened all 15 final artifacts without repair and all 18 manifest hashes matched. Full pytest: 3,019 passed, 7 skipped, 10 known compare failures caused by compare widening zero-width insertions before the ambiguity-safe planner; no heuristic tie-break or PR #44 behavior change was added.

## Stack

Parent: #49. Published head: `36be26010a1805bbc4492511fb9073b558a6f144`. This PR documents the stack; it does not merge it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proposal-only changes with no runtime or API implementation edits in this diff.
> 
> **Overview**
> Updates **README**, **docs/index**, and API pages so public guidance matches the current selection and replacement stack instead of removed or misleading shortcuts (portable block locators, `surrounding_format`, topology-preservation modes, refreshed spans after mutation).
> 
> Adds a **Selection and preservation** narrative: exact-by-default search, inspection-only `near`, owner-bound live blocks vs inert serialized anchors, one-paragraph mutation refusal, ambiguity-first ordinary replacement with start-run formatting and consumed spans, and matching tracked-replacement rules. **paper-blocks** and feature bullets spell out live paragraph targets and table lookup/row-copy refusal policies. **paper-tableops** drops a duplicated `insert_row_after` paragraph.
> 
> Introduces **`docs/proposals/lossy-selection-audit.md`** as a single historical audit (LS-01–LS-11) tying prior lossy behaviors to dispositions; not a live API reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de304044a351c4ef5aa0687f105cdb61097d6000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->